### PR TITLE
Fix Issue #59: Load thrust limits from drone-controller.

### DIFF
--- a/lsy_drone_racing/control/attitude_rl.py
+++ b/lsy_drone_racing/control/attitude_rl.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
+from drone_controllers.mellinger.params import ForceTorqueParams
 from drone_models.core import load_params
 from scipy.interpolate import CubicSpline
 
@@ -42,8 +43,9 @@ class AttitudeRL(Controller):
 
         drone_params = load_params(config.sim.physics, config.sim.drone_model)
         self.drone_mass = drone_params["mass"]  # alternatively from sim.drone_mass
-        self.thrust_min = drone_params["thrust_min"] * 4  # min total thrust
-        self.thrust_max = drone_params["thrust_max"] * 4  # max total thrust
+        params = ForceTorqueParams.load(config.sim.drone_model)
+        self.thrust_min = params.thrust_min * 4  # min total thrust
+        self.thrust_max = params.thrust_max * 4  # max total thrust
 
         # Set num of stacked obs
         self.n_obs = 2


### PR DESCRIPTION
Fix tiny bug in deployment script for RL. Load thrust limits params from drone-controller instead of drone-models to keep consistent with action_space() in crazyflow.envs.drone_env, where it also load params from controller.

This is coming from the misalignment of thrust limits in drone-controller and drone-models, which are already fixed in their latest main branches. That means if we simply upgrade to new published packages, these values will also be aligned.

If you think this is not necessary, please discard this PR.