### PR TITLE
Update for ADR ws25.

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,8 +1,16 @@
 name: Ruff
 on: [ push, pull_request ]
 jobs:
-  ruff:
+  ruff-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v1
+
+  ruff-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v1
+        with:
+          args: "format --check --diff"

--- a/config/level0.toml
+++ b/config/level0.toml
@@ -16,7 +16,7 @@ check_drone_start_pos = true
 real_track_objects = true
 
 [[deploy.drones]]
-id = 91
+id = 10
 channel = 100
 drone_model = "cf21B_500"                        # Model of the drone, i.e., cf2x_L250, cf2x_P250, cf2x_T500, cf21B_500. For this course, we use cf21B_500
 

--- a/config/level0.toml
+++ b/config/level0.toml
@@ -64,6 +64,7 @@ pos = [0.0, -0.75, 1.2]
 rpy = [0.0, 0.0, 0.0]
 
 # Obstacle height: 1.52m + reflective marker on top. Height is measured from the ground to the top of the obstacle.
+# Obstacles are cylinders with a diameter of 0.03m.
 [[env.track.obstacles]]
 pos = [0.0, 0.75, 1.55]
 [[env.track.obstacles]]

--- a/config/level0.toml
+++ b/config/level0.toml
@@ -49,6 +49,7 @@ control_mode = "state"  # Control mode of the environment. Can be either "state"
 randomize = false
 
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
+# Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]
 pos = [0.5 , 0.25, 0.7]
 rpy = [0.0, 0.0, -0.78]

--- a/config/level1.toml
+++ b/config/level1.toml
@@ -16,7 +16,7 @@ check_drone_start_pos = true
 real_track_objects = true
 
 [[deploy.drones]]
-id = 91
+id = 10
 channel = 100
 drone_model = "cf21B_500"                        # Model of the drone, i.e., cf2x_L250, cf2x_P250, cf2x_T500, cf21B_500. For this course, we use cf21B_500
 

--- a/config/level1.toml
+++ b/config/level1.toml
@@ -64,6 +64,7 @@ pos = [0.0, -0.75, 1.2]
 rpy = [0.0, 0.0, 0.0]
 
 # Obstacle height: 1.52m + reflective marker on top. Height is measured from the ground to the top of the obstacle.
+# Obstacles are cylinders with a diameter of 0.03m.
 [[env.track.obstacles]]
 pos = [0.0, 0.75, 1.55]
 [[env.track.obstacles]]

--- a/config/level1.toml
+++ b/config/level1.toml
@@ -49,6 +49,7 @@ control_mode = "state"  # Control mode of the environment. Can be either "state"
 randomize = false
 
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
+# Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]
 pos = [0.5 , 0.25, 0.7]
 rpy = [0.0, 0.0, -0.78]

--- a/config/level2.toml
+++ b/config/level2.toml
@@ -16,8 +16,8 @@ check_drone_start_pos = true
 real_track_objects = true
 
 [[deploy.drones]]
-id = 52
-channel = 80
+id = 10
+channel = 100
 drone_model = "cf21B_500"                        # Model of the drone, i.e., cf2x_L250, cf2x_P250, cf2x_T500, cf21B_500. For this course, we use cf21B_500
 
 

--- a/config/level2.toml
+++ b/config/level2.toml
@@ -64,6 +64,7 @@ pos = [0.0, -0.75, 1.2]
 rpy = [0.0, 0.0, 0.0]
 
 # Obstacle height: 1.52m + reflective marker on top. Height is measured from the ground to the top of the obstacle.
+# Obstacles are cylinders with a diameter of 0.03m.
 [[env.track.obstacles]]
 pos = [0.0, 0.75, 1.55]
 [[env.track.obstacles]]

--- a/config/level2.toml
+++ b/config/level2.toml
@@ -49,6 +49,7 @@ control_mode = "state"  # Control mode of the environment. Can be either "state"
 randomize = false
 
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
+# Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]
 pos = [0.5 , 0.25, 0.7]
 rpy = [0.0, 0.0, -0.78]

--- a/config/level3.toml
+++ b/config/level3.toml
@@ -16,7 +16,7 @@ check_drone_start_pos = true
 real_track_objects = true
 
 [[deploy.drones]]
-id = 91
+id = 10
 channel = 100
 drone_model = "cf21B_500"                        # Model of the drone, i.e., cf2x_L250, cf2x_P250, cf2x_T500, cf21B_500. For this course, we use cf21B_500
 

--- a/config/level3.toml
+++ b/config/level3.toml
@@ -64,6 +64,7 @@ pos = [0.0, 0.0, 1.2]
 rpy = [0.0, 0.0, 0.0]
 
 # Obstacle height: 1.52m + reflective marker on top. Height is measured from the ground to the top of the obstacle.
+# Obstacles are cylinders with a diameter of 0.03m.
 [[env.track.obstacles]]
 pos = [0.0, 0.0, 1.55]
 [[env.track.obstacles]]

--- a/config/level3.toml
+++ b/config/level3.toml
@@ -49,6 +49,7 @@ control_mode = "state"  # Control mode of the environment. Can be either "state"
 randomize = true
 
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
+# Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]
 pos = [0.0, 0.0, 0.7]
 rpy = [0.0, 0.0, 0.0]

--- a/config/multi_level0.toml
+++ b/config/multi_level0.toml
@@ -18,13 +18,13 @@ check_drone_start_pos = true
 real_track_objects = true
 
 [[deploy.drones]]
-id = 91
-channel = 80
+id = 10
+channel = 100
 drone_model = "cf21B_500"                        # Model of the drone, i.e., cf2x_L250, cf2x_P250, cf2x_T500, cf21B_500. For this course, we use cf21B_500
 
 [[deploy.drones]]
-id = 6
-channel = 80
+id = 20
+channel = 100
 drone_model = "cf21B_500"                        # Model of the drone, i.e., cf2x_L250, cf2x_P250, cf2x_T500, cf21B_500. For this course, we use cf21B_500
 
 

--- a/config/multi_level0.toml
+++ b/config/multi_level0.toml
@@ -76,6 +76,7 @@ pos = [0.0, -0.75, 1.2]
 rpy = [0.0, 0.0, 0.0]
 
 # Obstacle height: 1.52m + reflective marker on top. Height is measured from the ground to the top of the obstacle.
+# Obstacles are cylinders with a diameter of 0.03m.
 [[env.track.obstacles]]
 pos = [0.0, 0.75, 1.55]
 [[env.track.obstacles]]

--- a/config/multi_level0.toml
+++ b/config/multi_level0.toml
@@ -61,6 +61,7 @@ control_mode = "attitude"
 randomize = false
 
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
+# Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]
 pos = [0.5 , 0.25, 0.7]
 rpy = [0.0, 0.0, -0.78]

--- a/config/multi_level2.toml
+++ b/config/multi_level2.toml
@@ -18,13 +18,13 @@ check_drone_start_pos = true
 real_track_objects = true
 
 [[deploy.drones]]
-id = 91
-channel = 80
+id = 10
+channel = 100
 drone_model = "cf21B_500"                        # Model of the drone, i.e., cf2x_L250, cf2x_P250, cf2x_T500, cf21B_500. For this course, we use cf21B_500
 
 [[deploy.drones]]
-id = 6
-channel = 80
+id = 20
+channel = 100
 drone_model = "cf21B_500"                        # Model of the drone, i.e., cf2x_L250, cf2x_P250, cf2x_T500, cf21B_500. For this course, we use cf21B_500
 
 

--- a/config/multi_level2.toml
+++ b/config/multi_level2.toml
@@ -76,6 +76,7 @@ pos = [0.0, -0.75, 1.2]
 rpy = [0.0, 0.0, 0.0]
 
 # Obstacle height: 1.52m + reflective marker on top. Height is measured from the ground to the top of the obstacle.
+# Obstacles are cylinders with a diameter of 0.03m.
 [[env.track.obstacles]]
 pos = [0.0, 0.75, 1.55]
 [[env.track.obstacles]]

--- a/config/multi_level2.toml
+++ b/config/multi_level2.toml
@@ -61,6 +61,7 @@ control_mode = "attitude"
 randomize = false
 
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
+# Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]
 pos = [0.5 , 0.25, 0.7]
 rpy = [0.0, 0.0, -0.78]

--- a/docs/challenge/deployment.rst
+++ b/docs/challenge/deployment.rst
@@ -27,6 +27,15 @@ The second terminal is used to launch the estimator for the drone. If you want t
     pixi shell -e deploy
     python -m drone_estimators.ros_nodes.ros2_node --drone_name cf52
 
+Generating Tracks for Level 3 Deployment
+------------------------------------------
+For level 3 deployment, you need to generate new configuration file with a track layout based on the real-world positions of the gates and obstacles. To do so, use the ``save_track_as_config.py`` script in the ``lsy_drone_racing/scripts`` folder. 
+
+.. code-block:: bash
+
+    python scripts/save_track_as_config.py --config <config_name> --save_config_to <config_output_path>
+
+The script will query the Vicon system for the current positions of all gates and obstacles, and generate a new deploy-ready TOML configuration file with the specified name.
 
 Deploying Your Controller
 -------------------------
@@ -37,6 +46,6 @@ To deploy your controller on the real drone, use the deployment script in the ``
 
 .. code-block:: bash
 
-    python scripts/deploy_controller.py --controller <controller_name>
+    python scripts/deploy.py --config <config_name> --controller <controller_name>
 
 The deployment script will first check if the real track poses and the drone starting pose is within acceptable bounds of the configured track. If not, the script will print an error message and terminate. If the poses are correct, the drone will take off, fly through the track, print out the final lap time, and land automatically.

--- a/docs/challenge/overview.rst
+++ b/docs/challenge/overview.rst
@@ -67,4 +67,6 @@ The challenge is divided into different difficulty levels, each specified by a T
 
 On level 0, we have perfect knowledge of the drones properties (mass, inertia) and the track layout. Merely some noise on the action and physics is applied. On level 1, physics parameters (mass, inertia, etc.) or the drone are randomized. At level 2, the position of the gates and obstacles is randomized around their nominal positions. Only when entering the observation range, the exact position is revealed. Finally, at level 3, unlike in level 2 where the nominal positions are known and hard coding a trajectory is possible, the (noisy) positions of gates and obstacles are only known at runtime and the controller must find the optimal path online.
 
-You may use the easier scenarios to develop and debug your controller. However, the final evaluation will be on the hardest scenario (Level 3) and, more importantly, the sim2real scenario.
+You may use the easier scenarios to develop and debug your controller. However, the final evaluation will be on the hardest scenarios (Level 2 & 3) and the corresponding sim2real transfer.
+
+In real-world deployment, the racing agents are given the nominal positions of the gates and obstacles, before they approach within a certain observation range and receive more accurate measurements, similar to simulation. For level 3, the track layout is generated reversely from randomly placed gates and obstacles in the real world.

--- a/docs/challenge/overview.rst
+++ b/docs/challenge/overview.rst
@@ -7,7 +7,11 @@ We use the Crazyflie nano quadcopter for our challenge. It is a small, low-cost 
 
 The Track
 ---------
-Contrary to other drone racing challenges, we not only include gates in our tracks, but also obstacles designed to be avoided by the drones. The current iteration uses four gates and four obstacles. Gates have to be traversed in the correct order and in the correct direction. Passing a gate in the opposite direction will not count as a successful pass.
+Contrary to other drone racing challenges, this setup not only includes gates in the track but also obstacles that must be avoided by the drones. The current iteration consists of four gates and four obstacles. Gates must be traversed in the correct order and in the correct direction, as passing a gate in the opposite direction will not count as a successful pass. Once a gate has been successfully passed, traversing it again in reverse will not undo the completion; from that point on, the gate simply acts as another obstacle within the track.
+
+All details about the track elements are provided in the level files explained below. The track features two types of gates: tall gates and short gates. The tall gates have a height of 1.195 meters, while the short gates measure 0.695 meters. In both cases, the height is measured from the ground to the center of the gate. Each gate is square in shape, with an outer frame width of 0.72 meters and an inner opening width of 0.4 meters.
+
+The obstacles are designed as slender cylindrical poles with 0.03 meters in diameter. Each obstacle has a total height of 1.52 meters, measured from the ground to the top, and is fitted with a reflective marker mounted on top.
 
 Project Goals
 -------------

--- a/docs/getting_started/setup.rst
+++ b/docs/getting_started/setup.rst
@@ -178,16 +178,6 @@ This is for the deployment in the lab, either on your own machine or on the lab 
 
 This will automatically create a ros2 workspace with RoboStack, clone the motion_capture_tracking package, and build it. Thus, the terminal might freeze for 1 minute after regular installation.
 
-Then we still have to install extra packages with pip. For that, stay in the deploy shell, run one of the commands below:
-
-.. code-block:: bash
-
-   pip install -e .[sim,deploy]
-   pip install -e .[sim,gpu,deploy]
-
-.. note::
-   Some subpackages currently depend on a prerelease version of `scipy <https://github.com/scipy/scipy>`_, which needs to be built from source. This might take more than 10 minutes on older hardware.
-
 .. note::
    By running the commands above, our automated scripts will install and activate **acados** by default. This might cause the terminal to freeze for several minutes. `Acados installation guide <https://docs.acados.org/index.html>`_ is an Optimal Control Framework that can be used to control the quadrotor using a Model Predictive Controller. If something does not work out of the box, we refer the reader to the `official installation guide <https://docs.acados.org/installation/>`_.
 
@@ -228,7 +218,7 @@ Second, start another deploy shell and run the estimator node. Please check the 
 
 .. code-block:: bash
 
-   python -m drone_estimators.ros_nodes.ros2_node --drone_name cf52
+   python -m drone_estimators.ros_nodes.ros2_node --drone_name cf10
 
 Lastly, run the deployment script with the correct configuration and controller.
 

--- a/lsy_drone_racing/control/__init__.py
+++ b/lsy_drone_racing/control/__init__.py
@@ -11,7 +11,7 @@ To give you an idea of what you need to do, we also include some example impleme
   A controller that follows a pre-defined trajectory using cubic spline interpolation.
 * :class:`AttitudeController <lsy_drone_racing.control.attitude_controller.AttitudeController>`: A
   controller that follows a pre-defined attitude using cubic spline interpolation.
-"""
+"""  # noqa: E501, required for linking in the docs
 
 from lsy_drone_racing.control.controller import Controller
 

--- a/lsy_drone_racing/control/attitude_controller.py
+++ b/lsy_drone_racing/control/attitude_controller.py
@@ -83,7 +83,8 @@ class AttitudeController(Controller):
             info: Optional additional information as a dictionary.
 
         Returns:
-            The orientation as roll, pitch, yaw angles, and the collective thrust [r_des, p_des, y_des, t_des] as a numpy array.
+            The orientation as roll, pitch, yaw angles, and the collective thrust
+            [r_des, p_des, y_des, t_des] as a numpy array.
         """
         t = min(self._tick / self._freq, self._t_total)
         if t >= self._t_total:  # Maximum duration reached

--- a/lsy_drone_racing/control/attitude_mpc.py
+++ b/lsy_drone_racing/control/attitude_mpc.py
@@ -122,7 +122,7 @@ def create_ocp_solver(
     Vx_e[0:nx, 0:nx] = np.eye(nx)  # Select all states
     ocp.cost.Vx_e = Vx_e
 
-    # Set initial references (we will overwrite these later on to make the controller track the traj.)
+    # Set initial references. We will overwrite these later to track the trajectory
     ocp.cost.yref, ocp.cost.yref_e = np.zeros((ny,)), np.zeros((ny_e,))
 
     # Set State Constraints (rpy < 30°)
@@ -234,7 +234,8 @@ class AttitudeMPC(Controller):
             info: Optional additional information as a dictionary.
 
         Returns:
-            The orientation as roll, pitch, yaw angles, and the collective thrust [r_des, p_des, y_des, t_des] as a numpy array.
+            The orientation as roll, pitch, yaw angles, and the collective thrust
+            [r_des, p_des, y_des, t_des] as a numpy array.
         """
         i = min(self._tick, self._tick_max)
         if self._tick >= self._tick_max:

--- a/lsy_drone_racing/control/train_rl.py
+++ b/lsy_drone_racing/control/train_rl.py
@@ -543,7 +543,9 @@ class Agent(nn.Module):
         action_mean = self.actor_mean(x)
         action_logstd = self.actor_logstd.expand_as(action_mean)
         action_std = torch.exp(action_logstd)
-        # During learning the agent explores the environment by sampling actions from a Normal distribution. The standard deviation is a learnable parameter that should decrease during training as the agent gets more confident in its actions.
+        # During learning the agent explores the environment by sampling actions from a Normal
+        # distribution. The standard deviation is a learnable parameter that should decrease during
+        # training as the agent gets more confident in its actions.
         probs = Normal(action_mean, action_std)
         if action is None:
             action = probs.sample() if not deterministic else action_mean

--- a/lsy_drone_racing/envs/assets/gate.xml
+++ b/lsy_drone_racing/envs/assets/gate.xml
@@ -21,8 +21,8 @@
       <!-- Textured front -->
       <geom name="front_top" type="box" size=".3 .05 5e-4" pos="-1e-3 0.0 0.25" euler="-90 -90 180" material="gate_mat_top"/>
       <geom name="front_bottom" type="box" size=".3 .05 5e-4" pos="-1e-3 0.0 -0.25" euler="-90 -90 180" material="gate_mat_bottom"/>
-      <geom name="front_left" type="box" size=".05 .2 5e-4" pos="-1e-3 -0.25 0" euler="90 90 180" material="gate_mat_left"/>
-      <geom name="front_right" type="box" size=".05 .2 5e-4" pos="-1e-3 0.25 0" euler="90 90 180" material="gate_mat_right"/>
+      <geom name="front_left" type="box" size=".05 .2 5e-4" pos="-1e-3 -0.25 0" euler="90 -90 180" material="gate_mat_left"/>
+      <geom name="front_right" type="box" size=".05 .2 5e-4" pos="-1e-3 0.25 0" euler="90 -90 180" material="gate_mat_right"/>
 
       <!-- Textured back -->
       <geom name="back_top" type="box" size=".3 .05 5e-4" pos="1e-3 0.0 0.25" euler="90 90 0" material="gate_mat_top"/>

--- a/lsy_drone_racing/envs/assets/obstacle.xml
+++ b/lsy_drone_racing/envs/assets/obstacle.xml
@@ -2,7 +2,7 @@
   <compiler angle="degree"/>
   <worldbody>
     <body name="obstacle">
-      <geom name="obstacle" type="capsule" size="0.015 0.75" pos="0 0 -0.75" rgba="0.7 0.68 0.55 1"/>
+      <geom name="obstacle" type="capsule" size="0.015 0.8" pos="0 0 -0.8" rgba="0.7 0.68 0.55 1"/>
     </body>
   </worldbody>
 </mujoco>

--- a/lsy_drone_racing/envs/drone_race.py
+++ b/lsy_drone_racing/envs/drone_race.py
@@ -65,7 +65,7 @@ class DroneRaceEnv(RaceCoreEnv, Env):
             max_episode_steps=max_episode_steps,
             device=device,
         )
-        self.action_space = build_action_space(control_mode)
+        self.action_space = build_action_space(control_mode, sim_config.drone_model)
         n_gates, n_obstacles = len(track.gates), len(track.obstacles)
         self.observation_space = build_observation_space(n_gates, n_obstacles)
         self.autoreset = False
@@ -149,7 +149,7 @@ class VecDroneRaceEnv(RaceCoreEnv, VectorEnv):
             device=device,
         )
         self.num_envs = num_envs
-        self.single_action_space = build_action_space(control_mode)
+        self.single_action_space = build_action_space(control_mode, sim_config.drone_model)
         self.action_space = batch_space(self.single_action_space, num_envs)
         n_gates, n_obstacles = len(track.gates), len(track.obstacles)
         self.single_observation_space = build_observation_space(n_gates, n_obstacles)

--- a/lsy_drone_racing/envs/multi_drone_race.py
+++ b/lsy_drone_racing/envs/multi_drone_race.py
@@ -71,7 +71,9 @@ class MultiDroneRaceEnv(RaceCoreEnv, Env):
             max_episode_steps=max_episode_steps,
             device=device,
         )
-        self.action_space = batch_space(build_action_space(control_mode), n_drones)
+        self.action_space = batch_space(
+            build_action_space(control_mode, sim_config.drone_model), n_drones
+        )
         self.observation_space = batch_space(
             build_observation_space(n_gates, n_obstacles), n_drones
         )
@@ -162,7 +164,9 @@ class VecMultiDroneRaceEnv(RaceCoreEnv, VectorEnv):
             device=device,
         )
         self.num_envs = num_envs
-        self.single_action_space = batch_space(build_action_space(control_mode), n_drones)
+        self.single_action_space = batch_space(
+            build_action_space(control_mode, sim_config.drone_model), n_drones
+        )
         self.action_space = batch_space(batch_space(self.single_action_space), num_envs)
         self.single_observation_space = batch_space(
             build_observation_space(n_gates, n_obstacles), n_drones

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -349,7 +349,7 @@ class RealRaceCoreEnv:
         Note:
             These settings are also required to make the high-level drone commander work properly.
         """
-        # Estimator setting;  1: complementary, 2: kalman -> Manual test: kalman significantly better!
+        # Estimators: 1: complementary, 2: kalman. We recommend kalman based on real-world tests
         self.drone.param.set_value("stabilizer.estimator", 2)
         time.sleep(0.1)  # TODO: Maybe remove
         # enable/disable tumble control. Required 0 for agressive maneuvers
@@ -389,8 +389,7 @@ class RealRaceCoreEnv:
 
         pos = self._ros_connector.pos[self.drone_name]
         vel = self._ros_connector.vel[self.drone_name]
-        # This quick check prevents us from engaging the return controller if we havent even started yet.
-        if pos[2] < 0.2:
+        if pos[2] < 0.2:  # Do not enter the return sequence if we have not taken off
             return
         break_pos = pos + vel / np.linalg.norm(vel) * BREAKING_DISTANCE
         break_pos[2] = RETURN_HEIGHT

--- a/lsy_drone_racing/envs/utils.py
+++ b/lsy_drone_racing/envs/utils.py
@@ -114,7 +114,7 @@ def generate_random_track(
 
     Args:
         track: default track layout (n_gates, n_obs, start pos etc)
-        seed: for randomization
+        key: for randomization
         border_safety_margin: min distance [m] of all objects fom the border
         start_pos_min_r: exclusion radius around inital drone position
         gates_min_r: exclusion radius around gates

--- a/lsy_drone_racing/envs/utils.py
+++ b/lsy_drone_racing/envs/utils.py
@@ -99,7 +99,7 @@ def gate_passed(
 
 def generate_random_track(
     track: ConfigDict,
-    seed: int = 1337,
+    key: jax.random.PRNGKey,
     border_safety_margin: float = 0.5,
     start_pos_min_r: float = 1.0,
     gates_min_r: float = 1.0,
@@ -128,12 +128,14 @@ def generate_random_track(
     Returns:
         New track layout with randomized tracks
     """
-    key = jax.random.PRNGKey(seed)
     # Get infos from track
     xmin, ymin = jnp.array(track.safety_limits["pos_limit_low"][:2]) + border_safety_margin
     xmax, ymax = jnp.array(track.safety_limits["pos_limit_high"][:2]) - border_safety_margin
     start_pos = jax.random.uniform(
-        key, (2,), minval=jnp.array([xmin, ymin]), maxval=jnp.array([xmax, ymax])
+        key,
+        (2,),
+        minval=jnp.array([xmin - border_safety_margin, ymin - border_safety_margin]),
+        maxval=jnp.array([xmax + border_safety_margin, ymax + border_safety_margin]),
     )
 
     N_gates, N_obstacles = len(track.gates), len(track.obstacles)

--- a/lsy_drone_racing/utils/checks.py
+++ b/lsy_drone_racing/utils/checks.py
@@ -6,59 +6,63 @@ import logging
 from typing import TYPE_CHECKING
 
 import numpy as np
-from drone_estimators.ros_nodes.ros2_connector import ROSConnector
 from scipy.spatial.transform import Rotation as R
 
 if TYPE_CHECKING:
     from ml_collections import ConfigDict
-    from numpy.typing import ArrayLike, NDArray
+    from numpy.typing import NDArray
 
 logger = logging.getLogger("rosout." + __name__)
 
 
 def check_race_track(
-    gates_pos: ArrayLike, gates_quat: ArrayLike, obstacles_pos: ArrayLike, rng_config: ConfigDict
+    gates_pos: NDArray,
+    nominal_gates_pos: NDArray,
+    gates_quat: NDArray,
+    nominal_gates_quat: NDArray,
+    obstacles_pos: NDArray,
+    nominal_obstacles_pos: NDArray,
+    rng_config: ConfigDict,
 ):
     """Check if the race track's gates and obstacles are within tolerances.
 
     Args:
-        gates_pos: An Nx3 ArrayLike with all nominal gate positions.
-        gates_quat: An Nx4 ArrayLike with all nominal gate quaternions.
-        obstacles_pos: An Mx3 ArrayLike with all nominal obstacle positions.
+        gates_pos: The positions of the gates.
+        nominal_gates_pos: The nominal positions of the gates.
+        gates_quat: The orientations of the gates as quaternions.
+        nominal_gates_quat: The nominal orientations of the gates as quaternions.
+        obstacles_pos: The positions of the obstacles.
+        nominal_obstacles_pos: The nominal positions of the obstacles.
         rng_config: Environment randomization config.
     """
     assert rng_config.gate_pos.fn == "uniform", "Race track checks expect uniform distributions"
     assert rng_config.obstacle_pos.fn == "uniform", "Race track checks expect uniform distributions"
-    gates_pos, gates_quat = np.array(gates_pos), np.array(gates_quat)
-    obstacles_pos = np.array(obstacles_pos)
-    n_gates, n_obstacles = len(gates_pos), len(obstacles_pos)
-    gate_names = [f"gate{i}" for i in range(1, n_gates + 1)]
-    obstacle_names = [f"obstacle{i}" for i in range(1, n_obstacles + 1)]
-    ros_connector = ROSConnector(tf_names=gate_names + obstacle_names, timeout=5.0)
-    try:
-        ang_tol = rng_config.gate_rpy.kwargs.maxval[2]  # Only check yaw rotation
-        for i in range(n_gates):
-            name = f"gate{i + 1}"
-            nominal_pos, nominal_rot = gates_pos[i, ...], R.from_quat(gates_quat[i, ...])
-            gate_pos, gate_rot = ros_connector.pos[name], R.from_quat(ros_connector.quat[name])
-            low, high = rng_config.gate_pos.kwargs.minval, rng_config.gate_pos.kwargs.maxval
-            check_bounds(name, gate_pos, nominal_pos, low, high)
-            check_rotation(name, gate_rot, nominal_rot, ang_tol)
+    low, high = rng_config.gate_pos.kwargs.minval, rng_config.gate_pos.kwargs.maxval
+    for i, (pos, nominal_pos) in enumerate(zip(gates_pos, nominal_gates_pos)):
+        check_bounds(f"gate{i + 1}", pos, nominal_pos, np.array(low), np.array(high))
 
-        for i in range(n_obstacles):
-            name = f"obstacle{i + 1}"
-            nominal_pos = obstacles_pos[i, ...]
-            low, high = rng_config.obstacle_pos.kwargs.minval, rng_config.obstacle_pos.kwargs.maxval
-            check_bounds(name, ros_connector.pos[name][:2], nominal_pos[:2], low[:2], high[:2])
-    finally:
-        ros_connector.close()
+    high_tol = np.array(rng_config.gate_rpy.kwargs.maxval)
+    low_tol = np.array(rng_config.gate_rpy.kwargs.minval)
+    for i, (quat, nominal_quat) in enumerate(zip(gates_quat, nominal_gates_quat)):
+        gate_rot = R.from_quat(quat)
+        nominal_rot = R.from_quat(nominal_quat)
+        check_rotation(f"gate{i + 1}", gate_rot, nominal_rot, low=low_tol, high=high_tol)
+
+    low, high = rng_config.obstacle_pos.kwargs.minval, rng_config.obstacle_pos.kwargs.maxval
+    for i, (pos, nominal_pos) in enumerate(zip(obstacles_pos, nominal_obstacles_pos)):
+        check_bounds(
+            f"obstacle{i + 1}", pos[:2], nominal_pos[:2], np.array(low[:2]), np.array(high[:2])
+        )
 
 
-def check_drone_start_pos(pos: NDArray, rng_config: ConfigDict, drone_name: str):
+def check_drone_start_pos(
+    nominal_pos: NDArray, real_pos: NDArray, rng_config: ConfigDict, drone_name: str
+):
     """Check if the real drone start position matches the settings.
 
     Args:
-        pos: Current drone position.
+        nominal_pos: Nominal drone position.
+        real_pos: Current drone position.
         rng_config: Environment randomization config.
         drone_name: Name of the drone (e.g. cf10).
     """
@@ -66,16 +70,24 @@ def check_drone_start_pos(pos: NDArray, rng_config: ConfigDict, drone_name: str)
         "Drone start position check expects uniform distributions"
     )
     tol_min, tol_max = rng_config.drone_pos.kwargs.minval, rng_config.drone_pos.kwargs.maxval
-    ros_connector = ROSConnector(estimator_names=[drone_name], timeout=5.0)
-    try:
-        real_pos = ros_connector.pos[drone_name]
-    finally:
-        ros_connector.close()
-    check_bounds(drone_name, real_pos[:2], pos[:2], tol_min[:2], tol_max[:2])
+    check_bounds(
+        drone_name, real_pos[:2], nominal_pos[:2], np.array(tol_min[:2]), np.array(tol_max[:2])
+    )
 
 
 def check_bounds(name: str, actual: NDArray, desired: NDArray, low: NDArray, high: NDArray):
-    """Check if the actual value is within the specified bounds of the desired value."""
+    """Check if the actual value is within the specified bounds of the desired value.
+
+    Args:
+        name: Name of the object being checked.
+        actual: Values to check.
+        desired: Reference values.
+        low: Lower bound. Minimum permissible value of (actual - desired).
+        high: Upper bound. Maximum value of (actual - desired).
+
+    Raises:
+            RuntimeError: The values are not in the permissible interval.
+    """
     if np.any(actual - desired < low):
         raise RuntimeError(
             f"{name} exceeds lower tolerances ({low}). Position is: {actual}, should be: {desired}"
@@ -86,11 +98,34 @@ def check_bounds(name: str, actual: NDArray, desired: NDArray, low: NDArray, hig
         )
 
 
-def check_rotation(name: str, actual_rot: R, desired_rot: R, ang_tol: float):
-    """Check if the actual rotation is within the specified tolerance of the desired rotation."""
-    if (actual_rot.inv() * desired_rot).magnitude() > ang_tol:
-        actual, desired = actual_rot.as_euler("xyz"), desired_rot.as_euler("xyz")
+def check_rotation(name: str, actual_rot: R, desired_rot: R, low: NDArray, high: NDArray):
+    """Compare gate orientations in world-frame Euler xyz.
+
+    Warning:
+        Comparing Euler angles is tricky. While we try to sanitize the comparison as best as we
+        can, edge cases may still cause failures.
+
+    Todo:
+        Switch to a more sane rotation check method.
+
+    Args:
+        name: Name of the object being checked.
+        actual_rot: R object describing rotation of the real object.
+        desired_rot:  R object describing rotation of the nominal object.
+        low: Array designating the per axis rotation lower limit
+        high: Array designating the per axis rotation higher limit
+
+    """
+    actual = actual_rot.as_euler("xyz", degrees=False)
+    desired = desired_rot.as_euler("xyz", degrees=False)
+    diff = (actual - desired + np.pi) % (2 * np.pi) - np.pi
+    if np.any(diff < low):
         raise RuntimeError(
-            f"{name} exceeds rotation tolerances ({ang_tol}).\n"
+            f"{name} exceeds lower rotation tolerances ({low}).\n"
+            f"Rotation is: {actual}, should be: {desired}"
+        )
+    elif np.any(diff > high):
+        raise RuntimeError(
+            f"{name} exceeds higher rotation tolerances ({high}).\n"
             f"Rotation is: {actual}, should be: {desired}"
         )

--- a/lsy_drone_racing/utils/ros.py
+++ b/lsy_drone_racing/utils/ros.py
@@ -1,0 +1,74 @@
+"""Utility functions that require ROS."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from drone_estimators.ros_nodes.ros2_connector import ROSConnector
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+def track_poses(n_gates: int, n_obstacles: int) -> tuple[NDArray, NDArray, NDArray]:
+    """Get the track's gate positions, orientations and obstacle positions from the Mocap system.
+
+    Args:
+        n_gates: Number of gates in the track.
+        n_obstacles: Number of obstacles in the track.
+
+    Returns:
+        A tuple containing the (n_gates, 3) gate positions, the (n_gates, 4) gate orientations, and
+        the (n_obstacles, 3) obstacle positions.
+    """
+    gate_pos = np.zeros((n_gates, 3), dtype=np.float32)
+    gate_quat = np.zeros((n_gates, 4), dtype=np.float32)
+    obstacle_pos = np.zeros((n_obstacles, 3), dtype=np.float32)
+
+    tf_names = [f"gate{i}" for i in range(1, n_gates + 1)]
+    tf_names += [f"obstacle{i}" for i in range(1, n_obstacles + 1)]
+    try:
+        ros_connector = ROSConnector(tf_names=tf_names, timeout=10.0)
+        pos, quat = ros_connector.pos, ros_connector.quat
+        for i in range(n_gates):
+            gate_pos[i, ...] = pos[f"gate{i + 1}"]
+            gate_quat[i, ...] = quat[f"gate{i + 1}"]
+        for i in range(n_obstacles):
+            obstacle_pos[i, ...] = pos[f"obstacle{i + 1}"]
+    except KeyError as e:
+        raise KeyError(
+            f"Could not find all track objects in the ROS TF tree: {e}. Have you enabled the track "
+            "objects in Vicon and started the motion capture tracking node?"
+        ) from e
+    finally:
+        ros_connector.close()
+    return gate_pos, gate_quat, obstacle_pos
+
+
+def drone_poses(drone_names: list[str]) -> tuple[NDArray, NDArray]:
+    """Get the drone positions from the Mocap system.
+
+    Args:
+        drone_names: List of drone estimator names.
+
+    Returns:
+        A tuple containing:
+            - drone_pos: An (n_drones, 3) array of drone positions.
+            - drone_quat: An (n_drones, 4) array of drone orientations as quaternions.
+    """
+    drone_pos = np.zeros((len(drone_names), 3), dtype=np.float32)
+    drone_quat = np.zeros((len(drone_names), 4), dtype=np.float32)
+    try:
+        ros_connector = ROSConnector(estimator_names=drone_names, timeout=10.0)
+        for i, drone_name in enumerate(drone_names):
+            drone_pos[i, ...] = ros_connector.pos[drone_name]
+            drone_quat[i, ...] = ros_connector.quat[drone_name]
+    except KeyError as e:
+        raise KeyError(
+            f"Could not find drone in the ROS estimator messages: {e}. Have you enabled the drone "
+            "in Vicon and started the estimator node?"
+        ) from e
+    finally:
+        ros_connector.close()
+    return drone_pos, drone_quat

--- a/pixi.lock
+++ b/pixi.lock
@@ -83,7 +83,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
-      - pypi: git+https://github.com/data-apis/array-api-typing#5447ef90f4117270008a68eb260c3e4ca3e57bbd
+      - pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
       - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/17/8a7503c9dc3f8cc2868c632291e5d224822b05ae62f1279c529c459368d2/array_api_extra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
@@ -954,7 +954,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
-      - pypi: git+https://github.com/data-apis/array-api-typing#5447ef90f4117270008a68eb260c3e4ca3e57bbd
+      - pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
       - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/17/8a7503c9dc3f8cc2868c632291e5d224822b05ae62f1279c529c459368d2/array_api_extra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
@@ -1105,7 +1105,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
-      - pypi: git+https://github.com/data-apis/array-api-typing#5447ef90f4117270008a68eb260c3e4ca3e57bbd
+      - pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
       - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/17/8a7503c9dc3f8cc2868c632291e5d224822b05ae62f1279c529c459368d2/array_api_extra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
@@ -1276,7 +1276,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
-      - pypi: git+https://github.com/data-apis/array-api-typing#5447ef90f4117270008a68eb260c3e4ca3e57bbd
+      - pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
       - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/17/8a7503c9dc3f8cc2868c632291e5d224822b05ae62f1279c529c459368d2/array_api_extra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
@@ -1428,7 +1428,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-      - pypi: git+https://github.com/data-apis/array-api-typing#5447ef90f4117270008a68eb260c3e4ca3e57bbd
+      - pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
       - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/17/8a7503c9dc3f8cc2868c632291e5d224822b05ae62f1279c529c459368d2/array_api_extra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
@@ -1671,9 +1671,9 @@ packages:
   requires_dist:
   - array-api-compat>=1.12.0,<2
   requires_python: '>=3.10'
-- pypi: git+https://github.com/data-apis/array-api-typing#5447ef90f4117270008a68eb260c3e4ca3e57bbd
+- pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
   name: array-api-typing
-  version: 0.1.dev28+g5447ef90f
+  version: 0.1.dev30+g909ee50fa
   requires_dist:
   - typing-extensions>=4.14.1
   requires_python: '>=3.10'
@@ -6094,7 +6094,7 @@ packages:
 - pypi: ./
   name: lsy-drone-racing
   version: 0.0.1
-  sha256: b0c2ff2c13181e08cdc405e75fe9c84f124ad329166219f377a5a943b5ee73ce
+  sha256: c4d7bbb3b54c3812801f9f5747b4199ea0cf032bdc5e92f48458e46e071c46de
   requires_dist:
   - fire>=0.6.0
   - numpy

--- a/pixi.lock
+++ b/pixi.lock
@@ -6094,7 +6094,7 @@ packages:
 - pypi: ./
   name: lsy-drone-racing
   version: 0.0.1
-  sha256: c4d7bbb3b54c3812801f9f5747b4199ea0cf032bdc5e92f48458e46e071c46de
+  sha256: af62b6c572dfd79eeb5d3af762033b15026c5bf1f81b3914d243081e43165e3c
   requires_dist:
   - fire>=0.6.0
   - numpy

--- a/pixi.lock
+++ b/pixi.lock
@@ -83,15 +83,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
-      - pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
       - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/17/8a7503c9dc3f8cc2868c632291e5d224822b05ae62f1279c529c459368d2/array_api_extra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/0c/96102c01dd02ae740d4afc3644d5c7d7fc51d3feefd67300a2aa1ddbf7cb/chex-0.1.91-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
-      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=adr_ws25#7cf6e319f6dd9bacafaed252bbca78d3e59037bd
-      - pypi: git+https://github.com/utiasDSL/drone-controllers.git?rev=adr_ws25#3b741afe0aee89462bb9011d460be3908fbc8678
-      - pypi: git+https://github.com/utiasDSL/drone-models.git?rev=adr_ws25#ff1662c3ed3948b80fa0b307036964cb89dfaf01
+      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=0.1.0b0#d630bc0da89fa65404e855f51517576b28afe45c
+      - pypi: https://files.pythonhosted.org/packages/fb/ce/5c72cdb8b4994c1a8182ce5261269b131959dab552b52d27de2ad62296f0/drone_controllers-0.1.0b0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/2b/17c4f7e77249ff861bb1b7fcd7b2d267fc855a6c5d5b979a26abbde85262/drone_models-0.1.0b0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/98/87b5946356095738cb90a6df7b35ff69ac5750f6e783d5fbcc5cb3b6cbd7/etils-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
@@ -120,7 +119,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl
-      - pypi: git+https://github.com/scipy/scipy.git?rev=4cb83b6#4cb83b62d4bf1d27f63a57988a0fcd2aa15d6640
+      - pypi: https://files.pythonhosted.org/packages/d7/52/871177befb910285db87fb23a93cb39d30e1fd38e6a6a0c6c63b872d41d6/scipy-1.17.0rc1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/43/f1/b392952200f3393bb06fbc4dd975fc63a6843261705839355560b7264eb2/simplejson-3.20.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/68/d6/d95cde18ca2475bf317051b2be168cc963c5cfcd67e9c59786326ccdca53/tensorstore-0.1.78-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl
@@ -133,8 +132,8 @@ environments:
       - pypi: ./
   deploy:
     channels:
-    - url: https://prefix.dev/robostack-jazzy/
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://prefix.dev/robostack-kilted/
     indexes:
     - https://pypi.org/simple
     packages:
@@ -143,9 +142,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.0-py312h033f2cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.2-py312h27b7581_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
@@ -153,24 +152,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.44-h4852527_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.44-hdf8817f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.44-h4852527_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb03c661_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-3.25-h26dfbe5_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-cpp-3.25-hcbe3ca9_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.10.0-h2b85faf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h35888ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cli11-2.6.0-h54a6638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.1.2-hc85cc9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.2.1-hc85cc9f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cd-0.1.1-pyhd8ed1ab_1.conda
@@ -182,7 +181,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-library-path-0.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-metadata-0.2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-output-0.2.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
@@ -195,30 +194,30 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compilers-1.10.0-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-13.4.0-h54dc52d_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-13.4.0-h109b0d3_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312hd9148b4_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.11.0-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312hd9148b4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.18.3-py312h014360a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312hee9fe19_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312ha4b625e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.10.0-h1a2810e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h171cf75_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.7.1-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h127656b_906.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.7.3-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.1-gpl_ha0aeed6_910.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-docstrings-1.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-import-order-0.19.2-pyhd8ed1ab_0.conda
@@ -231,28 +230,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.60.1-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.61.1-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-1.10.0-h36df796_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h3a85593_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h165c975_23.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.4.0-h81444f0_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.4.0-h69c5793_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.4.0-h0a5b801_12.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.3-h2b0a6b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.4.0-h0dff253_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.4.0-hf787b08_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.4.0-h0a5b801_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.4-h2b0a6b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran-13.4.0-h7467c50_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-13.4.0-h847f9e2_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-13.4.0-h4647a72_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-13.4.0-hb485fb8_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-13.4.0-hcdeb356_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gl2ps-1.4.2-hae5d5c5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.1.0-h9c3ff4c_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.0-he175458_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.0-hf516916_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.2-hbcf1ec1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.2-hf516916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.17.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
@@ -263,58 +262,60 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.4.0-h7467c50_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.4.0-haf17267_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.4.0-hb5b9838_12.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-cmake3-3.5.5-h05f81b2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math7-7.5.2-h5bbc156_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math7-python-7.5.2-py312h89d136e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils2-2.2.1-hd5bf738_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.1.0-h15599e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.4.0-h6a38259_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.4.0-h1d934a6_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-cmake4-4.2.0-h83e9d05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math8-8.2.0-h91c16d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math8-python-8.2.0-py312hc0cb2ee_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils3-3.1.1-h22fa418_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h6e4c0c1_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h1b119a7_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.2.1-hde8ca8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.9.0-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.8-he3c4edf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jsoncpp-1.9.6-hf42df4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.9-py312h0a2e395_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.9-py312h0a2e395_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-ha97dd6f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.24.3-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250127.1-cxx17_hbbce691_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.26.2-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libacl-2.3.2-h0f662aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.4-h3f801dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.25.1-h3f43e3d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-hba53ac1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h766b0b6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-37_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h6395336_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hed09d94_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.86.0-hfcd1e18_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.86.0-ha770c72_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py312hf890105_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.76-h0b2e76d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-37_h0358290_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-5_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.0-default_h99862b1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-21.1.0-default_h746c552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.16.0-h4e3cde8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.17.0-h4e3cde8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
@@ -322,38 +323,37 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.4.0-hba01cd7_107.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.4.0-hd1d28cc_116.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.25.1-h3f43e3d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-hcd61629_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.0-h1fed272_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.2-h32235b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake3-3.5.5-h54a6638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.2.0-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils2-2.2.1-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math8-8.2.0-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils3-3.1.1-h38f3fdc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h3d81e11_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-37_h47877c9_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-37_h6ae95b6_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-hf08fa70_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-5_h6ae95b6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.0-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
@@ -363,84 +363,87 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.11.0-qt6_py312h4381209_609.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.12.0-qt6_py312hbf51571_603.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.0.0-hdc3f47d_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.0.0-h4d9b6c2_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.0.0-h4d9b6c2_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.0.0-h981d57b_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.0.0-hdc3f47d_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.0.0-hdc3f47d_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.0.0-hdc3f47d_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.0.0-h981d57b_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.0.0-h0e684df_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.0.0-h0e684df_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.0.0-h5888daf_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.0.0-h684f15b_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.0.0-h5888daf_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.2.0-hb617929_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.2.0-hed573e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.2.0-hed573e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.2.0-hd41364c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.2.0-hb617929_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.2.0-hb617929_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.2.0-hb617929_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.2.0-hd41364c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.2.0-h1862bb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.2.0-h1862bb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.2.0-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.2.0-h0767aad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.2.0-hecca717_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.5.2-hd0c01bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.50-h421ea60_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.6-h3675c94_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.29.3-h7460b1f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.53-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.4-h9969a89_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.4.0-h14bf0c3_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.4.0-h2a15e64_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.1-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.4.0-hba01cd7_107.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.9-h996ca69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.4.0-h6963c3b_116.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtheora-1.1.1-h4ab18f5_1006.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h8261f1e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.9-h085a93f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liburcu-0.14.0-hac33072_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.12-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-h5347b49_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h4f16b4b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.328.1-h5279c79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.11.0-he8b52b9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.8-h04c0eec_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.9-h04c0eec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h7a3aeb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzenohc-1.5.1-hfad6b34_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lttng-ust-2.13.9-hf5eda4c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.2-py312h70dad80_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.4-py312h5d89b6d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.5-py312h3d67a73_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.7-py312he3d6523_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.8-py312he3d6523_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.3-py312h178313f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.37-h29cc59b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.117-h445c969_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.38-h29cc59b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.118-h445c969_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.5-py312h33ff503_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openblas-0.3.30-pthreads_h6ec200e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openblas-0.3.30-pthreads_h6ec200e_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.5-h09fa569_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.5-h608838b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.4-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.3-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
@@ -448,39 +451,40 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.46-h1321c63_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py312h7b42cdd_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.0.0-py312h50c33e8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.6.2-h18fbb6c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.1-py312h4c3975b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.3-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a8bead_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.11.0-qt6_py312h0c4a6be_609.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.12.0-qt6_py312h598be00_603.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pybullet-3.25-py312hf49885f_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.28.0-py312h2596900_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py312h2596900_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydot-4.0.1-py312h7900ff3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pygraphviz-1.14-py312hdfa1987_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py312h82c0db2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-builder-1.15.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-builder-1.18.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py312h1289d80_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-16.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hfe2f287_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-orocos-kdl-1.5.3-py312h1289d80_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
@@ -489,350 +493,354 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3a7ef08_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.2-h5bd77bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-msgs-2.0.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-tutorials-cpp-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-tutorials-interfaces-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-tutorials-py-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-actionlib-msgs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-auto-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-copyright-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-core-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cppcheck-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cpplint-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-definitions-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-dependencies-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-include-directories-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-interfaces-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-libraries-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-link-flags-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-targets-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-flake8-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gen-version-h-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gmock-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gtest-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-include-directories-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-libraries-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-lint-cmake-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pep257-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pytest-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-python-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-ros-0.12.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-target-dependencies-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-test-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-uncrustify-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-version-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-xmllint-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-copyright-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cppcheck-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cpplint-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-flake8-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-cpp-1.8.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-python-1.8.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-auto-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-cmake-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-common-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-package-0.16.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-pep257-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-uncrustify-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-xmllint-0.17.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-angles-1.16.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-builtin-interfaces-2.0.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-class-loader-2.7.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-common-interfaces-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-composition-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-composition-interfaces-2.0.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-console-bridge-vendor-1.7.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-cv-bridge-4.1.0-np126py312h5cbfcd5_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-cyclonedds-0.10.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-demo-nodes-cpp-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-demo-nodes-cpp-native-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-demo-nodes-py-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-depthimage-to-laserscan-2.5.1-np126py312h5cbfcd5_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-desktop-0.11.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-msgs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-domain-coordinator-0.12.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-dummy-map-server-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-dummy-robot-bringup-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-dummy-sensors-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-eigen3-cmake-module-0.3.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-example-interfaces-0.12.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-action-client-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-action-server-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-client-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-composition-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-publisher-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-service-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-subscriber-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-timer-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-multithreaded-executor-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-executors-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-action-client-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-action-server-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-client-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-publisher-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-service-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-subscriber-0.19.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastcdr-2.2.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-2.14.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-cmake-module-3.6.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-foonathan-memory-vendor-1.3.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-geometry-msgs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-geometry2-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gmock-vendor-1.14.9000-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gtest-vendor-1.14.9000-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-cmake-vendor-0.0.10-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-math-vendor-0.0.8-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-utils-vendor-0.0.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-binding-c-2.0.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-hoofs-2.0.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-posh-2.0.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-geometry-4.1.0-np126py312h5cbfcd5_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-tools-0.33.7-np126py312h5cbfcd5_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-transport-5.1.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-interactive-markers-2.5.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-intra-process-demo-0.33.7-np126py312h5cbfcd5_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joy-3.3.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kdl-parser-2.11.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-keyboard-handler-0.3.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-laser-geometry-2.7.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-3.4.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-ros-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-3.4.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ament-cmake-3.4.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ros-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-xml-3.4.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-yaml-3.4.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libcurl-vendor-3.4.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-liblz4-vendor-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libstatistics-collector-1.7.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libyaml-vendor-1.6.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-lifecycle-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-lifecycle-msgs-2.0.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-logging-demo-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-map-msgs-2.4.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-mcap-vendor-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-message-filters-4.11.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-nav-msgs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-orocos-kdl-vendor-0.5.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-osrf-pycommon-2.1.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pcl-conversions-2.6.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pcl-msgs-1.0.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pendulum-control-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pendulum-msgs-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pluginlib-5.4.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-point-cloud-transport-4.0.4-np126py312h3bd2861_11.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pybind11-vendor-3.1.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-cmake-module-0.11.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-qt-binding-2.2.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-qt-dotgraph-2.7.5-np126py312hd4d1b83_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-qt-gui-2.7.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-qt-gui-cpp-2.7.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-qt-gui-py-common-2.7.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-quality-of-service-demo-cpp-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-quality-of-service-demo-py-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-9.2.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-action-9.2.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-interfaces-2.0.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-lifecycle-9.2.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-interface-3.1.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-spdlog-3.1.1-np126py312he340118_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-yaml-param-parser-9.2.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-28.1.12-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-action-28.1.12-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-components-28.1.12-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-lifecycle-28.1.12-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclpy-7.1.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcpputils-2.11.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcutils-6.7.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-resource-retriever-3.4.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-7.3.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-0.22.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-common-0.22.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-cyclonedds-cpp-2.2.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-dds-common-3.1.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-cpp-8.4.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-dynamic-cpp-8.4.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-shared-cpp-8.4.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-2.15.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-cmake-7.3.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-robot-state-publisher-3.3.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-base-0.11.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-core-0.11.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-environment-4.2.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-workspace-1.0.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2action-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2bag-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-common-extensions-0.3.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2component-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2doctor-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2interface-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2launch-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2lifecycle-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2multicast-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2node-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2param-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2pkg-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2run-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2service-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2topic-0.32.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-compression-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-compression-zstd-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-cpp-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-interfaces-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-py-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-storage-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-storage-default-plugins-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-storage-mcap-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-storage-sqlite3-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-transport-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosgraph-msgs-2.0.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-adapter-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cli-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cmake-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-generators-0.2.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-runtime-0.2.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-generators-1.6.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-runtime-1.6.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-0.1.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-fastrtps-0.1.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-c-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-cpp-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-py-0.22.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-type-description-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-parser-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-pycommon-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-c-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-cpp-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-py-0.13.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-c-3.2.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-cpp-3.2.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-c-3.6.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-cpp-3.6.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-interface-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-c-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-cpp-4.6.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rpyutils-0.4.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-action-2.2.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-bag-1.5.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-bag-plugins-1.5.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-common-plugins-1.2.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-console-2.2.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-graph-1.5.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-gui-1.6.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-gui-cpp-1.6.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-gui-py-1.6.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-image-view-1.3.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-msg-1.5.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-plot-1.4.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-publisher-1.7.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-py-common-1.6.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-py-console-1.2.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-reconfigure-1.6.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-service-caller-1.2.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-shell-1.2.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-srv-1.2.2-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-topic-1.7.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rti-connext-dds-cmake-module-0.22.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rttest-0.17.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-assimp-vendor-14.1.15-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-common-14.1.15-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-default-plugins-14.1.15-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-ogre-vendor-14.1.15-np126py312h39124df_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-rendering-14.1.15-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz2-14.1.15-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdl2-vendor-3.3.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-py-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-service-msgs-2.0.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-shape-msgs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-spdlog-vendor-1.6.1-np126py312he340118_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sqlite3-vendor-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-0.13.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-cmake-0.13.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-statistics-msgs-2.0.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-msgs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-srvs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-stereo-msgs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tango-icons-vendor-0.3.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-teleop-twist-joy-2.6.5-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-teleop-twist-keyboard-2.4.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-bullet-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-eigen-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-eigen-kdl-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-geometry-msgs-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-kdl-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-msgs-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-py-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-py-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-sensor-msgs-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-tools-0.36.14-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tinyxml2-vendor-0.9.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tlsf-0.9.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tlsf-cpp-0.17.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-topic-monitor-0.33.7-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tracetools-8.2.4-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-trajectory-msgs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-turtlesim-1.8.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-type-description-interfaces-2.0.3-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-uncrustify-vendor-3.0.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-unique-identifier-msgs-2.5.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-2.10.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-parser-plugin-2.10.0-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-4.0.1-py312h24bf083_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-headers-1.1.2-py312h24bf083_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-visualization-msgs-5.3.6-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-yaml-cpp-vendor-9.0.1-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-zstd-vendor-0.26.9-np126py312h3bd2861_10.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros2-distro-mutex-0.11.0-jazzy_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rosdep-0.26.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-tutorials-cpp-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-tutorials-py-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-core-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-definitions-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-dependencies-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-include-directories-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-interfaces-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-libraries-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-link-flags-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-targets-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gen-version-h-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gmock-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gtest-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-include-directories-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-libraries-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pytest-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-python-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-0.14.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-core-0.14.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-target-dependencies-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-test-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-version-2.7.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-copyright-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cppcheck-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cpplint-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-flake8-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-cpp-1.11.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-python-1.11.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-auto-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-common-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-package-0.17.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-angles-1.16.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-composition-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-cv-bridge-4.1.0-np2py312h887a3b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-demo-nodes-cpp-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-demo-nodes-cpp-native-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-demo-nodes-py-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-depthimage-to-laserscan-2.5.1-np2py312h887a3b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-desktop-0.12.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-dummy-map-server-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-dummy-robot-bringup-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-dummy-sensors-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-example-interfaces-0.13.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-action-client-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-action-server-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-client-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-composition-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-publisher-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-service-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-subscriber-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-timer-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-multithreaded-executor-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-executors-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-action-client-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-action-server-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-client-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-publisher-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-service-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-subscriber-0.20.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry2-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-cmake-vendor-0.2.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-math-vendor-0.2.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-geometry-4.1.0-np2py312h887a3b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-tools-0.36.2-np2py312h887a3b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-transport-6.1.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-interactive-markers-2.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-intra-process-demo-0.36.2-np2py312h887a3b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joy-3.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-kdl-parser-2.12.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-keyboard-handler-0.4.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-laser-geometry-2.10.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-3.8.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ament-cmake-3.8.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libcurl-vendor-3.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-liblz4-vendor-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-lifecycle-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-logging-demo-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-map-msgs-2.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-mcap-vendor-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pcl-conversions-2.7.3-np2py312h43d1557_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pcl-msgs-1.0.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pendulum-control-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pendulum-msgs-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-point-cloud-transport-5.1.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pybind11-vendor-3.2.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-python-qt-binding-2.3.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-qt-dotgraph-2.9.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-qt-gui-2.9.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-qt-gui-cpp-2.9.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-qt-gui-py-common-2.9.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-quality-of-service-demo-cpp-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-quality-of-service-demo-py-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-10.1.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-lifecycle-10.1.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-interface-3.2.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-spdlog-3.2.2-np2py312hb464df2_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-yaml-param-parser-10.1.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-29.5.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-action-29.5.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-components-29.5.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-lifecycle-29.5.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.8-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-resource-retriever-3.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-dds-common-4.0.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-3.0.4-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-security-common-7.8.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-zenoh-cpp-0.6.4-np2py312hf7ffe29_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-robot-state-publisher-3.4.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-base-0.12.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2bag-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2component-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2doctor-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2interface-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2launch-0.28.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2lifecycle-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2multicast-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2node-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2param-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2pkg-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2run-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2service-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2topic-0.38.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-zstd-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-cpp-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-interfaces-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-py-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-default-plugins-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-mcap-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-sqlite3-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-transport-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosgraph-msgs-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-adapter-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cli-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cmake-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-generators-0.3.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-runtime-0.3.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-generators-1.7.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-runtime-1.7.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-c-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-cpp-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-py-0.24.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-type-description-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-parser-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-pycommon-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-c-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-cpp-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-interface-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-action-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-bag-2.0.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-bag-plugins-2.0.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-common-plugins-1.2.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-console-2.3.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-graph-1.7.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-gui-1.9.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-gui-cpp-1.9.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-gui-py-1.9.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-image-view-1.3.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-msg-1.6.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-plot-1.6.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-publisher-1.9.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-py-common-1.9.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-py-console-1.4.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-reconfigure-1.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-service-caller-1.4.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-shell-1.3.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-srv-1.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-topic-1.8.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rttest-0.18.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-assimp-vendor-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-common-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-default-plugins-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-ogre-vendor-15.0.6-np2py312hb5dd976_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-rendering-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-resource-interfaces-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz2-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdl2-vendor-3.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-py-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312hb464df2_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sqlite3-vendor-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-0.15.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-cmake-0.15.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tango-icons-vendor-0.4.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-teleop-twist-joy-2.6.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-teleop-twist-keyboard-2.4.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-bullet-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-kdl-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-geometry-msgs-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-kdl-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-sensor-msgs-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-tools-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tlsf-0.10.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tlsf-cpp-0.18.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-topic-monitor-0.36.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-turtlesim-1.9.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-turtlesim-msgs-1.9.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-2.12.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-parser-plugin-2.12.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-4.0.1-py312h24bf083_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-headers-1.1.2-py312h24bf083_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zenoh-cpp-vendor-0.6.4-np2py312hf7ffe29_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-vendor-0.32.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros2-distro-mutex-0.12.0-kilted_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rosdep-0.26.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.1-ha3a3aed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.10-h4196e79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.24-h68140b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py312h1289d80_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.3-h6dc744f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.4-hbc0de68_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-3.0.2-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.2.0-hb60516a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-devel-2022.2.0-h74b38a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.51.1-hbc0de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-3.1.2-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-devel-2022.3.0-h74b38a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-11.0.0-h3f2d84a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-h8577fbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.81.0-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py312h4c3975b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.0-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-hae71d53_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/utfcpp-4.0.8-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-9.4.2-hf9009d3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-base-9.4.2-py312h28cca35_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-io-ffmpeg-9.4.2-he57672f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-h3e06ad9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.45-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wslink-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
@@ -841,12 +849,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
@@ -860,16 +868,90 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.6-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.20.1-py312h178313f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.22.0-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zenoh-rust-abi-1.5.1.1.85.0-h8619998_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.2-hceb46e0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-he45264a_2.conda
+      - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1d/05/2709750ddb088eb2fc5053ba214b4f54334d15d4cb28217e2956b5507bac/array_api_extra-0.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/24/ab/d7233c915b12c005655437c6c4cf0ae46cbbb2b20d743cb5e4881ad3104a/casadi-3.7.2-cp312-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ea/2c/8d67048a1fa8838a3e09b1a3a645b34d89d03dde4762e90076d3015e23a3/cfclient-2025.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/16/73/5de1f983f5329d9fc11ff9457a9c7b7d707c162f30f158b7ffe410576f8a/cflib-0.1.30-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/0c/96102c01dd02ae740d4afc3644d5c7d7fc51d3feefd67300a2aa1ddbf7cb/chex-0.1.91-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=0.1.0b0#d630bc0da89fa65404e855f51517576b28afe45c
+      - pypi: https://files.pythonhosted.org/packages/fb/ce/5c72cdb8b4994c1a8182ce5261269b131959dab552b52d27de2ad62296f0/drone_controllers-0.1.0b0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/60/d660a283ed138cdd5037abf461889ec117b9195d24322c958af187bb7163/drone_estimators-0.1.0b0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/2b/17c4f7e77249ff861bb1b7fcd7b2d267fc855a6c5d5b979a26abbde85262/drone_models-0.1.0b0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/98/87b5946356095738cb90a6df7b35ff69ac5750f6e783d5fbcc5cb3b6cbd7/etils-1.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/4c/93d0f85318da65923e4b91c1c2ff03d8a458cbefebe3bc612a6693c7906d/fire-0.7.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/6b/7b75508251f4220df8f68e7718b476ee3d614a2a51f9eace97393ee91b46/flax-0.12.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b6/36/853cad240ec63e21a37a512ee19c896b655ce1772d803a3dd80fccfe63fe/freetype_py-2.5.1-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/02/6e639e90f181dc9127046e00d0528f9f7ad12d428972e3a5378b9aefdb0b/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/56/d3/ea5f088e3638dbab12e5c20d6559d5b3bdaeaa1f2af74e526e6815836285/gymnasium-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/36/5bddefea3d7adf22a64f9aa9701492f8a9fe6948223f5cf2602c22ec9be7/hsluv-5.0.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/5b/9512c5fb6c8218332b530f13500c6ff5f3ce3342f35e0dd7be9ac3856fd3/humanize-4.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/e7/19b8cfc8963b2e10a01a4db7bb27ec5fa39ecd024bc62f8e2d1de5625a9d/jax-0.8.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/85/c59752caca94e72861f7a6a42f37485df706e60ec4bb27090081899001d4/jax_cuda12_pjrt-0.8.1-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/20/60/1dde369dd70b349ff388cd699d69c7d49ff3494af30b5b774037cc4d45e6/jax_cuda12_plugin-0.8.1-cp312-cp312-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/eb/4b/3c7e373d81219ee7493c1581c85a926c413ddeb3794cff87a37023a337e4/jaxlib-0.8.1-cp312-cp312-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/43/5a2331615693b56221a902869fb2094d9a0b9a764a8706c8ba16e915f77c/libusb_package-1.0.26.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ab/8a/18d4ff2c7bd83f30d6924bd4ad97abf418488c3f908dea228d6f0961ad68/ml_collections-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c6/10/fa6b8762efbb02bd349503a39fb9dbbcf9e12041b0c5b29d484cafc09355/mujoco-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/29/2f/8c2f734a0c4762416895ae3a7a9f46b10a3a8f3d72c0457d72b31d329c34/mujoco_mjx-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/b3/7c69b37f03260a061883bec0e7b05be7117c1b1c85f5212c72c8c2bc3c8c/munch-4.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/3c/aa88abe01f3be3d1f8f787d1d33dc83e76fec05945f9a28fbb41cfb99cd5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/b1/6b944dd4cf0a1d1e70d659f35a2202c735916cbd47cb93beccc4f2e8e696/nvidia_cudnn_cu12-9.17.0.29-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/4a/4e/44dbb46b3d1b0ec61afda8e84837870f2f9ace33c564317d59b70bc19d3e/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/ec/19c6cc6064c7fc8f0cd6d5b37c4747849e66040c6ca98f86565efc2c227c/optax-0.2.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/da/3a/abbc3c5cac2e082e88cfec2161bf837f18fef786caaa3f007594c839fc8c/orbax_checkpoint-0.11.31-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/d3/8789879c05cfe06127c4b59258632bd175fcdd9eaaadaf0c897b458fb91d/PyQt6-6.7.1-1-cp38-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/4d/26ca7239f7223e5b95b58a58537a09b069582ebb4dfa38234113a9f898ab/PyQt6_Qt6-6.7.3-py3-none-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/11/fd/04adac969ba70bb042d52e13c99c968fce0e1fa6a52146f03a974168a848/pyqt6_sip-13.10.3-cp312-cp312-manylinux1_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/32/36/4c242f81fdcbfa4fb62a5645f6af79191f4097a0577bd5460c24f19cc4ef/pyqtgraph-0.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/b8/27e6312e86408a44fe16bd28ee12dd98608b39f7e7e57884a24e8f29b573/pyusb-1.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/b1/57db58cfc8af592ce94f40649bd1804369c05b2190e4cbc0a2dad572baeb/pyzmq-26.4.0-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a9/0e/45af88dc9d4ebd36ce6c2778e67a6124bcbf0565ddc7751279fe0af5b2bd/scipy-1.17.0rc1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/20/05/ed9b2571bbf38f1a2425391f18e3ac11cb1e91482c22d644a1640dea9da7/simplejson-3.20.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/48/85/55addd16896343ea2731388028945576060139dda3c68a15d6b00158ef6f/tensorstore-0.1.80-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/d5/141f53d7c1eb2a80e6d3e9a390228c3222c27705cbe7f048d3623053f3ca/termcolor-3.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/7a/f38385f1b2d5f54221baf1db3d6371dc6eef8041d95abff39576c694e9d9/transforms3d-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/43/2b/36e984399089c026a6499ac8f7401d38487cf0183839a4aa78140d373771/treescope-0.1.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/0c/f08f0d16b4f97ec2ea6d542b9a70472a344384382fa3543a12ec417cc063/trimesh-4.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/a4/dc6f335e54877f5d26ad4e4aac8f49b2d6e7719dee3e08f363d882c8aba4/vispy-0.15.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ea/85/22c1e2ed47daec6dd40eaf0b11c6b86ad483636b8038453a87d1031f8a36/warp_lang-1.10.1-py3-none-manylinux_2_28_x86_64.whl
       - pypi: ./
   gpu:
     channels:
@@ -954,15 +1036,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
-      - pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
       - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/17/8a7503c9dc3f8cc2868c632291e5d224822b05ae62f1279c529c459368d2/array_api_extra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/0c/96102c01dd02ae740d4afc3644d5c7d7fc51d3feefd67300a2aa1ddbf7cb/chex-0.1.91-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
-      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=adr_ws25#7cf6e319f6dd9bacafaed252bbca78d3e59037bd
-      - pypi: git+https://github.com/utiasDSL/drone-controllers.git?rev=adr_ws25#3b741afe0aee89462bb9011d460be3908fbc8678
-      - pypi: git+https://github.com/utiasDSL/drone-models.git?rev=adr_ws25#ff1662c3ed3948b80fa0b307036964cb89dfaf01
+      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=0.1.0b0#d630bc0da89fa65404e855f51517576b28afe45c
+      - pypi: https://files.pythonhosted.org/packages/fb/ce/5c72cdb8b4994c1a8182ce5261269b131959dab552b52d27de2ad62296f0/drone_controllers-0.1.0b0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/2b/17c4f7e77249ff861bb1b7fcd7b2d267fc855a6c5d5b979a26abbde85262/drone_models-0.1.0b0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/98/87b5946356095738cb90a6df7b35ff69ac5750f6e783d5fbcc5cb3b6cbd7/etils-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
@@ -1005,7 +1086,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl
-      - pypi: git+https://github.com/scipy/scipy.git?rev=4cb83b6#4cb83b62d4bf1d27f63a57988a0fcd2aa15d6640
+      - pypi: https://files.pythonhosted.org/packages/d7/52/871177befb910285db87fb23a93cb39d30e1fd38e6a6a0c6c63b872d41d6/scipy-1.17.0rc1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/43/f1/b392952200f3393bb06fbc4dd975fc63a6843261705839355560b7264eb2/simplejson-3.20.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/68/d6/d95cde18ca2475bf317051b2be168cc963c5cfcd67e9c59786326ccdca53/tensorstore-0.1.78-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl
@@ -1105,15 +1186,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
-      - pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
       - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/17/8a7503c9dc3f8cc2868c632291e5d224822b05ae62f1279c529c459368d2/array_api_extra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/0c/96102c01dd02ae740d4afc3644d5c7d7fc51d3feefd67300a2aa1ddbf7cb/chex-0.1.91-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
-      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=adr_ws25#7cf6e319f6dd9bacafaed252bbca78d3e59037bd
-      - pypi: git+https://github.com/utiasDSL/drone-controllers.git?rev=adr_ws25#3b741afe0aee89462bb9011d460be3908fbc8678
-      - pypi: git+https://github.com/utiasDSL/drone-models.git?rev=adr_ws25#ff1662c3ed3948b80fa0b307036964cb89dfaf01
+      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=0.1.0b0#d630bc0da89fa65404e855f51517576b28afe45c
+      - pypi: https://files.pythonhosted.org/packages/fb/ce/5c72cdb8b4994c1a8182ce5261269b131959dab552b52d27de2ad62296f0/drone_controllers-0.1.0b0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/2b/17c4f7e77249ff861bb1b7fcd7b2d267fc855a6c5d5b979a26abbde85262/drone_models-0.1.0b0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/98/87b5946356095738cb90a6df7b35ff69ac5750f6e783d5fbcc5cb3b6cbd7/etils-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
@@ -1156,7 +1236,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl
-      - pypi: git+https://github.com/scipy/scipy.git?rev=4cb83b6#4cb83b62d4bf1d27f63a57988a0fcd2aa15d6640
+      - pypi: https://files.pythonhosted.org/packages/d7/52/871177befb910285db87fb23a93cb39d30e1fd38e6a6a0c6c63b872d41d6/scipy-1.17.0rc1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/43/f1/b392952200f3393bb06fbc4dd975fc63a6843261705839355560b7264eb2/simplejson-3.20.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/68/d6/d95cde18ca2475bf317051b2be168cc963c5cfcd67e9c59786326ccdca53/tensorstore-0.1.78-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl
@@ -1276,15 +1356,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
-      - pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
       - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/17/8a7503c9dc3f8cc2868c632291e5d224822b05ae62f1279c529c459368d2/array_api_extra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/0c/96102c01dd02ae740d4afc3644d5c7d7fc51d3feefd67300a2aa1ddbf7cb/chex-0.1.91-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
-      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=adr_ws25#7cf6e319f6dd9bacafaed252bbca78d3e59037bd
-      - pypi: git+https://github.com/utiasDSL/drone-controllers.git?rev=adr_ws25#3b741afe0aee89462bb9011d460be3908fbc8678
-      - pypi: git+https://github.com/utiasDSL/drone-models.git?rev=adr_ws25#ff1662c3ed3948b80fa0b307036964cb89dfaf01
+      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=0.1.0b0#d630bc0da89fa65404e855f51517576b28afe45c
+      - pypi: https://files.pythonhosted.org/packages/fb/ce/5c72cdb8b4994c1a8182ce5261269b131959dab552b52d27de2ad62296f0/drone_controllers-0.1.0b0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/2b/17c4f7e77249ff861bb1b7fcd7b2d267fc855a6c5d5b979a26abbde85262/drone_models-0.1.0b0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/98/87b5946356095738cb90a6df7b35ff69ac5750f6e783d5fbcc5cb3b6cbd7/etils-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
@@ -1313,7 +1392,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl
-      - pypi: git+https://github.com/scipy/scipy.git?rev=4cb83b6#4cb83b62d4bf1d27f63a57988a0fcd2aa15d6640
+      - pypi: https://files.pythonhosted.org/packages/d7/52/871177befb910285db87fb23a93cb39d30e1fd38e6a6a0c6c63b872d41d6/scipy-1.17.0rc1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/43/f1/b392952200f3393bb06fbc4dd975fc63a6843261705839355560b7264eb2/simplejson-3.20.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/68/d6/d95cde18ca2475bf317051b2be168cc963c5cfcd67e9c59786326ccdca53/tensorstore-0.1.78-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl
@@ -1428,16 +1507,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-      - pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
       - pypi: https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/17/8a7503c9dc3f8cc2868c632291e5d224822b05ae62f1279c529c459368d2/array_api_extra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/0c/96102c01dd02ae740d4afc3644d5c7d7fc51d3feefd67300a2aa1ddbf7cb/chex-0.1.91-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl
-      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=adr_ws25#7cf6e319f6dd9bacafaed252bbca78d3e59037bd
-      - pypi: git+https://github.com/utiasDSL/drone-controllers.git?rev=adr_ws25#3b741afe0aee89462bb9011d460be3908fbc8678
-      - pypi: git+https://github.com/utiasDSL/drone-models.git?rev=adr_ws25#ff1662c3ed3948b80fa0b307036964cb89dfaf01
+      - pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=0.1.0b0#d630bc0da89fa65404e855f51517576b28afe45c
+      - pypi: https://files.pythonhosted.org/packages/fb/ce/5c72cdb8b4994c1a8182ce5261269b131959dab552b52d27de2ad62296f0/drone_controllers-0.1.0b0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/2b/17c4f7e77249ff861bb1b7fcd7b2d267fc855a6c5d5b979a26abbde85262/drone_models-0.1.0b0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/98/87b5946356095738cb90a6df7b35ff69ac5750f6e783d5fbcc5cb3b6cbd7/etils-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
@@ -1490,7 +1568,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl
-      - pypi: git+https://github.com/scipy/scipy.git?rev=4cb83b6#4cb83b62d4bf1d27f63a57988a0fcd2aa15d6640
+      - pypi: https://files.pythonhosted.org/packages/d7/52/871177befb910285db87fb23a93cb39d30e1fd38e6a6a0c6c63b872d41d6/scipy-1.17.0rc1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0f/cb/c21b96ff379923310b4fb2c06e8d560d801e24aeb300faa72a04776868fc/sentry_sdk-2.42.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/f1/b392952200f3393bb06fbc4dd975fc63a6843261705839355560b7264eb2/simplejson-3.20.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl
@@ -1563,9 +1641,9 @@ packages:
   - pkg:pypi/aiohappyeyeballs?source=hash-mapping
   size: 19750
   timestamp: 1741775303303
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.0-py312h033f2cf_0.conda
-  sha256: 07f71fb3a68f8e0d248811217884f859cd1a6ca30f6aafffadd4239cff3213cb
-  md5: 1063ec5a1ae783cba0befa2b768a6af2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.2-py312h27b7581_0.conda
+  sha256: baf2bbf52aeecdbfe6e03a373b2664169cbdc37a92a2ac68bc7ef45353f65d61
+  md5: ad84ca57d502eead2df0233090261dfb
   depends:
   - __glibc >=2.17,<3.0.a0
   - aiohappyeyeballs >=2.5.0
@@ -1582,8 +1660,8 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/aiohttp?source=hash-mapping
-  size: 1009094
-  timestamp: 1759836346867
+  size: 1014925
+  timestamp: 1761727721839
 - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
   sha256: 8dc149a6828d19bf104ea96382a9d04dae185d4a03cc6beb1bc7b84c428e3ca2
   md5: 421a865222cd0c9d83ff08bc78bf3a61
@@ -1597,17 +1675,17 @@ packages:
   - pkg:pypi/aiosignal?source=hash-mapping
   size: 13688
   timestamp: 1751626573984
-- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
-  sha256: b9214bc17e89bf2b691fad50d952b7f029f6148f4ac4fe7c60c08f093efdf745
-  md5: 76df83c2a9035c54df5d04ff81bcc02d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.1-hb03c661_0.conda
+  sha256: 224f1a55a9ba7e877bce980f14fc3e3c0f0fb6d3cbf3c5f1a8f5dd8391ce8bba
+  md5: bba37fb066adb90e1d876dff0fd5d09d
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   license: LGPL-2.1-or-later
   license_family: GPL
   purls: []
-  size: 566531
-  timestamp: 1744668655747
+  size: 585491
+  timestamp: 1766155792553
 - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
   name: annotated-types
   version: 0.7.0
@@ -1626,6 +1704,10 @@ packages:
   purls: []
   size: 2706396
   timestamp: 1718551242397
+- pypi: https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl
+  name: appdirs
+  version: 1.4.4
+  sha256: a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
 - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.3-pyhd8ed1ab_0.conda
   sha256: a2a1879c53b7a8438c898d20fa5f6274e4b1c30161f93b7818236e9df6adffde
   md5: 8f37c8fb7116a18da04e52fa9e2c8df9
@@ -1671,11 +1753,12 @@ packages:
   requires_dist:
   - array-api-compat>=1.12.0,<2
   requires_python: '>=3.10'
-- pypi: git+https://github.com/data-apis/array-api-typing#909ee50fab11a70af915d2193a7a9dfc2fc71b91
-  name: array-api-typing
-  version: 0.1.dev30+g909ee50fa
+- pypi: https://files.pythonhosted.org/packages/1d/05/2709750ddb088eb2fc5053ba214b4f54334d15d4cb28217e2956b5507bac/array_api_extra-0.9.1-py3-none-any.whl
+  name: array-api-extra
+  version: 0.9.1
+  sha256: 78b3e6605d1cdc9a66bb49e340e1bb620f045f1809a4e146d74500c3cb813b74
   requires_dist:
-  - typing-extensions>=4.14.1
+  - array-api-compat>=1.12.0,<2
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
   sha256: c9022ee34f756847f48907472514da3395a8c0549679cfd2a1b4f6833dd6298c
@@ -1746,17 +1829,18 @@ packages:
   purls: []
   size: 68072
   timestamp: 1756738968573
-- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
-  sha256: f6c3c19fa599a1a856a88db166c318b148cac3ee4851a9905ed8a04eeec79f45
-  md5: c7944d55af26b6d2d7629e27e9a972c1
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+  sha256: c13d5e42d187b1d0255f591b7ce91201d4ed8a5370f0d986707a802c20c9d32f
+  md5: 537296d57ea995666c68c821b00e360b
   depends:
   - python >=3.10
+  - python
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/attrs?source=compressed-mapping
-  size: 60101
-  timestamp: 1759762331492
+  size: 64759
+  timestamp: 1764875182184
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.44-h4852527_2.conda
   sha256: 1461b66ef4801c20dc39d7005eed559bfcd3a62c219dc030343ddd570b58a9e6
   md5: 7f77703af8f54071370e0bc3a4b225af
@@ -1767,6 +1851,16 @@ packages:
   purls: []
   size: 34957
   timestamp: 1758810956483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_104.conda
+  sha256: 1625ea421e0f44dbdde01e3e7d2c4958bea6c55731e6ac6954ba912d339982c2
+  md5: d351e4894d6c4d9d8775bf169a97089d
+  depends:
+  - binutils_impl_linux-64 >=2.45,<2.46.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 35316
+  timestamp: 1764007880473
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.44-hdf8817f_2.conda
   sha256: 014eda0be99345946706a8141ecf32f619c731152831b85e4a752b4917c4528c
   md5: f0716b5f7e87e83678d50da21e7a54b4
@@ -1778,6 +1872,18 @@ packages:
   purls: []
   size: 3797704
   timestamp: 1758810925961
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
+  sha256: 054a77ccab631071a803737ea8e5d04b5b18e57db5b0826a04495bd3fdf39a7c
+  md5: a7a67bf132a4a2dea92a7cb498cdc5b1
+  depends:
+  - ld_impl_linux-64 2.45 default_hbd61a6d_104
+  - sysroot_linux-64
+  - zstd >=1.5.7,<1.6.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 3747046
+  timestamp: 1764007847963
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.44-h4852527_2.conda
   sha256: fd73320b4b3df2b18a1c2a9e17ed8c1402e1530c03a7d5af8240469b389128dd
   md5: 9102871743e92e2eea2f2b3bfef74ed0
@@ -1788,6 +1894,16 @@ packages:
   purls: []
   size: 35965
   timestamp: 1758810959224
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_104.conda
+  sha256: ed23fee4db69ad82320cca400fc77404c3874cd866606651a20bf743acd1a9b1
+  md5: e30e71d685e23cc1e5ac1c1990ba1f81
+  depends:
+  - binutils_impl_linux-64 2.45 default_hfdba357_104
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 36180
+  timestamp: 1764007883258
 - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
   sha256: a05971bb80cca50ce9977aad3f7fc053e54ea7d5321523efc7b9a6e12901d3cd
   md5: f0b4c8e370446ef89797608d60a564b3
@@ -1818,33 +1934,33 @@ packages:
   purls: []
   size: 48427
   timestamp: 1733513201413
-- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb03c661_4.conda
-  sha256: 294526a54fa13635341729f250d0b1cf8f82cad1e6b83130304cbf3b6d8b74cc
-  md5: eaf3fbd2aa97c212336de38a51fe404e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
+  sha256: e511644d691f05eb12ebe1e971fd6dc3ae55a4df5c253b4e1788b789bdf2dfa6
+  md5: 8ccf913aaba749a5496c17629d859ed1
   depends:
   - __glibc >=2.17,<3.0.a0
-  - brotli-bin 1.1.0 hb03c661_4
-  - libbrotlidec 1.1.0 hb03c661_4
-  - libbrotlienc 1.1.0 hb03c661_4
+  - brotli-bin 1.2.0 hb03c661_1
+  - libbrotlidec 1.2.0 hb03c661_1
+  - libbrotlienc 1.2.0 hb03c661_1
   - libgcc >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 19883
-  timestamp: 1756599394934
-- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb03c661_4.conda
-  sha256: 444903c6e5c553175721a16b7c7de590ef754a15c28c99afbc8a963b35269517
-  md5: ca4ed8015764937c81b830f7f5b68543
+  size: 20103
+  timestamp: 1764017231353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
+  sha256: 64b137f30b83b1dd61db6c946ae7511657eead59fdf74e84ef0ded219605aa94
+  md5: af39b9a8711d4a8d437b52c1d78eb6a1
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libbrotlidec 1.1.0 hb03c661_4
-  - libbrotlienc 1.1.0 hb03c661_4
+  - libbrotlidec 1.2.0 hb03c661_1
+  - libbrotlienc 1.2.0 hb03c661_1
   - libgcc >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 19615
-  timestamp: 1756599385418
+  size: 21021
+  timestamp: 1764017221344
 - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py313h7033f15_4.conda
   sha256: b1941426e564d326097ded7af8b525540be219be7a88ca961d58a8d4fc116db2
   md5: bc8624c405856b1d047dd0a81829b08c
@@ -1912,6 +2028,17 @@ packages:
   purls: []
   size: 206884
   timestamp: 1744127994291
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+  sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
+  md5: 920bb03579f15389b9e512095ad995b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 207882
+  timestamp: 1765214722852
 - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.10.0-h2b85faf_0.conda
   sha256: 70be54bfe92b72794f664ad95b6fcef74d508710a9b2d790bc9c69f5a40239c3
   md5: 9256b7e5e900a1b98aedc8d6ffe91bec
@@ -1933,6 +2060,15 @@ packages:
   purls: []
   size: 155907
   timestamp: 1759649036195
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+  sha256: b986ba796d42c9d3265602bc038f6f5264095702dd546c14bc684e60c385e773
+  md5: f0991f0f84902f6b6009b4d2350a83aa
+  depends:
+  - __unix
+  license: ISC
+  purls: []
+  size: 152432
+  timestamp: 1762967197890
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
   sha256: 3bd6a391ad60e471de76c0e9db34986c4b5058587fbf2efa5a7f54645e28c2c7
   md5: 09262e66b19567aff4f592fb53b28760
@@ -1959,6 +2095,12 @@ packages:
   purls: []
   size: 978114
   timestamp: 1741554591855
+- pypi: https://files.pythonhosted.org/packages/24/ab/d7233c915b12c005655437c6c4cf0ae46cbbb2b20d743cb5e4881ad3104a/casadi-3.7.2-cp312-none-manylinux2014_x86_64.whl
+  name: casadi
+  version: 3.7.2
+  sha256: cde616930fa1440ad66f1850670399423edd37354eed9b12e74b3817b98d1187
+  requires_dist:
+  - numpy
 - pypi: https://files.pythonhosted.org/packages/3f/5b/7120e22f6e22ca77283f4a086ab2e59d107f00bfc952116db41a015385fe/casadi-3.7.2-cp313-none-manylinux2014_x86_64.whl
   name: casadi
   version: 3.7.2
@@ -1991,12 +2133,35 @@ packages:
   - pkg:pypi/certifi?source=hash-mapping
   size: 160248
   timestamp: 1759648987029
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h35888ee_0.conda
-  sha256: f9e906b2cb9ae800b5818259472c3f781b14eb1952e867ac5c1f548e92bf02d9
-  md5: 60b9cd087d22272885a6b8366b1d3d43
+- pypi: https://files.pythonhosted.org/packages/ea/2c/8d67048a1fa8838a3e09b1a3a645b34d89d03dde4762e90076d3015e23a3/cfclient-2025.12-py3-none-any.whl
+  name: cfclient
+  version: '2025.12'
+  sha256: 2cbb92dc6812ea62c777146a891a76f48634b7644fe33a4f6fd1c9fe25ed8356
+  requires_dist:
+  - cflib~=0.1.30
+  - setuptools
+  - appdirs~=1.4.0
+  - pyzmq~=26.0
+  - pyqtgraph~=0.13
+  - pyyaml~=6.0.1
+  - numpy~=2.2
+  - vispy~=0.15.2
+  - pyopengl~=3.1.7
+  - pyserial~=3.5
+  - pyqt6~=6.7.1
+  - pyqt6-sip~=13.8
+  - pysdl2~=0.9.14 ; sys_platform == 'darwin' or sys_platform == 'win32'
+  - pysdl2-dll==2.24.0 ; sys_platform == 'darwin' or sys_platform == 'win32'
+  - pre-commit ; extra == 'dev'
+  - cx-freeze==5.1.1 ; sys_platform == 'win32' and extra == 'dev'
+  - jinja2==2.10.3 ; sys_platform == 'win32' and extra == 'dev'
+  requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
+  sha256: 7dafe8173d5f94e46cf9cd597cc8ff476a8357fbbd4433a8b5697b2864845d9c
+  md5: 648ee28dcd4e07a1940a17da62eccd40
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libffi >=3.4.6,<3.5.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
   - pycparser
   - python >=3.12,<3.13.0a0
@@ -2005,8 +2170,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/cffi?source=hash-mapping
-  size: 296986
-  timestamp: 1758716192805
+  size: 295716
+  timestamp: 1761202958833
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py313hf01b4d8_0.conda
   sha256: cbead764b88c986642578bb39f77d234fbc3890bd301ed29f849a6d3898ed0fc
   md5: 062317cc1cd26fbf6454e86ddd3622c4
@@ -2023,6 +2188,20 @@ packages:
   - pkg:pypi/cffi?source=compressed-mapping
   size: 298211
   timestamp: 1758716239290
+- pypi: https://files.pythonhosted.org/packages/16/73/5de1f983f5329d9fc11ff9457a9c7b7d707c162f30f158b7ffe410576f8a/cflib-0.1.30-py3-none-any.whl
+  name: cflib
+  version: 0.1.30
+  sha256: b6a2d4badb7d4c2448d0a2a1c229e3e28d433d2c822e6b09eddc0a3197f8ca5a
+  requires_dist:
+  - pyusb~=1.2
+  - libusb-package~=1.0
+  - scipy~=1.14
+  - numpy~=2.2
+  - packaging~=25.0
+  - pre-commit ; extra == 'dev'
+  - qtm-rt~=3.0.2 ; extra == 'qualisys'
+  - motioncapture~=1.0a4 ; extra == 'motioncapture'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
   sha256: b32f8362e885f1b8417bac2b3da4db7323faa12d5db62b7fd6691c02d60d6f59
   md5: a22d1fd9bf98827e280a02875d9a007a
@@ -2076,6 +2255,11 @@ packages:
   version: 3.1.1
   sha256: c8c5a44295039331ee9dad40ba100a9c7297b6f988e50e87ccdf3765a668350e
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  name: cloudpickle
+  version: 3.1.2
+  sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.1.2-hc85cc9f_0.conda
   sha256: 2176c4bce9f602cee0efbae86283a1a75733921ecc0916c8d2f49df2aee1a0f0
   md5: 3d5d0a07f07ba1fc43f52b5e33e3cd7c
@@ -2097,6 +2281,27 @@ packages:
   purls: []
   size: 21290609
   timestamp: 1759261133874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.2.1-hc85cc9f_0.conda
+  sha256: 655db6eddb370306d6d0ed3ac1d679ca044e45e03a43fc98cccfc5cafc341c5f
+  md5: e4afa0cb7943cc9810546f70f02223d5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.17.0,<9.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libgcc >=14
+  - liblzma >=5.8.1,<6.0a0
+  - libstdcxx >=14
+  - libuv >=1.51.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - rhash >=1.4.6,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 22303088
+  timestamp: 1765229009574
 - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
   sha256: 05ccb85cad9ca58be9dcb74225f6180a68907a6ab0c990e3940f4decc5bb2280
   md5: bde6042a1b40a2d4021e1becbe8dd84f
@@ -2264,18 +2469,18 @@ packages:
   - pkg:pypi/colcon-output?source=hash-mapping
   size: 16174
   timestamp: 1676526311561
-- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.0-pyhd8ed1ab_0.conda
-  sha256: fcea11b23e09e885f7989dfb1468c34985060bf9c5f1ec6d8e59af3f8256ce92
-  md5: ed85497b62f88dd3c018272edc81d8b5
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.0-pyhd8ed1ab_1.conda
+  sha256: 6654254ab628a9ca1648a18b7a1c078ae11bf9eca898a4ee20f601b622acd783
+  md5: 6f4c11d25a53f2a7daac0232c3306556
   depends:
   - colcon-core
-  - python >=3.5
+  - python >=3.10
   license: Apache-2.0
   license_family: APACHE
   purls:
   - pkg:pypi/colcon-package-information?source=hash-mapping
-  size: 18063
-  timestamp: 1710399124724
+  size: 18705
+  timestamp: 1764592318817
 - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
   sha256: 1cc39947aace656988696bc63c520e031c27a974e18b3fce0db58e18bb6228a5
   md5: 1ef460db4fbafbb3279e950378d317b5
@@ -2426,6 +2631,16 @@ packages:
   purls: []
   size: 7452
   timestamp: 1751115555727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-13.4.0-h109b0d3_16.conda
+  sha256: b2d12800cbb3fe22df48321383fef463e09d9bb2efc1b304f9ecac97e0e40540
+  md5: 42991ce268372fadf2c584f78863baa9
+  depends:
+  - gcc_impl_linux-64 >=13.4.0,<13.4.1.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 31363
+  timestamp: 1765256109339
 - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-13.4.0-h54dc52d_7.conda
   sha256: ab5d1ca92419e367be9fb9cd7334f6450cb825f2e2938b95478b4c2538d9f56b
   md5: 1bd050fd3d8abd8dcf4ec73e3a94e3ef
@@ -2447,9 +2662,9 @@ packages:
   purls: []
   size: 18460
   timestamp: 1648912649612
-- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312hd9148b4_2.conda
-  sha256: cedae3c71ad59b6796d182f9198e881738b7a2c7b70f18427d7788f3173befb2
-  md5: bce621e43978c245261c76b45edeaa3d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312hd9148b4_3.conda
+  sha256: e173ea96fb135b233c7f57c35c0d07f7adc50ebacf814550f3daf1c7ba2ed51e
+  md5: 86cf7a7d861b79d38e3f0e5097e4965b
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -2461,11 +2676,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/contourpy?source=hash-mapping
-  size: 295534
-  timestamp: 1756544766129
-- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.11.0-py312h8a5da7c_0.conda
-  sha256: e2ab39dd818674131055df51ae293b4dbcb60992f2102caa6c35369da007c23e
-  md5: c23f0ca5a6e2f0ef5735825f14fbe007
+  size: 295243
+  timestamp: 1762525427240
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.0-py312h8a5da7c_0.conda
+  sha256: 1624eaffb5ff622a48712114faf328b44e11d800dc85e891ee2412ffd38bd18b
+  md5: da396284d1f498e20b4377478dbb830c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -2476,8 +2691,8 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
-  size: 379172
-  timestamp: 1760545159050
+  size: 383584
+  timestamp: 1765203584575
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.18.3-py312h014360a_1.conda
   sha256: f4321bdeddc9178f006a8cc3dedeaf32ab7e4c3be843845fbf594bc07999d2d6
   md5: ab786ccd5cc6a08c0ebd5f6154c9dfcd
@@ -2497,11 +2712,13 @@ packages:
   - pkg:pypi/cppcheck-htmlreport?source=hash-mapping
   size: 3065679
   timestamp: 1757440259649
-- pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=adr_ws25#7cf6e319f6dd9bacafaed252bbca78d3e59037bd
+- pypi: git+https://github.com/utiasDSL/crazyflow.git?rev=0.1.0b0#d630bc0da89fa65404e855f51517576b28afe45c
   name: crazyflow
-  version: 0.0.2
+  version: 0.1.0b0
   requires_dist:
-  - jax>=0.7.0
+  - numpy>=2.0.0
+  - scipy>=1.17.0rc1
+  - jax>=0.7.0,<0.8.2
   - mujoco>=3.3.0
   - mujoco-mjx>=3.3.0
   - gymnasium[mujoco]>=1.2.0
@@ -2510,16 +2727,16 @@ packages:
   - flax
   - ml-collections
   - casadi
-  - numpy
-  - scipy @ git+https://github.com/scipy/scipy.git@4cb83b6
+  - drone-models
+  - drone-controllers
   - jax[cuda12] ; extra == 'gpu'
   - fire ; extra == 'benchmark'
   - matplotlib ; extra == 'benchmark'
   - pandas ; extra == 'benchmark'
-  requires_python: '>=3.11'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312hee9fe19_0.conda
-  sha256: 3b158c55cb494a5da669465ff86c774b2e65f0c8541a888aae970fb7a74aeb58
-  md5: 85ce285422e464eb1768aefd7d0d89f0
+  requires_python: '>=3.11,<3.14'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312ha4b625e_1.conda
+  sha256: 28dd9ae4bf7913a507e08ccd13788f0abe75557831095244e487bda2c474554f
+  md5: a42f7c8a15d53cdb6738ece5bd745d13
   depends:
   - __glibc >=2.17,<3.0.a0
   - cffi >=1.14
@@ -2532,9 +2749,9 @@ packages:
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   purls:
-  - pkg:pypi/cryptography?source=compressed-mapping
-  size: 1716207
-  timestamp: 1760605051655
+  - pkg:pypi/cryptography?source=hash-mapping
+  size: 1716814
+  timestamp: 1764805537696
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.10.0-h1a2810e_0.conda
   sha256: 88ff4a72ad70a3b9a20a0296e395c0caaa6dc0a0e46a752aa683fb42be03facd
   md5: 3cd322edac3d40904ff07355a8be8086
@@ -2547,17 +2764,18 @@ packages:
   purls: []
   size: 6633
   timestamp: 1751115555450
-- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
-  sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
-  md5: 44600c4667a319d67dbe0681fc0bc833
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+  sha256: bb47aec5338695ff8efbddbc669064a3b10fe34ad881fb8ad5d64fbfa6910ed1
+  md5: 4c2a8fef270f6c69591889b93f9f55c1
   depends:
-  - python >=3.9
+  - python >=3.10
+  - python
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/cycler?source=hash-mapping
-  size: 13399
-  timestamp: 1733332563512
+  size: 14778
+  timestamp: 1764466758386
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
   sha256: ee09ad7610c12c7008262d713416d0b58bf365bc38584dce48950025850bdf3f
   md5: cae723309a49399d2949362f4ab5c9e4
@@ -2584,34 +2802,32 @@ packages:
   purls: []
   size: 760229
   timestamp: 1685695754230
-- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
-  sha256: 3b988146a50e165f0fa4e839545c679af88e4782ec284cc7b6d07dd226d6a068
-  md5: 679616eb5ad4e521c83da4650860aba7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+  sha256: 8bb557af1b2b7983cf56292336a1a1853f26555d9c6cecf1e5b2b96838c9da87
+  md5: ce96f2f470d39bd96ce03945af92e280
   depends:
-  - libstdcxx >=13
-  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libexpat >=2.7.0,<3.0a0
+  - libgcc >=14
+  - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
-  - libglib >=2.84.2,<3.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
+  - libglib >=2.86.2,<3.0a0
+  - libexpat >=2.7.3,<3.0a0
+  license: AFL-2.1 OR GPL-2.0-or-later
   purls: []
-  size: 437860
-  timestamp: 1747855126005
-- conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
-  sha256: d614bcff10696f1efc714df07651b50bf3808401fcc03814309ecec242cc8870
-  md5: 0cef44b1754ae4d6924ac0eef6b9fdbe
+  size: 447649
+  timestamp: 1764536047944
+- conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_0.conda
+  sha256: c994a70449d548dd388768090c71c1da81e1e128a281547ab9022908d46878c5
+  md5: bf74a83f7a0f2a21b5d709997402cac4
   depends:
-  - python >=3.9
+  - python >=3.10
   - wrapt <2,>=1.10
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/deprecated?source=hash-mapping
-  size: 14382
-  timestamp: 1737987072859
+  size: 15815
+  timestamp: 1761813872696
 - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
   sha256: 6d977f0b2fc24fee21a9554389ab83070db341af6d6f09285360b2e09ef8b26e
   md5: 003b8ba0a94e2f1e117d0bd46aebc901
@@ -2634,16 +2850,16 @@ packages:
   - pkg:pypi/distro?source=hash-mapping
   size: 41773
   timestamp: 1734729953882
-- conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.2-pyhd8ed1ab_0.conda
-  sha256: dd02330f2ecca4a489a001e5ec66ee8aa50773dc2c621c8fc7053b454d9a27b2
-  md5: ba6a7a1c262587d333761b0cda2bbd28
+- conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+  sha256: 0d605569a77350fb681f9ed8d357cc71649b59a304099dc9d09fbeec5e84a65e
+  md5: d6bd3cd217e62bbd7efe67ff224cd667
   depends:
   - python >=3.10
   license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
   purls:
-  - pkg:pypi/docutils?source=hash-mapping
-  size: 437394
-  timestamp: 1758409808966
+  - pkg:pypi/docutils?source=compressed-mapping
+  size: 438002
+  timestamp: 1766092633160
 - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
   sha256: 1bcc132fbcc13f9ad69da7aa87f60ea41de7ed4d09f3a00ff6e0e70e1c690bc2
   md5: bfd56492d8346d669010eccafe0ba058
@@ -2656,24 +2872,43 @@ packages:
   purls: []
   size: 69544
   timestamp: 1739569648873
-- pypi: git+https://github.com/utiasDSL/drone-controllers.git?rev=adr_ws25#3b741afe0aee89462bb9011d460be3908fbc8678
+- pypi: https://files.pythonhosted.org/packages/fb/ce/5c72cdb8b4994c1a8182ce5261269b131959dab552b52d27de2ad62296f0/drone_controllers-0.1.0b0-py3-none-any.whl
   name: drone-controllers
-  version: 0.0.1
+  version: 0.1.0b0
+  sha256: 68b72d933c341ce2f507107a01ed0cc551913917406f83760c8f003f6299cd92
   requires_dist:
   - numpy>=2.0.0
+  - scipy>=1.17.0rc1
   - array-api-compat
   - array-api-extra
-  - array-api-typing @ git+https://github.com/data-apis/array-api-typing
-  - scipy @ git+https://github.com/scipy/scipy.git@4cb83b6
-- pypi: git+https://github.com/utiasDSL/drone-models.git?rev=adr_ws25#ff1662c3ed3948b80fa0b307036964cb89dfaf01
+- pypi: https://files.pythonhosted.org/packages/e8/60/d660a283ed138cdd5037abf461889ec117b9195d24322c958af187bb7163/drone_estimators-0.1.0b0-py3-none-any.whl
+  name: drone-estimators
+  version: 0.1.0b0
+  sha256: a1bce4ffb4dc04f6d20876271abe1719972bb7feb16cfed0c0ec5aff2468bcde
+  requires_dist:
+  - jax
+  - numpy>=2.0
+  - scipy>=1.17.0rc1
+  - drone-models>=0.1.0b0
+  - munch
+  - transforms3d
+  - flax
+  - array-api-compat
+  - array-api-extra
+  - drone-models ; extra == 'dev'
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - torch ; extra == 'test'
+- pypi: https://files.pythonhosted.org/packages/1f/2b/17c4f7e77249ff861bb1b7fcd7b2d267fc855a6c5d5b979a26abbde85262/drone_models-0.1.0b0-py3-none-any.whl
   name: drone-models
-  version: 0.0.1
+  version: 0.1.0b0
+  sha256: 53e863cbf0521c4c9d7dbeb756ec92e79f36eb3953fa11452e50497084cafe2c
   requires_dist:
   - numpy>=2.0.0
+  - scipy>=1.17.0rc1
   - casadi>=3.7.0
   - array-api-compat
-  - scipy @ git+https://github.com/scipy/scipy.git@4cb83b6
-  - array-api-typing @ git+https://github.com/data-apis/array-api-typing
   - array-api-extra
 - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h171cf75_1.conda
   sha256: fee3738c2431c13f4930778e9d7daca9328e7e2f2a38928cf6ca5a0daa86474a
@@ -2810,25 +3045,36 @@ packages:
   - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 21284
   timestamp: 1746947398083
-- conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.7.1-hecca717_0.conda
-  sha256: e981cf62a722f0eb4631ac7b786c288c03883fbc241fa98a276308fb69cb2c59
-  md5: 6033d8c2bb9b460929d00ba54154614c
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
+  md5: 8e662bd460bda79b1ea39194e3c4c9ab
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.6.0
+  license: MIT and PSF-2.0
+  purls:
+  - pkg:pypi/exceptiongroup?source=compressed-mapping
+  size: 21333
+  timestamp: 1763918099466
+- conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.7.3-hecca717_0.conda
+  sha256: c5d573e6831fb41177fb5ae0f1ee09caed55a868ec9887bc80ccc22c3e57b9b4
+  md5: c81f6fa1865526f5ab1e6b669b3ee877
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libexpat 2.7.1 hecca717_0
+  - libexpat 2.7.3 hecca717_0
   - libgcc >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 140948
-  timestamp: 1752719584725
+  size: 143991
+  timestamp: 1763549744569
 - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
   name: farama-notifications
   version: 0.0.4
   sha256: 14de931035a41961f7c056361dc7f980762a143d05791ef5794a751a2caf05ae
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h127656b_906.conda
-  sha256: e8e93a1afd93bed11ccf2a2224d2b92b2af8758c89576ed87ff4df7f3269604f
-  md5: 28cffcba871461840275632bc4653ce3
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.1-gpl_ha0aeed6_910.conda
+  sha256: cb2453b75759813beb3ca1af8cc134b7b5ae3580a43745964f61d921ad3f591a
+  md5: 983afde30790eeb90054f0838fabaff2
   depends:
   - __glibc >=2.17,<3.0.a0
   - alsa-lib >=1.2.14,<1.3.0a0
@@ -2838,42 +3084,43 @@ packages:
   - fontconfig >=2.15.0,<3.0a0
   - fonts-conda-ecosystem
   - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=11.0.1
+  - harfbuzz >=11.4.5
   - lame >=3.100,<3.101.0a0
-  - libass >=0.17.3,<0.17.4.0a0
-  - libexpat >=2.7.0,<3.0a0
+  - libass >=0.17.4,<0.17.5.0a0
+  - libexpat >=2.7.1,<3.0a0
   - libfreetype >=2.13.3
   - libfreetype6 >=2.13.3
-  - libgcc >=13
+  - libgcc >=14
   - libiconv >=1.18,<2.0a0
   - liblzma >=5.8.1,<6.0a0
-  - libopenvino >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-auto-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-hetero-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-gpu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-npu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-ir-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-onnx-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-paddle-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-pytorch-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.0.0,<2025.0.1.0a0
+  - libopenvino >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-auto-batch-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-auto-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-hetero-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-intel-cpu-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-intel-gpu-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-intel-npu-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-ir-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-onnx-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-paddle-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-pytorch-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-tensorflow-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2025.2.0,<2025.2.1.0a0
   - libopus >=1.5.2,<2.0a0
   - librsvg >=2.58.4,<3.0a0
-  - libstdcxx >=13
+  - libstdcxx >=14
   - libva >=2.22.0,<3.0a0
   - libvorbis >=1.3.7,<1.4.0a0
+  - libvpl >=2.15.0,<2.16.0a0
   - libvpx >=1.14.1,<1.15.0a0
   - libxcb >=1.17.0,<2.0a0
   - libxml2 >=2.13.8,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
   - openh264 >=2.6.0,<2.6.1.0a0
-  - openssl >=3.5.0,<4.0a0
+  - openssl >=3.5.2,<4.0a0
   - pulseaudio-client >=17.0,<17.1.0a0
   - sdl2 >=2.32.54,<3.0a0
-  - svt-av1 >=3.0.2,<3.0.3.0a0
+  - svt-av1 >=3.1.2,<3.1.3.0a0
   - x264 >=1!164.3095,<1!165
   - x265 >=3.5,<3.6.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
@@ -2882,8 +3129,8 @@ packages:
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 10377191
-  timestamp: 1748704974937
+  size: 10543003
+  timestamp: 1757215060681
 - pypi: https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl
   name: filelock
   version: 3.20.0
@@ -2919,18 +3166,18 @@ packages:
   - pkg:pypi/flake8?source=hash-mapping
   size: 111916
   timestamp: 1750968083921
-- conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.0.0-pyhd8ed1ab_0.conda
-  sha256: b8522466bee2e362aa046712b12a06e79381b996e91888e05abadde4e24aef99
-  md5: c1112609cc3e996cde98219180a789f4
+- conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.1.0-pyhd8ed1ab_0.conda
+  sha256: d022684576c0c6f474bddbc263c82a3ba303c3bd09185d15af4eb7b60e896d7f
+  md5: 5cbaa86cc684a52a057831cbcb3bd5b9
   depends:
   - flake8
-  - python >=3.9
+  - python >=3.10
   license: GPL-2.0-only
   license_family: GPL2
   purls:
   - pkg:pypi/flake8-builtins?source=hash-mapping
-  size: 18158
-  timestamp: 1755540142244
+  size: 19501
+  timestamp: 1761594405382
 - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
   sha256: a0427b75e67d6f2f41f7645b850ac028876bee3a11d8fbaa18d88fd61b467a94
   md5: 9f5bd5fb0aa24273e9cce97830629e20
@@ -3058,6 +3305,70 @@ packages:
   - pre-commit>=3.8.0 ; extra == 'dev'
   - scikit-build-core[pyproject]>=0.11.0 ; extra == 'dev'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/b7/6b/7b75508251f4220df8f68e7718b476ee3d614a2a51f9eace97393ee91b46/flax-0.12.2-py3-none-any.whl
+  name: flax
+  version: 0.12.2
+  sha256: 912fdd8a7c623ec8b2694b28d2827608e7fc82a3a6f8fff17ec5038f2bca66f4
+  requires_dist:
+  - numpy>=1.23.2 ; python_full_version >= '3.11'
+  - numpy>=1.26.0 ; python_full_version >= '3.12'
+  - jax>=0.8.1
+  - msgpack
+  - optax
+  - orbax-checkpoint
+  - tensorstore
+  - rich>=11.1
+  - typing-extensions>=4.2
+  - pyyaml>=5.4.1
+  - treescope>=0.1.7
+  - clu ; extra == 'testing'
+  - clu<=0.0.9 ; python_full_version < '3.10' and extra == 'testing'
+  - einops ; extra == 'testing'
+  - gymnasium[atari] ; extra == 'testing'
+  - jaxlib ; extra == 'testing'
+  - jaxtyping ; extra == 'testing'
+  - jraph>=0.0.6.dev0 ; extra == 'testing'
+  - ml-collections ; extra == 'testing'
+  - mypy ; extra == 'testing'
+  - opencv-python ; extra == 'testing'
+  - protobuf<6 ; python_full_version >= '3.13' and extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-custom-exit-code ; extra == 'testing'
+  - pytest-xdist ; extra == 'testing'
+  - pytype ; extra == 'testing'
+  - sentencepiece==0.2.0 ; extra == 'testing'
+  - tensorflow-text>=2.11.0 ; python_full_version < '3.13' and sys_platform != 'darwin' and extra == 'testing'
+  - tensorflow-datasets ; extra == 'testing'
+  - tensorflow>=2.12.0 ; python_full_version < '3.13' and extra == 'testing'
+  - tensorflow>=2.20.0 ; python_full_version >= '3.13' and extra == 'testing'
+  - keras<3.13 ; extra == 'testing'
+  - torch ; extra == 'testing'
+  - treescope>=0.1.1 ; python_full_version >= '3.10' and extra == 'testing'
+  - cloudpickle>=3.0.0 ; extra == 'testing'
+  - ale-py>=0.10.2 ; extra == 'testing'
+  - sphinx==6.2.1 ; extra == 'docs'
+  - sphinx-book-theme ; extra == 'docs'
+  - pygments>=2.6.1 ; extra == 'docs'
+  - ipykernel ; extra == 'docs'
+  - myst-nb ; extra == 'docs'
+  - nbstripout ; extra == 'docs'
+  - recommonmark ; extra == 'docs'
+  - ipython-genutils ; extra == 'docs'
+  - sphinx-design ; extra == 'docs'
+  - jupytext==1.13.8 ; extra == 'docs'
+  - dm-haiku>=0.0.14 ; extra == 'docs'
+  - docutils ; extra == 'docs'
+  - matplotlib ; extra == 'docs'
+  - scikit-learn ; extra == 'docs'
+  - ml-collections ; extra == 'docs'
+  - einops ; extra == 'docs'
+  - kagglehub>=0.3.3 ; extra == 'docs'
+  - ipywidgets>=8.1.5 ; extra == 'docs'
+  - nanobind>=2.5.0 ; extra == 'dev'
+  - pre-commit>=3.8.0 ; extra == 'dev'
+  - scikit-build-core[pyproject]>=0.11.0 ; extra == 'dev'
+  requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.2.0-h07f6e7f_0.conda
   sha256: e0f53b7801d0bcb5d61a1ddcb873479bfe8365e56fd3722a232fbcc372a9ac52
   md5: 0c2f855a88fab6afa92a7aa41217dc8e
@@ -3127,22 +3438,22 @@ packages:
   purls: []
   size: 3667
   timestamp: 1566974674465
-- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-  sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  md5: f766549260d6815b0c52253f1fb1bb29
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+  sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+  md5: a7970cd949a077b7cb9696379d338681
   depends:
-  - font-ttf-dejavu-sans-mono
-  - font-ttf-inconsolata
-  - font-ttf-source-code-pro
   - font-ttf-ubuntu
+  - font-ttf-inconsolata
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-source-code-pro
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 4102
-  timestamp: 1566932280397
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.60.1-py312h8a5da7c_0.conda
-  sha256: 1be46e58f063c1f563f114df9e78bcb70c4b59760104c5456bbe3b0cb17af9cf
-  md5: b12bb9cc477156ce84038e0be6d0f763
+  size: 4059
+  timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.61.1-py312h8a5da7c_0.conda
+  sha256: c73cd238e0f6b2183c5168b64aa35a7eb66bb145192a9b26bb9041a4152844a3
+  md5: 3bf8fb959dc598c67dac0430b4aff57a
   depends:
   - __glibc >=2.17,<3.0.a0
   - brotli
@@ -3155,8 +3466,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/fonttools?source=hash-mapping
-  size: 2888637
-  timestamp: 1759187635166
+  size: 2932702
+  timestamp: 1765632761555
 - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.3-h5888daf_1.conda
   sha256: 28d9fce64ee8b5e94350feb0829e054811678f9638039f78ddff8a8615c1b693
   md5: 2a3316f47d7827afde5381ecd43b5e85
@@ -3198,27 +3509,27 @@ packages:
   purls: []
   size: 144010
   timestamp: 1719014356708
-- conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h3a85593_22.conda
-  sha256: 03ccff5d255eab7a1736de9eeb539fbb1333036fa5e37ea7c8ec428270067c99
-  md5: bbdf3d43d752b793ac81f27b28c49e2d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h165c975_23.conda
+  sha256: 66441643fb22912b304944945180429bb734f569a3b6228fe5b9a70bebf88a92
+  md5: 7335e72da49f11061b550bec41d6e6bf
   depends:
   - __glibc >=2.17,<3.0.a0
-  - imath >=3.1.12,<3.1.13.0a0
+  - imath >=3.2.1,<3.2.2.0a0
   - jxrlib >=1.1,<1.2.0a0
-  - libgcc >=13
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libraw >=0.21.3,<0.22.0a0
-  - libstdcxx >=13
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libraw >=0.21.4,<0.22.0a0
+  - libstdcxx >=14
   - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - openexr >=3.3.1,<3.4.0a0
-  - openjpeg >=2.5.2,<3.0a0
+  - openexr >=3.3.5,<3.4.0a0
+  - openjpeg >=2.5.3,<3.0a0
   license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
   purls: []
-  size: 467860
-  timestamp: 1729024045245
+  size: 470221
+  timestamp: 1757407791120
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
   sha256: bf8e4dffe46f7d25dc06f31038cacb01672c47b9f45201f065b0f4d00ab0a83e
   md5: 4afc585cd97ba8a23809406cd8a9eda8
@@ -3229,6 +3540,11 @@ packages:
   purls: []
   size: 173114
   timestamp: 1757945422243
+- pypi: https://files.pythonhosted.org/packages/b6/36/853cad240ec63e21a37a512ee19c896b655ce1772d803a3dd80fccfe63fe/freetype_py-2.5.1-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+  name: freetype-py
+  version: 2.5.1
+  sha256: 289b443547e03a4f85302e3ac91376838e0d11636050166662a4f75e3087ed0b
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
   sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
   md5: f9f81ea472684d75b9dd8d0b328cf655
@@ -3361,6 +3677,124 @@ packages:
   - zstandard ; python_full_version < '3.14' and extra == 'test-full'
   - tqdm ; extra == 'tqdm'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl
+  name: fsspec
+  version: 2025.12.0
+  sha256: 8bf1fe301b7d8acfa6e8571e3b1c3d158f909666642431cc78a1b7b4dbc5ec5b
+  requires_dist:
+  - adlfs ; extra == 'abfs'
+  - adlfs ; extra == 'adl'
+  - pyarrow>=1 ; extra == 'arrow'
+  - dask ; extra == 'dask'
+  - distributed ; extra == 'dask'
+  - pre-commit ; extra == 'dev'
+  - ruff>=0.5 ; extra == 'dev'
+  - numpydoc ; extra == 'doc'
+  - sphinx ; extra == 'doc'
+  - sphinx-design ; extra == 'doc'
+  - sphinx-rtd-theme ; extra == 'doc'
+  - yarl ; extra == 'doc'
+  - dropbox ; extra == 'dropbox'
+  - dropboxdrivefs ; extra == 'dropbox'
+  - requests ; extra == 'dropbox'
+  - adlfs ; extra == 'full'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'full'
+  - dask ; extra == 'full'
+  - distributed ; extra == 'full'
+  - dropbox ; extra == 'full'
+  - dropboxdrivefs ; extra == 'full'
+  - fusepy ; extra == 'full'
+  - gcsfs ; extra == 'full'
+  - libarchive-c ; extra == 'full'
+  - ocifs ; extra == 'full'
+  - panel ; extra == 'full'
+  - paramiko ; extra == 'full'
+  - pyarrow>=1 ; extra == 'full'
+  - pygit2 ; extra == 'full'
+  - requests ; extra == 'full'
+  - s3fs ; extra == 'full'
+  - smbprotocol ; extra == 'full'
+  - tqdm ; extra == 'full'
+  - fusepy ; extra == 'fuse'
+  - gcsfs ; extra == 'gcs'
+  - pygit2 ; extra == 'git'
+  - requests ; extra == 'github'
+  - gcsfs ; extra == 'gs'
+  - panel ; extra == 'gui'
+  - pyarrow>=1 ; extra == 'hdfs'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'http'
+  - libarchive-c ; extra == 'libarchive'
+  - ocifs ; extra == 'oci'
+  - s3fs ; extra == 's3'
+  - paramiko ; extra == 'sftp'
+  - smbprotocol ; extra == 'smb'
+  - paramiko ; extra == 'ssh'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'test'
+  - numpy ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-asyncio!=0.22.0 ; extra == 'test'
+  - pytest-benchmark ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - pytest-recording ; extra == 'test'
+  - pytest-rerunfailures ; extra == 'test'
+  - requests ; extra == 'test'
+  - aiobotocore>=2.5.4,<3.0.0 ; extra == 'test-downstream'
+  - dask[dataframe,test] ; extra == 'test-downstream'
+  - moto[server]>4,<5 ; extra == 'test-downstream'
+  - pytest-timeout ; extra == 'test-downstream'
+  - xarray ; extra == 'test-downstream'
+  - adlfs ; extra == 'test-full'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'test-full'
+  - cloudpickle ; extra == 'test-full'
+  - dask ; extra == 'test-full'
+  - distributed ; extra == 'test-full'
+  - dropbox ; extra == 'test-full'
+  - dropboxdrivefs ; extra == 'test-full'
+  - fastparquet ; extra == 'test-full'
+  - fusepy ; extra == 'test-full'
+  - gcsfs ; extra == 'test-full'
+  - jinja2 ; extra == 'test-full'
+  - kerchunk ; extra == 'test-full'
+  - libarchive-c ; extra == 'test-full'
+  - lz4 ; extra == 'test-full'
+  - notebook ; extra == 'test-full'
+  - numpy ; extra == 'test-full'
+  - ocifs ; extra == 'test-full'
+  - pandas ; extra == 'test-full'
+  - panel ; extra == 'test-full'
+  - paramiko ; extra == 'test-full'
+  - pyarrow ; extra == 'test-full'
+  - pyarrow>=1 ; extra == 'test-full'
+  - pyftpdlib ; extra == 'test-full'
+  - pygit2 ; extra == 'test-full'
+  - pytest ; extra == 'test-full'
+  - pytest-asyncio!=0.22.0 ; extra == 'test-full'
+  - pytest-benchmark ; extra == 'test-full'
+  - pytest-cov ; extra == 'test-full'
+  - pytest-mock ; extra == 'test-full'
+  - pytest-recording ; extra == 'test-full'
+  - pytest-rerunfailures ; extra == 'test-full'
+  - python-snappy ; extra == 'test-full'
+  - requests ; extra == 'test-full'
+  - smbprotocol ; extra == 'test-full'
+  - tqdm ; extra == 'test-full'
+  - urllib3 ; extra == 'test-full'
+  - zarr ; extra == 'test-full'
+  - zstandard ; python_full_version < '3.14' and extra == 'test-full'
+  - tqdm ; extra == 'tqdm'
+  requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.4.0-h0dff253_16.conda
+  sha256: 4f96dc5cbf7970ccdf15a8fb426e3467159396005064bde17675b45fb2af9194
+  md5: 78994dd52db53e931e8d5f1d0fedd143
+  depends:
+  - conda-gcc-specs
+  - gcc_impl_linux-64 13.4.0 hf787b08_16
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 29123
+  timestamp: 1765256273448
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.4.0-h81444f0_7.conda
   sha256: 11e1793a6eefbeb6b8bdcabb333fb1eebb504fd649425ec8ec4c82d2c6ac1486
   md5: 927ca740c61a86c1576d431cdeb95e2c
@@ -3388,6 +3822,23 @@ packages:
   purls: []
   size: 66926199
   timestamp: 1759964810732
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.4.0-hf787b08_16.conda
+  sha256: 2b93609f40343c78a0888c9c7e3f7d0313d856ab3dacf187ba6ab3e0bfa72d8c
+  md5: caae4d0c8a309f05394e5fb380d653c9
+  depends:
+  - binutils_impl_linux-64 >=2.45
+  - libgcc >=13.4.0
+  - libgcc-devel_linux-64 13.4.0 hd1d28cc_116
+  - libgomp >=13.4.0
+  - libsanitizer 13.4.0 h2a15e64_16
+  - libstdcxx >=13.4.0
+  - libstdcxx-devel_linux-64 13.4.0 h6963c3b_116
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 68443177
+  timestamp: 1765255975307
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.4.0-h0a5b801_12.conda
   sha256: 6b37ca55decee7bfc29fda22b5ef1d844e9a889d6ad724e8fca97573ee0f6cf7
   md5: 0141fe8e6aa94fda1cd6a03e287d4df7
@@ -3400,9 +3851,21 @@ packages:
   purls: []
   size: 27952
   timestamp: 1759866821148
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.3-h2b0a6b4_0.conda
-  sha256: bbacfedf7aef18117a3642c29a916c3e93b08b5d2d4c4b077ce30617c29e966e
-  md5: 8a6c305c6c6b169f839eefb951608e29
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.4.0-h0a5b801_16.conda
+  sha256: 84177142301ca8d839779fe9e3bae0a3d42722c339e6de6cde4631714cc1c9d3
+  md5: b78eb8c4200b3040b20503dfca33a5c7
+  depends:
+  - gcc_impl_linux-64 13.4.0.*
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 28910
+  timestamp: 1765841858820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.4-h2b0a6b4_0.conda
+  sha256: f47222f58839bcc77c15f11a8814c1d8cb8080c5ca6ba83398a12b640fd3c85c
+  md5: c379d67c686fb83475c1a6ed41cc41ff
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -3414,8 +3877,8 @@ packages:
   license: LGPL-2.1-or-later
   license_family: LGPL
   purls: []
-  size: 572548
-  timestamp: 1759245368266
+  size: 572093
+  timestamp: 1761082340749
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.25.1-h3f43e3d_1.conda
   sha256: cbfa8c80771d1842c2687f6016c5e200b52d4ca8f2cc119f6377f64f899ba4ff
   md5: c42356557d7f2e37676e121515417e3b
@@ -3471,6 +3934,20 @@ packages:
   purls: []
   size: 16092689
   timestamp: 1759964958634
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-13.4.0-hb485fb8_16.conda
+  sha256: c5a9b5495da2fafc526709bb86ce48b48ab0226dc0b865a6663a91e8994a5c89
+  md5: b93a214e350f98ca8a189bd9e14c8d95
+  depends:
+  - gcc_impl_linux-64 >=13.4.0
+  - libgcc >=13.4.0
+  - libgfortran5 >=13.4.0
+  - libstdcxx >=13.4.0
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 17053892
+  timestamp: 1765256178362
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-13.4.0-h4647a72_12.conda
   sha256: c1586c7dedad2f6d9ebd2da5a2c1f0c21aedbbd15fd47920ac327da8c770a300
   md5: fa11450b20312b5ad5ae60a1a9aaa55a
@@ -3484,6 +3961,19 @@ packages:
   purls: []
   size: 26685
   timestamp: 1759866821148
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-13.4.0-hcdeb356_16.conda
+  sha256: cfc05b5ed1de06bce370fdb32704835249a04da0836afdb94009008dea20339c
+  md5: c18f6b85e24b35c60d76f97fbf3e88b9
+  depends:
+  - gfortran_impl_linux-64 13.4.0.*
+  - gcc_linux-64 ==13.4.0 h0a5b801_16
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 27100
+  timestamp: 1765841858820
 - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
   name: gitdb
   version: 4.0.12
@@ -3545,30 +4035,30 @@ packages:
   sha256: 7916034efa867927892635733a3b6af8cd95ceb10566fd7f1e0d2763c2ee8b12
   requires_dist:
   - glfw-preview ; extra == 'preview'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.0-he175458_0.conda
-  sha256: 3846e03ce529d9d8655651ad765b92cbb7baef4f2345e4df28b2af6133343a58
-  md5: 1891353ef1a104cff6d51de55a60c9c0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.2-hbcf1ec1_0.conda
+  sha256: cbf7d14a84eacdfc1ac250a351d6f4ae77b8e75af5f92beef247918b26e9d47a
+  md5: bece9d9271a32ac5b6db28f96ff1dbcc
   depends:
-  - glib-tools 2.86.0 hf516916_0
-  - libffi >=3.4.6,<3.5.0a0
-  - libglib 2.86.0 h1fed272_0
+  - glib-tools 2.86.2 hf516916_0
+  - libffi >=3.5.2,<3.6.0a0
+  - libglib 2.86.2 h32235b2_0
   - packaging
   - python *
   license: LGPL-2.1-or-later
   purls: []
-  size: 611178
-  timestamp: 1757403380893
-- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.0-hf516916_0.conda
-  sha256: b77316bd5c8680bde4e5a7ab7013c8f0f10c1702cc6c3b0fd0fac3923a31fec3
-  md5: 1a8e49615381c381659de1bc6a3bf9ec
+  size: 612485
+  timestamp: 1763672446934
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.2-hf516916_0.conda
+  sha256: 5517dae367d069de42c16d48f4b7e269acdedc11d43a5d4ec8d077d43ae00f45
+  md5: 14ad79cb7501b6a408485b04834a734c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libglib 2.86.0 h1fed272_0
+  - libglib 2.86.2 h32235b2_0
   license: LGPL-2.1-or-later
   purls: []
-  size: 117284
-  timestamp: 1757403341964
+  size: 116278
+  timestamp: 1763672395899
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.17.0-ha770c72_1.conda
   sha256: 80ca13dc518962fcd86856586cb5fb612fe69914234eab322f9dee25f628090f
   md5: 33e7a8280999b958df24a95f0cb86b1a
@@ -3753,6 +4243,19 @@ packages:
   purls: []
   size: 30507
   timestamp: 1759965051922
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.4.0-h6a38259_16.conda
+  sha256: 090ff75b90e36ee3bca01028ae155d6c83b6da238268ff311539b05d6613d3dc
+  md5: c4af92ec1b2d24a02015c3917bf6655d
+  depends:
+  - gcc_impl_linux-64 13.4.0 hf787b08_16
+  - libstdcxx-devel_linux-64 13.4.0 h6963c3b_116
+  - sysroot_linux-64
+  - tzdata
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 13527490
+  timestamp: 1765256231456
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.4.0-haf17267_7.conda
   sha256: fca070814b1e51f4b646462208d7a735597e3a897094580cb53dce187e585b58
   md5: db49b83aa376e75ce2d7f5359a8d4e77
@@ -3766,6 +4269,19 @@ packages:
   purls: []
   size: 13518456
   timestamp: 1759964992050
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.4.0-h1d934a6_16.conda
+  sha256: 0e5156bd46f9dd9ede6868fc4f2bdef504ddd0c26d7039b69a6daf2df93d0fa6
+  md5: b71251de6c162581b615f0c423383bf6
+  depends:
+  - gxx_impl_linux-64 13.4.0.*
+  - gcc_linux-64 ==13.4.0 h0a5b801_16
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 27454
+  timestamp: 1765841858823
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.4.0-hb5b9838_12.conda
   sha256: decdbc63a14d3ce77a2d23df734caeb8bca07a383f786355f3be938ce4df397c
   md5: 9706de225e50a9b2a8c583bac92f6c04
@@ -3841,54 +4357,117 @@ packages:
   - dill>=0.3.7 ; extra == 'testing'
   - array-api-extra>=0.7.0 ; extra == 'testing'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-cmake3-3.5.5-h05f81b2_0.conda
-  sha256: b654d0102a8b8242836a5863c0157945b5c549d505383f4f8b724926a55f68aa
-  md5: fda2ad837ffe2ed7f73ddfab260d82e3
+- pypi: https://files.pythonhosted.org/packages/56/d3/ea5f088e3638dbab12e5c20d6559d5b3bdaeaa1f2af74e526e6815836285/gymnasium-1.2.3-py3-none-any.whl
+  name: gymnasium
+  version: 1.2.3
+  sha256: e6314bba8f549c7fdcc8677f7cd786b64908af6e79b57ddaa5ce1825bffb5373
+  requires_dist:
+  - numpy>=1.21.0
+  - cloudpickle>=1.2.0
+  - typing-extensions>=4.3.0
+  - farama-notifications>=0.0.1
+  - ale-py>=0.9 ; extra == 'atari'
+  - box2d==2.3.10 ; extra == 'box2d'
+  - pygame>=2.1.3 ; extra == 'box2d'
+  - swig==4.* ; extra == 'box2d'
+  - pygame>=2.1.3 ; extra == 'classic-control'
+  - pygame>=2.1.3 ; extra == 'classic-control'
+  - mujoco>=2.1.5 ; extra == 'mujoco'
+  - imageio>=2.14.1 ; extra == 'mujoco'
+  - packaging>=23.0 ; extra == 'mujoco'
+  - pygame>=2.1.3 ; extra == 'toy-text'
+  - pygame>=2.1.3 ; extra == 'toy-text'
+  - jax>=0.4.16 ; extra == 'jax'
+  - jaxlib>=0.4.16 ; extra == 'jax'
+  - flax>=0.5.0 ; extra == 'jax'
+  - array-api-compat>=1.11.0 ; extra == 'jax'
+  - numpy>=2.1 ; extra == 'jax'
+  - torch>=1.13.0 ; extra == 'torch'
+  - array-api-compat>=1.11.0 ; extra == 'torch'
+  - numpy>=2.1 ; extra == 'torch'
+  - array-api-compat>=1.11.0 ; extra == 'array-api'
+  - numpy>=2.1 ; extra == 'array-api'
+  - packaging>=23.0 ; extra == 'array-api'
+  - moviepy>=1.0.0 ; extra == 'other'
+  - matplotlib>=3.0 ; extra == 'other'
+  - opencv-python>=3.0 ; extra == 'other'
+  - seaborn>=0.13 ; extra == 'other'
+  - ale-py>=0.9 ; extra == 'all'
+  - box2d==2.3.10 ; extra == 'all'
+  - pygame>=2.1.3 ; extra == 'all'
+  - swig==4.* ; extra == 'all'
+  - pygame>=2.1.3 ; extra == 'all'
+  - mujoco>=2.1.5 ; extra == 'all'
+  - imageio>=2.14.1 ; extra == 'all'
+  - packaging>=23.0 ; extra == 'all'
+  - pygame>=2.1.3 ; extra == 'all'
+  - jax>=0.4.16 ; extra == 'all'
+  - jaxlib>=0.4.16 ; extra == 'all'
+  - flax>=0.5.0 ; extra == 'all'
+  - array-api-compat>=1.11.0 ; extra == 'all'
+  - numpy>=2.1 ; extra == 'all'
+  - torch>=1.13.0 ; extra == 'all'
+  - array-api-compat>=1.11.0 ; extra == 'all'
+  - numpy>=2.1 ; extra == 'all'
+  - array-api-compat>=1.11.0 ; extra == 'all'
+  - numpy>=2.1 ; extra == 'all'
+  - opencv-python>=3.0 ; extra == 'all'
+  - matplotlib>=3.0 ; extra == 'all'
+  - moviepy>=1.0.0 ; extra == 'all'
+  - pytest>=7.1.3 ; extra == 'testing'
+  - scipy>=1.7.3 ; extra == 'testing'
+  - dill>=0.3.7 ; extra == 'testing'
+  - array-api-extra>=0.7.0 ; extra == 'testing'
+  requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-cmake4-4.2.0-h83e9d05_1.conda
+  sha256: 05d289bdcbe5ea05964b34e8e19ac1b7ad950fa66bb4add04d4015e257c74088
+  md5: 591dd28313202ca8a42a36a953c0752b
   depends:
-  - libgz-cmake3 ==3.5.5 h54a6638_0
+  - libgz-cmake4 ==4.2.0 h54a6638_1
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 7430
-  timestamp: 1759138411890
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math7-7.5.2-h5bbc156_2.conda
-  sha256: 3c0eeb73fb3a5d01d6e2f10778a0948286b19cf9500ae24a67547262c521ff35
-  md5: 058fd7a11695871d6c26080a1b2e96a1
+  size: 7428
+  timestamp: 1759138566319
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math8-8.2.0-h91c16d2_2.conda
+  sha256: f7b8b7992433e8841f871e0877497d01cde635818f993a70aa9ae6eaefb255c4
+  md5: 2d150314957d6006b81c7e3b8683eb2e
   depends:
-  - libgz-math7 ==7.5.2 h54a6638_2
-  - gz-math7-python >=7.5.2,<7.5.3.0a0
+  - libgz-math8 ==8.2.0 h54a6638_2
+  - gz-math8-python >=8.2.0,<8.2.1.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 8251
-  timestamp: 1759147748392
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math7-python-7.5.2-py312h89d136e_2.conda
-  sha256: a20c5d236a70831cfa21fda695c4482fcbbe64ea4c2db32d59c66ee7df05fe05
-  md5: f49be6a36d1cd45f9fcc96d2446c41c4
+  size: 8198
+  timestamp: 1759147796036
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math8-python-8.2.0-py312hc0cb2ee_2.conda
+  sha256: caa552f19bfea9400322276375a8570b26dedbd61360a4ecf898212194cded7b
+  md5: 75c9b44db1148bf7d96b79ba89e94915
   depends:
-  - libgz-math7 ==7.5.2 h54a6638_2
+  - libgz-math8 ==8.2.0 h54a6638_2
   - python
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - libgz-math7 >=7.5.2,<8.0a0
-  - pybind11-abi ==11
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - pybind11-abi ==11
+  - libgz-math8 >=8.2.0,<9.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 1029585
-  timestamp: 1759147748392
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils2-2.2.1-hd5bf738_1.conda
-  sha256: edac8bdb4b2e359814f06ed8972474ef282c5a2afbfd2d580e9fdf3fa8cf9fec
-  md5: 7464d6129d4a0bac5a4950835c747601
+  size: 1046498
+  timestamp: 1759147796036
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils3-3.1.1-h22fa418_2.conda
+  sha256: 33089a4281393c6ab1199bac919a2ae9abd4ad7184ad07eca92d8a6109d0a430
+  md5: 0efde9d42e9ae05ee1f5430d4a8eb359
   depends:
-  - libgz-utils2 ==2.2.1 h54a6638_1
+  - libgz-utils3 ==3.1.1 h38f3fdc_2
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 8049
-  timestamp: 1760392404832
+  size: 8167
+  timestamp: 1759142868065
 - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
   md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -3903,9 +4482,9 @@ packages:
   - pkg:pypi/h2?source=compressed-mapping
   size: 95967
   timestamp: 1756364871835
-- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.1.0-h15599e2_0.conda
-  sha256: df2a964f5b7dd652b59da018f1d2d9ae402b815c4e5d849384344df358d2a565
-  md5: 7704b1edaa8316b8792424f254c1f586
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
+  sha256: 6bd8b22beb7d40562b2889dc68232c589ff0d11a5ad3addd41a8570d11f039d9
+  md5: b8690f53007e9b5ee2c2178dd4ac778c
   depends:
   - __glibc >=2.17,<3.0.a0
   - cairo >=1.18.4,<2.0a0
@@ -3915,14 +4494,14 @@ packages:
   - libfreetype >=2.14.1
   - libfreetype6 >=2.14.1
   - libgcc >=14
-  - libglib >=2.86.0,<3.0a0
+  - libglib >=2.86.1,<3.0a0
   - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 2058414
-  timestamp: 1759365674184
+  size: 2411408
+  timestamp: 1762372726141
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
   sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
   md5: bd77f8da987968ec3927990495dc22e4
@@ -3936,24 +4515,24 @@ packages:
   purls: []
   size: 756742
   timestamp: 1695661547874
-- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h6e4c0c1_103.conda
-  sha256: 4f173af9e2299de7eee1af3d79e851bca28ee71e7426b377e841648b51d48614
-  md5: c74d83614aec66227ae5199d98852aaf
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h1b119a7_104.conda
+  sha256: 454e9724b322cee277abd7acf4f8d688e9c4ded006b6d5bc9fcc2a1ff907d27a
+  md5: 0857f4d157820dcd5625f61fdfefb780
   depends:
   - __glibc >=2.17,<3.0.a0
   - libaec >=1.1.4,<2.0a0
-  - libcurl >=8.14.1,<9.0a0
+  - libcurl >=8.17.0,<9.0a0
   - libgcc >=14
   - libgfortran
   - libgfortran5 >=14.3.0
   - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.1,<4.0a0
+  - openssl >=3.5.4,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3710057
-  timestamp: 1753357500665
+  size: 3720961
+  timestamp: 1764771748126
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
   sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
   md5: bbf6f174dcd3254e19a2f5d2295ce808
@@ -3973,6 +4552,11 @@ packages:
   - pkg:pypi/hpack?source=hash-mapping
   size: 30731
   timestamp: 1737618390337
+- pypi: https://files.pythonhosted.org/packages/96/36/5bddefea3d7adf22a64f9aa9701492f8a9fe6948223f5cf2602c22ec9be7/hsluv-5.0.4-py2.py3-none-any.whl
+  name: hsluv
+  version: 5.0.4
+  sha256: 0138bd10038e2ee1b13eecae9a7d49d4ec8c320b1d7eb4f860832c792e3e4567
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
   sha256: fa2071da7fab758c669e78227e6094f6b3608228740808a6de5d6bce83d9e52d
   md5: 7fe569c10905402ed47024fc481bb371
@@ -4025,7 +4609,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/idna?source=compressed-mapping
+  - pkg:pypi/idna?source=hash-mapping
   size: 50721
   timestamp: 1760286526795
 - pypi: https://files.pythonhosted.org/packages/cb/bd/b394387b598ed84d8d0fa90611a90bee0adc2021820ad5729f7ced74a8e2/imageio-2.37.0-py3-none-any.whl
@@ -4092,19 +4676,81 @@ packages:
   - fsspec[github] ; extra == 'test'
   - tifffile ; extra == 'tifffile'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
-  sha256: 4d8d07a4d5079d198168b44556fb86d094e6a716e8979b25a9f6c9c610e9fe56
-  md5: 37f5e1ab0db3691929f37dee78335d1b
+- pypi: https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl
+  name: imageio
+  version: 2.37.2
+  sha256: ad9adfb20335d718c03de457358ed69f141021a333c40a53e57273d8a5bd0b9b
+  requires_dist:
+  - numpy
+  - pillow>=8.3.2
+  - imageio-ffmpeg ; extra == 'ffmpeg'
+  - psutil ; extra == 'ffmpeg'
+  - fsspec[http] ; extra == 'freeimage'
+  - pillow-heif ; extra == 'pillow-heif'
+  - tifffile ; extra == 'tifffile'
+  - av ; extra == 'pyav'
+  - astropy ; extra == 'fits'
+  - rawpy ; extra == 'rawpy'
+  - numpy>2 ; extra == 'rawpy'
+  - gdal ; extra == 'gdal'
+  - itk ; extra == 'itk'
+  - black ; extra == 'linting'
+  - flake8 ; extra == 'linting'
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - fsspec[github] ; extra == 'test'
+  - sphinx<6 ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - fsspec[github] ; extra == 'dev'
+  - black ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - av ; extra == 'all-plugins'
+  - astropy ; extra == 'all-plugins'
+  - fsspec[http] ; extra == 'all-plugins'
+  - imageio-ffmpeg ; extra == 'all-plugins'
+  - numpy>2 ; extra == 'all-plugins'
+  - pillow-heif ; extra == 'all-plugins'
+  - psutil ; extra == 'all-plugins'
+  - rawpy ; extra == 'all-plugins'
+  - tifffile ; extra == 'all-plugins'
+  - fsspec[http] ; extra == 'all-plugins-pypy'
+  - imageio-ffmpeg ; extra == 'all-plugins-pypy'
+  - pillow-heif ; extra == 'all-plugins-pypy'
+  - psutil ; extra == 'all-plugins-pypy'
+  - tifffile ; extra == 'all-plugins-pypy'
+  - astropy ; extra == 'full'
+  - av ; extra == 'full'
+  - black ; extra == 'full'
+  - flake8 ; extra == 'full'
+  - fsspec[github,http] ; extra == 'full'
+  - imageio-ffmpeg ; extra == 'full'
+  - numpydoc ; extra == 'full'
+  - numpy>2 ; extra == 'full'
+  - pillow-heif ; extra == 'full'
+  - psutil ; extra == 'full'
+  - pydata-sphinx-theme ; extra == 'full'
+  - pytest ; extra == 'full'
+  - pytest-cov ; extra == 'full'
+  - rawpy ; extra == 'full'
+  - sphinx<6 ; extra == 'full'
+  - tifffile ; extra == 'full'
+  requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.2.1-hde8ca8f_0.conda
+  sha256: f4b11c1ba8abb6bc98f1b00fea97fadb3bb07c1c289bd4c810244dfdb019cdc4
+  md5: de2d48f334e255d98c445d7567bccde0
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
+  - libgcc >=14
+  - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 159630
-  timestamp: 1725971591485
+  size: 161004
+  timestamp: 1755292803595
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
   sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
   md5: 63ccfdc3a3ce25b027b8767eb722fca8
@@ -4164,6 +4810,32 @@ packages:
   - pkg:pypi/iniconfig?source=compressed-mapping
   size: 13387
   timestamp: 1760831448842
+- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.9.0-hb700be7_0.conda
+  sha256: edad668db79c6c4899d46e1cd4a331f5d008f9ed8f7d2e39e1dfe1a2d81acec0
+  md5: 26311c5112b5c713f472bdfbb5ec5aa3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1009795
+  timestamp: 1765886047465
+- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
+  sha256: 286679d4c175e8db2d047be766d1629f1ea5828bff9fe7e6aac2e6f0fad2b427
+  md5: 7ae2034a0e2e24eb07468f1a50cdf0bb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - intel-gmmlib >=22.8.1,<23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libva >=2.22.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 8424610
+  timestamp: 1757591682198
 - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.8-he3c4edf_0.conda
   sha256: 0e919ec86d980901d8cbb665e91f5e9bddb5ff662178f25aed6d63f999fd9afc
   md5: a04073db11c2c86c555fb088acc8f8c1
@@ -4208,10 +4880,44 @@ packages:
   - kubernetes ; extra == 'k8s'
   - xprof ; extra == 'xprof'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/f9/e7/19b8cfc8963b2e10a01a4db7bb27ec5fa39ecd024bc62f8e2d1de5625a9d/jax-0.8.1-py3-none-any.whl
+  name: jax
+  version: 0.8.1
+  sha256: 4cbdc5548f3095cdd69d38e4337950b2fc1f250a740a0234d190e4a319077564
+  requires_dist:
+  - jaxlib<=0.8.1,>=0.8.1
+  - ml-dtypes>=0.5.0
+  - numpy>=2.0
+  - opt-einsum
+  - scipy>=1.13
+  - jaxlib==0.8.1 ; extra == 'minimum-jaxlib'
+  - jaxlib==0.8.0 ; extra == 'ci'
+  - jaxlib<=0.8.1,>=0.8.1 ; extra == 'tpu'
+  - libtpu==0.0.30.* ; extra == 'tpu'
+  - requests ; extra == 'tpu'
+  - jaxlib<=0.8.1,>=0.8.1 ; extra == 'cuda'
+  - jax-cuda12-plugin[with-cuda]<=0.8.1,>=0.8.1 ; extra == 'cuda'
+  - jaxlib<=0.8.1,>=0.8.1 ; extra == 'cuda12'
+  - jax-cuda12-plugin[with-cuda]<=0.8.1,>=0.8.1 ; extra == 'cuda12'
+  - jaxlib<=0.8.1,>=0.8.1 ; extra == 'cuda13'
+  - jax-cuda13-plugin[with-cuda]<=0.8.1,>=0.8.1 ; extra == 'cuda13'
+  - jaxlib<=0.8.1,>=0.8.1 ; extra == 'cuda12-local'
+  - jax-cuda12-plugin<=0.8.1,>=0.8.1 ; extra == 'cuda12-local'
+  - jaxlib<=0.8.1,>=0.8.1 ; extra == 'cuda13-local'
+  - jax-cuda13-plugin<=0.8.1,>=0.8.1 ; extra == 'cuda13-local'
+  - jaxlib<=0.8.1,>=0.8.1 ; extra == 'rocm'
+  - jax-rocm60-plugin<=0.8.1,>=0.8.1 ; extra == 'rocm'
+  - kubernetes ; extra == 'k8s'
+  - xprof ; extra == 'xprof'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/1c/0b/e397b4cb3c6c6337755bc47445e4321e4772e28497e0a1cfcfcd69d0b774/jax_cuda12_pjrt-0.8.0-py3-none-manylinux_2_27_x86_64.whl
   name: jax-cuda12-pjrt
   version: 0.8.0
   sha256: 9e99c3e546f6be00ffc6a4edd2cf5b76d4c59aa34a8d8396d8239ab8fd8ebfd3
+- pypi: https://files.pythonhosted.org/packages/c1/85/c59752caca94e72861f7a6a42f37485df706e60ec4bb27090081899001d4/jax_cuda12_pjrt-0.8.1-py3-none-manylinux_2_27_x86_64.whl
+  name: jax-cuda12-pjrt
+  version: 0.8.1
+  sha256: 452b70ee10cb9ac5d7dfca55ffbcdb89b6c8bc6ba70a45af7c490d1dcea98eb7
 - pypi: https://files.pythonhosted.org/packages/57/ee/f11cc48cf3a3b8131a7670df5f0d8b8a99e2359efea99013ff804040981d/jax_cuda12_plugin-0.8.0-cp313-cp313-manylinux_2_27_x86_64.whl
   name: jax-cuda12-plugin
   version: 0.8.0
@@ -4231,10 +4937,38 @@ packages:
   - nvidia-cuda-nvrtc-cu12>=12.1.55 ; sys_platform == 'linux' and extra == 'with-cuda'
   - nvidia-nvshmem-cu12>=3.2.5 ; sys_platform == 'linux' and extra == 'with-cuda'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/20/60/1dde369dd70b349ff388cd699d69c7d49ff3494af30b5b774037cc4d45e6/jax_cuda12_plugin-0.8.1-cp312-cp312-manylinux_2_27_x86_64.whl
+  name: jax-cuda12-plugin
+  version: 0.8.1
+  sha256: b60bf0bbda24cec6fa71170bd69b613359f01a376d8e09fe34bf67ecc9a3164f
+  requires_dist:
+  - jax-cuda12-pjrt==0.8.1
+  - nvidia-cublas-cu12>=12.1.3.1 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-cuda-cupti-cu12>=12.1.105 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-cuda-nvcc-cu12>=12.6.85 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-cuda-runtime-cu12>=12.1.105 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-cudnn-cu12>=9.8,<10.0 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-cufft-cu12>=11.0.2.54 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-cusolver-cu12>=11.4.5.107 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-cusparse-cu12>=12.1.0.106 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-nccl-cu12>=2.18.1 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-nvjitlink-cu12>=12.1.105 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-cuda-nvrtc-cu12>=12.1.55 ; sys_platform == 'linux' and extra == 'with-cuda'
+  - nvidia-nvshmem-cu12>=3.2.5 ; sys_platform == 'linux' and extra == 'with-cuda'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/8f/f0/cde1d84c737bdb75712f70d69561120ce91f3f294acf2fba573c0de740b6/jaxlib-0.8.0-cp313-cp313-manylinux_2_27_x86_64.whl
   name: jaxlib
   version: 0.8.0
   sha256: 66c6f576f54a63ed052f5c469bef4db723f5f050b839ec0c429573011341bd58
+  requires_dist:
+  - scipy>=1.13
+  - numpy>=2.0
+  - ml-dtypes>=0.5.0
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/eb/4b/3c7e373d81219ee7493c1581c85a926c413ddeb3794cff87a37023a337e4/jaxlib-0.8.1-cp312-cp312-manylinux_2_27_x86_64.whl
+  name: jaxlib
+  version: 0.8.1
+  sha256: af4924189fc53b69237715b56ebcbfc71bb91ca16184143dcef0d430c8173de6
   requires_dist:
   - scipy>=1.13
   - numpy>=2.0
@@ -4305,6 +5039,16 @@ packages:
   purls: []
   size: 1272697
   timestamp: 1752669126073
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+  sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
+  md5: 86d9cba083cd041bfbf242a01a7a1999
+  constrains:
+  - sysroot_linux-64 ==2.28
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 1278712
+  timestamp: 1765578681495
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
   sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
   md5: b38117a3c920364aff79f870c984b4a3
@@ -4315,21 +5059,21 @@ packages:
   purls: []
   size: 134088
   timestamp: 1754905959823
-- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.9-py312h0a2e395_1.conda
-  sha256: 42f856c17ea4b9bce5ac5e91d6e58e15d835a3cac32d71bc592dd5031f9c0fb8
-  md5: cec5c1ea565944a94f82cdd6fba7cc76
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.9-py312h0a2e395_2.conda
+  sha256: 170d76b7ac7197012bb048e1021482a7b2455f3592a5e8d97c96f285ebad064b
+  md5: 3a3004fddd39e3bb1a631b08d7045156
   depends:
   - python
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/kiwisolver?source=hash-mapping
-  size: 77266
-  timestamp: 1756467527669
+  size: 77682
+  timestamp: 1762488738724
 - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
   md5: 3f43953b7d3fb3aaa1d0d0723d91e368
@@ -4391,6 +5135,19 @@ packages:
   purls: []
   size: 747158
   timestamp: 1758810907507
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
+  sha256: 9e191baf2426a19507f1d0a17be0fdb7aa155cdf0f61d5a09c808e0a69464312
+  md5: a6abd2796fc332536735f68ba23f7901
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.45
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 725545
+  timestamp: 1764007826689
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
   sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
   md5: 9344155d33912347b37f0ae6c410a835
@@ -4403,9 +5160,9 @@ packages:
   purls: []
   size: 264243
   timestamp: 1745264221534
-- conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.24.3-hb700be7_0.conda
-  sha256: 7209dbe2a8fed51a60c593f1592eba71ea1a8b11b109ddf6bc46f9ba97c4ad6b
-  md5: 753ddaa1303e04cfef8e1e5f9e9b7a2a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.26.2-hb700be7_0.conda
+  sha256: 1a756a2b8d58d2789223bc63971ffef714a8d5fadeb565dd82239c2395fbc858
+  md5: c0fd9999cacbe6c0156459080635b2d6
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -4413,23 +5170,23 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 610313
-  timestamp: 1758698525395
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250127.1-cxx17_hbbce691_0.conda
-  sha256: 65d5ca837c3ee67b9d769125c21dc857194d7f6181bb0e7bd98ae58597b457d0
-  md5: 00290e549c5c8a32cc271020acc9ec6b
+  size: 667315
+  timestamp: 1765910088541
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
+  sha256: dcd1429a1782864c452057a6c5bc1860f2b637dc20a2b7e6eacd57395bbceff8
+  md5: 83b160d4da3e1e847bf044997621ed63
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
   constrains:
-  - abseil-cpp =20250127.1
-  - libabseil-static =20250127.1=cxx17*
+  - libabseil-static =20250512.1=cxx17*
+  - abseil-cpp =20250512.1
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1325007
-  timestamp: 1742369558286
+  size: 1310612
+  timestamp: 1750194198254
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250814.1-cxx17_hee66210_0.conda
   sha256: 99e2574508f068960c847e112d736c4e12fb2d07483cf984ab9a27e3590a9d50
   md5: a5a7729bb44d885d615560dd05e5d487
@@ -4490,37 +5247,57 @@ packages:
   purls: []
   size: 34734
   timestamp: 1753342921605
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-hba53ac1_1.conda
-  sha256: aaf38bcb9b78963f4eb58d882a9a6a350f500cfa162bd8a80f7f215d3831afa2
-  md5: f5e75fe79d446bf4975b41d375314605
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
+  sha256: 035eb8b54e03e72e42ef707420f9979c7427776ea99e0f1e3c969f92eb573f19
+  md5: d3be7b2870bf7aff45b12ea53165babd
   depends:
   - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - harfbuzz >=10.1.0
-  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
   - fribidi >=1.0.10,<2.0a0
+  - libiconv >=1.18,<2.0a0
   - fontconfig >=2.15.0,<3.0a0
   - fonts-conda-ecosystem
-  - libiconv >=1.17,<2.0a0
+  - harfbuzz >=11.0.1
   license: ISC
   purls: []
-  size: 153294
-  timestamp: 1733786555242
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h766b0b6_0.conda
-  sha256: 170b51a3751c2f842ff9e11d22423494ef7254b448ef2b24751256ef18aa1302
-  md5: f17f2d0e5c9ad6b958547fd67b155771
+  size: 152179
+  timestamp: 1749328931930
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h6395336_2.conda
+  sha256: e3a44c0eda23aa15c9a8dfa8c82ecf5c8b073e68a16c29edd0e409e687056d30
+  md5: c09c4ac973f7992ba0c6bb1aafd77bd4
   depends:
   - __glibc >=2.17,<3.0.a0
   - aom >=3.9.1,<3.10.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
-  - libgcc >=13
+  - libgcc >=14
   - rav1e >=0.7.1,<0.8.0a0
-  - svt-av1 >=3.0.2,<3.0.3.0a0
+  - svt-av1 >=3.1.2,<3.1.3.0a0
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 140052
-  timestamp: 1746836263991
+  size: 139399
+  timestamp: 1756124751131
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
+  build_number: 5
+  sha256: 18c72545080b86739352482ba14ba2c4815e19e26a7417ca21a95b76ec8da24c
+  md5: c160954f7418d7b6e87eaf05a8913fa9
+  depends:
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
+  constrains:
+  - mkl <2026
+  - liblapack  3.11.0   5*_openblas
+  - libcblas   3.11.0   5*_openblas
+  - blas 2.305   openblas
+  - liblapacke 3.11.0   5*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 18213
+  timestamp: 1765818813880
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-37_h4a7cf45_openblas.conda
   build_number: 37
   sha256: b8872684dc3a68273de2afda2a4a1c79ffa3aab45fcfc4f9b3621bd1cc1adbcc
@@ -4595,53 +5372,68 @@ packages:
   purls: []
   size: 124701
   timestamp: 1756549734965
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
-  sha256: 2338a92d1de71f10c8cf70f7bb9775b0144a306d75c4812276749f54925612b6
-  md5: 1d29d2e33fe59954af82ef54a8af3fe1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+  sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
+  md5: 72c8fd1af66bd67bf580645b426513ed
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 69333
-  timestamp: 1756599354727
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
-  sha256: fcec0d26f67741b122f0d5eff32f0393d7ebd3ee6bb866ae2f17f3425a850936
-  md5: 5cb5a1c9a94a78f5b23684bcb845338d
+  size: 79965
+  timestamp: 1764017188531
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+  sha256: 12fff21d38f98bc446d82baa890e01fd82e3b750378fedc720ff93522ffb752b
+  md5: 366b40a69f0ad6072561c1d09301c886
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libbrotlicommon 1.1.0 hb03c661_4
+  - libbrotlicommon 1.2.0 hb03c661_1
   - libgcc >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 33406
-  timestamp: 1756599364386
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
-  sha256: d42c7f0afce21d5279a0d54ee9e64a2279d35a07a90e0c9545caae57d6d7dc57
-  md5: 2e55011fa483edb8bfe3fd92e860cd79
+  size: 34632
+  timestamp: 1764017199083
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+  sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
+  md5: 4ffbb341c8b616aa2494b6afb26a0c5f
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libbrotlicommon 1.1.0 hb03c661_4
+  - libbrotlicommon 1.2.0 hb03c661_1
   - libgcc >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 289680
-  timestamp: 1756599375485
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.76-h0b2e76d_0.conda
-  sha256: a946b61be1af15ff08c7722e9bac0fab446d8b9896c9f0f35657dfcf887fda8a
-  md5: 0f7f0c878c8dceb3b9ec67f5c06d6057
+  size: 298378
+  timestamp: 1764017210931
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
+  sha256: 9517cce5193144af0fcbf19b7bd67db0a329c2cc2618f28ffecaa921a1cbe9d3
+  md5: 09c264d40c67b82b49a3f3b89037bd2e
   depends:
   - __glibc >=2.17,<3.0.a0
-  - attr >=2.5.1,<2.6.0a0
-  - libgcc >=13
+  - attr >=2.5.2,<2.6.0a0
+  - libgcc >=14
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 121852
-  timestamp: 1744577167992
+  size: 121429
+  timestamp: 1762349484074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-5_h0358290_openblas.conda
+  build_number: 5
+  sha256: 0cbdcc67901e02dc17f1d19e1f9170610bd828100dc207de4d5b6b8ad1ae7ad8
+  md5: 6636a2b6f1a87572df2970d3ebc87cc0
+  depends:
+  - libblas 3.11.0 5_h4a7cf45_openblas
+  constrains:
+  - liblapacke 3.11.0   5*_openblas
+  - blas 2.305   openblas
+  - liblapack  3.11.0   5*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 18194
+  timestamp: 1765818837135
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-37_h0358290_openblas.conda
   build_number: 37
   sha256: 8e5a6014424cc11389ebf3febedad937aa4a00e48464831ae4dec69f3c46c4ab
@@ -4657,9 +5449,9 @@ packages:
   purls: []
   size: 17474
   timestamp: 1760212737633
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_4.conda
-  sha256: be2cd2768c932ade04bc4868b0f564ce6681bc861f28027419dc6651525afeb1
-  md5: 2a7f3bca5b60a34be5a35cbc70711bce
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_5.conda
+  sha256: b9f0e167cdf5cbe076231788fcb3affe25914534d84ab249258161b693c4cfd2
+  md5: 33acc83688f092f96ea2ead08e3b4dcd
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -4668,8 +5460,8 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 21250739
-  timestamp: 1759440009094
+  size: 21305254
+  timestamp: 1764393708507
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.0-default_h99862b1_1.conda
   sha256: efe9f1363a49668d10aacdb8be650433fab659f05ed6cc2b9da00e3eb7eaf602
   md5: d599b346638b9216c1e8f9146713df05
@@ -4727,6 +5519,23 @@ packages:
   purls: []
   size: 459851
   timestamp: 1760977209182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.17.0-h4e3cde8_1.conda
+  sha256: 2d7be2fe0f58a0945692abee7bb909f8b19284b518d958747e5ff51d0655c303
+  md5: 117499f93e892ea1e57fdca16c2e8351
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=14
+  - libnghttp2 >=1.67.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  size: 459417
+  timestamp: 1765379027010
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
   sha256: 8420748ea1cc5f18ecc5068b4f24c7a023cc9b20971c99c824ba10641fb95ddf
   md5: 64f0c503da58ec25ebd359e4d990afa8
@@ -4819,6 +5628,19 @@ packages:
   purls: []
   size: 74811
   timestamp: 1752719572741
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
+  sha256: 1e1b08f6211629cbc2efe7a5bca5953f8f6b3cae0eeb04ca4dacee1bd4e2db2f
+  md5: 8b09ae86839581147ef2e5c5e229d164
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.7.3.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 76643
+  timestamp: 1763549731408
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
   sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
   md5: ede4673863426c0883c0063d853bbd85
@@ -4830,20 +5652,31 @@ packages:
   purls: []
   size: 57433
   timestamp: 1743434498161
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
-  sha256: 65908b75fa7003167b8a8f0001e11e58ed5b1ef5e98b96ab2ba66d7c1b822c7d
-  md5: ee48bf17cc83a00f59ca1494d5646869
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
+  sha256: 25cbdfa65580cfab1b8d15ee90b4c9f1e0d72128f1661449c9a999d341377d54
+  md5: 35f29eec58405aaf55e01cb470d8c26a
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - libogg 1.3.*
-  - libogg >=1.3.4,<1.4.0a0
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 57821
+  timestamp: 1760295480630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+  sha256: e755e234236bdda3d265ae82e5b0581d259a9279e3e5b31d745dc43251ad64fb
+  md5: 47595b9d53054907a00d95e4d47af1d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libstdcxx >=14
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 394383
-  timestamp: 1687765514062
+  size: 424563
+  timestamp: 1764526740626
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
   sha256: 4641d37faeb97cf8a121efafd6afd040904d4bca8c46798122f417c31d5dfbec
   md5: f4084e4e6577797150f9b04a4560ceb0
@@ -4881,6 +5714,20 @@ packages:
   purls: []
   size: 822552
   timestamp: 1759968052178
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
+  sha256: 6eed58051c2e12b804d53ceff5994a350c61baf117ec83f5f10c953a3f311451
+  md5: 6d0363467e6ed84f11435eb309f2ff06
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_16
+  - libgomp 15.2.0 he0feb66_16
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 1042798
+  timestamp: 1765256792743
 - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.4.0-hba01cd7_107.conda
   sha256: a57b8999a05fcb57d6fd20fb6a7883d6ebb428ca20b9d05c572aba3d2dd0793f
   md5: f4269cc08f10c433c83e4ce4f2346051
@@ -4891,6 +5738,26 @@ packages:
   purls: []
   size: 2576281
   timestamp: 1759964641552
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.4.0-hd1d28cc_116.conda
+  sha256: 24554c1903b33db7604bbf53e889ade0c78e41cc7e1368f01f0af7b58e874f7c
+  md5: 41c21b992c82005ae8de661b57bd8c4c
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 2843362
+  timestamp: 1765255661156
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
+  sha256: 5f07f9317f596a201cc6e095e5fc92621afca64829785e483738d935f8cab361
+  md5: 5a68259fac2da8f2ee6f7bfe49c9eb8b
+  depends:
+  - libgcc 15.2.0 he0feb66_16
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 27256
+  timestamp: 1765256804124
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
   sha256: 2045066dd8e6e58aaf5ae2b722fb6dfdbb57c862b5f34ac7bfb58c40ef39b6ad
   md5: 280ea6eee9e2ddefde25ff799c4f0363
@@ -4901,17 +5768,6 @@ packages:
   purls: []
   size: 29313
   timestamp: 1759968065504
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
-  sha256: dc9c7d7a6c0e6639deee6fde2efdc7e119e7739a6b229fa5f9049a449bae6109
-  md5: 8504a291085c9fb809b66cabd5834307
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libgpg-error >=1.55,<2.0a0
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 590353
-  timestamp: 1747060639058
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
   sha256: 19e5be91445db119152217e8e8eec4fd0499d854acc7d8062044fb55a70971cd
   md5: 68fc66282364981589ef36868b1a7c78
@@ -4958,6 +5814,18 @@ packages:
   purls: []
   size: 37407
   timestamp: 1753342931100
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
+  sha256: 8a7b01e1ee1c462ad243524d76099e7174ebdd94ff045fe3e9b1e58db196463b
+  md5: 40d9b534410403c821ff64f00d0adc22
+  depends:
+  - libgfortran5 15.2.0 h68bc16d_16
+  constrains:
+  - libgfortran-ng ==15.2.0=*_16
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 27215
+  timestamp: 1765256845586
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_7.conda
   sha256: 9ca24328e31c8ef44a77f53104773b9fe50ea8533f4c74baa8489a12de916f02
   md5: 8621a450add4e231f676646880703f49
@@ -4970,6 +5838,19 @@ packages:
   purls: []
   size: 29275
   timestamp: 1759968110483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
+  sha256: d0e974ebc937c67ae37f07a28edace978e01dc0f44ee02f29ab8a16004b8148b
+  md5: 39183d4e0c05609fd65f130633194e37
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.2.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 2480559
+  timestamp: 1765256819588
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-hcd61629_7.conda
   sha256: e93ceda56498d98c9f94fedec3e2d00f717cbedfc97c49be0e5a5828802f2d34
   md5: f116940d825ffc9104400f0d7f1a4551
@@ -5005,22 +5886,22 @@ packages:
   purls: []
   size: 113911
   timestamp: 1731331012126
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.0-h1fed272_0.conda
-  sha256: 33336bd55981be938f4823db74291e1323454491623de0be61ecbe6cf3a4619c
-  md5: b8e4c93f4ab70c3b6f6499299627dbdc
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.2-h32235b2_0.conda
+  sha256: 918306d6ed211ab483e4e19368e5748b265d24e75c88a1c66a61f72b9fa30b29
+  md5: 0cb0612bc9cb30c62baf41f9d600611b
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libffi >=3.4.6,<3.5.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
   - libiconv >=1.18,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - pcre2 >=10.46,<10.47.0a0
   constrains:
-  - glib 2.86.0 *_0
+  - glib 2.86.2 *_0
   license: LGPL-2.1-or-later
   purls: []
-  size: 3978602
-  timestamp: 1757403291664
+  size: 3974801
+  timestamp: 1763672326986
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
   sha256: a0105eb88f76073bbb30169312e797ed5449ebb4e964a756104d6e54633d17ef
   md5: 8422fcc9e5e172c91e99aef703b3ce65
@@ -5075,31 +5956,16 @@ packages:
   purls: []
   size: 447919
   timestamp: 1759967942498
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
-  sha256: 697334de4786a1067ea86853e520c64dd72b11a05137f5b318d8a444007b5e60
-  md5: 2bd47db5807daade8500ed7ca4c512a4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
+  sha256: 5b3e5e4e9270ecfcd48f47e3a68f037f5ab0f529ccb223e8e5d5ac75a58fc687
+  md5: 26c46f90d0e727e95c6c9498a33a09f3
   depends:
-  - libstdcxx >=13
-  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: LGPL-2.1-only
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
   purls: []
-  size: 312184
-  timestamp: 1745575272035
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake3-3.5.5-h54a6638_0.conda
-  sha256: 6092ccfec5a52200a2dd5cfa33f67e7c75d473dbb1673baf145a56456589196f
-  md5: 046a934130154ef383da67712d179235
-  depends:
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 217564
-  timestamp: 1759138411890
+  size: 603284
+  timestamp: 1765256703881
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.2.0-h54a6638_1.conda
   sha256: f306eba52c454fab2d6435959fda20a9d9062c86e918a79edd2afd2a82885f9c
   md5: c6600ee72e2cadd45348bc7b99e8f736
@@ -5112,35 +5978,37 @@ packages:
   purls: []
   size: 217934
   timestamp: 1759138566319
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
-  sha256: fce7eb4797a025c4c61f9502372801bba87ffddc39c68dfbd09f25f30e282c45
-  md5: 27dd93bf04ea4699afedf5ec38758c55
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math8-8.2.0-h54a6638_2.conda
+  sha256: 604ee7ebac74a45c95ca38152b98984a6ea195ce88e47332bdf397f1ecf3b4b2
+  md5: 57644d9cd6fe5cda498611d058ce9197
   depends:
   - eigen
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - libgz-utils3 >=3.1.1,<4.0a0
   - libgz-cmake4 >=4.2.0,<5.0a0
-  - libgz-utils2 >=2.2.1,<3.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 295819
-  timestamp: 1759147748392
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils2-2.2.1-h54a6638_1.conda
-  sha256: bca92e3b0a51b5ab8184bd85f06cc98717b44e7e69c97a0d1045308ecaca507a
-  md5: caa0101c91c9fda4d7f438204f6c3eab
+  size: 298011
+  timestamp: 1759147796036
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils3-3.1.1-h38f3fdc_2.conda
+  sha256: 89905428e197c5796e12fb6324843e4da616d17dfe161695ba4e440c16a0e231
+  md5: b1f372fd32c93c1c169c69b2d3ec2ebb
   depends:
   - cli11
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgz-cmake3 >=3.5.5,<4.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - spdlog >=1.15.3,<1.16.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 63327
-  timestamp: 1760392404826
+  size: 78059
+  timestamp: 1759142868065
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h3d81e11_1000.conda
   sha256: eecaf76fdfc085d8fed4583b533c10cb7f4a6304be56031c43a107e01a56b7e2
   md5: d821210ab60be56dd27b5525ed18366d
@@ -5154,6 +6022,17 @@ packages:
   purls: []
   size: 2450422
   timestamp: 1752761850672
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
+  sha256: 2bdd1cdd677b119abc5e83069bec2e28fe6bfb21ebaea3cd07acee67f38ea274
+  md5: c2a0c1d0120520e979685034e0b79859
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Apache-2.0 OR BSD-3-Clause
+  purls: []
+  size: 1448617
+  timestamp: 1758894401402
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
   sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
   md5: 915f5995e94f60e9a4826e0b0920ee88
@@ -5164,18 +6043,48 @@ packages:
   purls: []
   size: 790176
   timestamp: 1754908768807
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
-  sha256: 98b399287e27768bf79d48faba8a99a2289748c65cd342ca21033fab1860d4a4
-  md5: 9fa334557db9f63da6c9285fd2a48638
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+  sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
+  md5: 8397539e3a0bbd1695584fb4f927485a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
   purls: []
-  size: 628947
-  timestamp: 1745268527144
+  size: 633710
+  timestamp: 1762094827865
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-hf08fa70_5.conda
+  sha256: 6b9524a6a7ea6ef1ac791b697f660c2898171ae505d12e6d27509b59cf059ee6
+  md5: 82954a6f42e3fba59628741dca105c98
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libgcc >=14
+  - libhwy >=1.3.0,<1.4.0a0
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1740728
+  timestamp: 1761788390905
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
+  build_number: 5
+  sha256: c723b6599fcd4c6c75dee728359ef418307280fa3e2ee376e14e85e5bbdda053
+  md5: b38076eb5c8e40d0106beda6f95d7609
+  depends:
+  - libblas 3.11.0 5_h4a7cf45_openblas
+  constrains:
+  - blas 2.305   openblas
+  - liblapacke 3.11.0   5*_openblas
+  - libcblas   3.11.0   5*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 18200
+  timestamp: 1765818857876
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-37_h47877c9_openblas.conda
   build_number: 37
   sha256: e37125ad315464a927578bf6ba3455a30a7f319d5e60e54ccc860ddd218d516d
@@ -5191,21 +6100,21 @@ packages:
   purls: []
   size: 17470
   timestamp: 1760212744703
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-37_h6ae95b6_openblas.conda
-  build_number: 37
-  sha256: ac75029957b5af1054c5efa47fe9b0d92797122d8d253a26807a32b9dff28ca0
-  md5: 112866450bb115f40a4a551e46efce93
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-5_h6ae95b6_openblas.conda
+  build_number: 5
+  sha256: 3ed01602bf863a44d32fef697dd79ae53436644cf8b54d67cba0957757323bfe
+  md5: e487a0e38d89da76410cb92a5db39ec5
   depends:
-  - libblas 3.9.0 37_h4a7cf45_openblas
-  - libcblas 3.9.0 37_h0358290_openblas
-  - liblapack 3.9.0 37_h47877c9_openblas
+  - libblas 3.11.0 5_h4a7cf45_openblas
+  - libcblas 3.11.0 5_h0358290_openblas
+  - liblapack 3.11.0 5_h47877c9_openblas
   constrains:
-  - blas 2.137   openblas
+  - blas 2.305   openblas
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17500
-  timestamp: 1760212751728
+  size: 18225
+  timestamp: 1765818880545
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
   sha256: a6fddc510de09075f2b77735c64c7b9334cf5a26900da351779b275d9f9e55e1
   md5: 59a7b967b6ef5d63029b1712f8dcf661
@@ -5358,62 +6267,77 @@ packages:
   purls: []
   size: 5938936
   timestamp: 1755474342204
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.11.0-qt6_py312h4381209_609.conda
-  sha256: 5e2704c26aad6f87d469a653153cf9c23d5e5d5fc4c8c1560bbdd40f2a836abb
-  md5: 89942830561713bedc985da901b0c85e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
+  sha256: 199d79c237afb0d4780ccd2fbf829cea80743df60df4705202558675e07dd2c5
+  md5: be43915efc66345cccb3c310b6ed0374
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - openblas >=0.3.30,<0.3.31.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 5927939
+  timestamp: 1763114673331
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.12.0-qt6_py312hbf51571_603.conda
+  sha256: 2203ce03f6e6558f639e6121a7bb6cf34af2fbc92f67d9d8a39cb915c3f06a39
+  md5: b22bbd89e936d92d55d87472556e0f03
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   - ffmpeg >=7.1.1,<8.0a0
-  - harfbuzz >=11.0.1
+  - harfbuzz >=11.4.3
   - hdf5 >=1.14.6,<1.14.7.0a0
-  - jasper >=4.2.5,<5.0a0
-  - libasprintf >=0.24.1,<1.0a0
+  - imath >=3.2.1,<3.2.2.0a0
+  - jasper >=4.2.8,<5.0a0
+  - libasprintf >=0.25.1,<1.0a0
   - libavif16 >=1.3.0,<2.0a0
   - libcblas >=3.9.0,<4.0a0
   - libegl >=1.7.0,<2.0a0
-  - libexpat >=2.7.0,<3.0a0
+  - libexpat >=2.7.1,<3.0a0
   - libfreetype >=2.13.3
   - libfreetype6 >=2.13.3
-  - libgcc >=13
-  - libgettextpo >=0.24.1,<1.0a0
+  - libgcc >=14
+  - libgettextpo >=0.25.1,<1.0a0
   - libgl >=1.7.0,<2.0a0
-  - libglib >=2.84.2,<3.0a0
+  - libglib >=2.84.3,<3.0a0
   - libiconv >=1.18,<2.0a0
   - libjpeg-turbo >=3.1.0,<4.0a0
+  - libjxl >=0.11,<0.12.0a0
   - liblapack >=3.9.0,<4.0a0
   - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-auto-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-hetero-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-gpu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-intel-npu-plugin >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-ir-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-onnx-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-paddle-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-pytorch-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2025.0.0,<2025.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.0.0,<2025.0.1.0a0
-  - libpng >=1.6.49,<1.7.0a0
-  - libprotobuf >=5.29.3,<5.29.4.0a0
-  - libstdcxx >=13
+  - libopenvino >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-auto-batch-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-auto-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-hetero-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-intel-cpu-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-intel-gpu-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-intel-npu-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-ir-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-onnx-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-paddle-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-pytorch-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-tensorflow-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2025.2.0,<2025.2.1.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
   - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.5.0,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - numpy >=1.23,<3
-  - openexr >=3.3.4,<3.4.0a0
+  - openexr >=3.3.5,<3.4.0a0
   - qt6-main >=6.9.1,<6.10.0a0
-  constrains:
-  - imath<3.2.0a0
   license: Apache-2.0
   license_family: Apache
   purls:
   - pkg:pypi/opencv-python?source=hash-mapping
   - pkg:pypi/opencv-python-headless?source=hash-mapping
-  size: 30775780
-  timestamp: 1750898820648
+  size: 32727704
+  timestamp: 1755993567498
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
   sha256: 215086c108d80349e96051ad14131b751d17af3ed2cb5a34edd62fa89bfe8ead
   md5: 7df50d44d4a14d6c31a2c54f2cd92157
@@ -5434,172 +6358,172 @@ packages:
   purls: []
   size: 15460
   timestamp: 1731331007610
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.0.0-hdc3f47d_3.conda
-  sha256: fe0e184141a3563d4c97134a1b7a60c66302cf0e2692d15d49c41382cdf61648
-  md5: 3a88245058baa9d18ef4ea6df18ff63e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.2.0-hb617929_1.conda
+  sha256: 235e7d474c90ad9d8955401b8a91dbe373aa1dc65db3c8232a5e22e4eaf41976
+  md5: 1da20cc4ff32dc74424dec68ec087dba
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
+  - libgcc >=14
+  - libstdcxx >=14
   - pugixml >=1.15,<1.16.0a0
   - tbb >=2021.13.0
   purls: []
-  size: 5698665
-  timestamp: 1742046924817
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.0.0-h4d9b6c2_3.conda
-  sha256: b4c61b3e8fc4d7090a94e3fd3936faf347eea07cac993417153dd99bd293c08d
-  md5: 2e349bafc75b212879bf70ef80e0d08c
+  size: 6244771
+  timestamp: 1753211097492
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.2.0-hed573e4_1.conda
+  sha256: 193f760e828b0dd5168dd1d28580d4bf429c5f14a4eee5e0c02ff4c6d4cf8093
+  md5: 94f9d17be1d658213b66b22f63cc6578
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libstdcxx >=13
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libstdcxx >=14
   - tbb >=2021.13.0
   purls: []
-  size: 111823
-  timestamp: 1742046947746
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.0.0-h4d9b6c2_3.conda
-  sha256: ae72903e0718897b85aae2110d9bb1bfa9490b0496522e3735b65c771e7da0ea
-  md5: 74d074a3ac7af3378e16bfa6ff9cba30
+  size: 114760
+  timestamp: 1753211116381
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.2.0-hed573e4_1.conda
+  sha256: a6f9f996e64e6d2f295f017a833eda7018ff58b6894503272d72f0002dfd6f33
+  md5: 071b3a82342715a411f216d379ab6205
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libstdcxx >=13
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libstdcxx >=14
   - tbb >=2021.13.0
   purls: []
-  size: 238973
-  timestamp: 1742046961091
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.0.0-h981d57b_3.conda
-  sha256: b2c9ef97907f9c77817290bfb898897b476cc7ccf1737f0b1254437dda3d4903
-  md5: 21f7997d68220d7356c1f80dc500bfad
+  size: 250500
+  timestamp: 1753211127339
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.2.0-hd41364c_1.conda
+  sha256: f43f9049338ef9735b6815bac3f483d1e3adddecbfdeb13be365bc3f601fe156
+  md5: 77c0c7028a8110076d40314dc7b1fa98
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libstdcxx >=13
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libstdcxx >=14
   - pugixml >=1.15,<1.16.0a0
   purls: []
-  size: 196083
-  timestamp: 1742046974588
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.0.0-hdc3f47d_3.conda
-  sha256: 9f6613906386a0c679c9a683ca97a5a2070111d9ada4f115c1806d921313e32d
-  md5: 3385f38d15c7aebcc3b453e4d8dfb0fe
+  size: 194815
+  timestamp: 1753211138624
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.2.0-hb617929_1.conda
+  sha256: a4a1cd320fa010a45d01f438dc3431b7a60271ee19188a901f884399fe744268
+  md5: e4cc6db5bdc8b554c06bf569de57f85f
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libstdcxx >=13
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2021.13.0
-  purls: []
-  size: 12419296
-  timestamp: 1742046988488
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.0.0-hdc3f47d_3.conda
-  sha256: 8430f87a3cc65d3ef1ec8f9bfa990f6fb635601ad34ce08d70209099ff03f39c
-  md5: f2d50e234edd843d9d695f7da34c7e96
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libstdcxx >=13
-  - ocl-icd >=2.3.2,<3.0a0
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libstdcxx >=14
   - pugixml >=1.15,<1.16.0a0
   - tbb >=2021.13.0
   purls: []
-  size: 10119530
-  timestamp: 1742047030958
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.0.0-hdc3f47d_3.conda
-  sha256: 37ec3e304bf14d2d7b7781c4b6a8b3a54deae90bc7275f6ae160589ef219bcef
-  md5: f632cad865436394eebd41c3afa2cda3
+  size: 12377488
+  timestamp: 1753211149903
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.2.0-hb617929_1.conda
+  sha256: 03ebf700586775144ca5913f401393a386b9a1d7a7cfcba4494830063ca5eb92
+  md5: b846fe6c158ca417e246122172d68d3a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - level-zero >=1.21.2,<2.0a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libstdcxx >=13
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libstdcxx >=14
+  - ocl-icd >=2.3.3,<3.0a0
   - pugixml >=1.15,<1.16.0a0
   - tbb >=2021.13.0
   purls: []
-  size: 1092544
-  timestamp: 1742047065987
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.0.0-h981d57b_3.conda
-  sha256: 268716b5c1858c1fddd51d63c7fcd7f3544ef04f221371ab6a2f9c579ca001e4
-  md5: 94f25cc6fe70f507897abb8e61603023
+  size: 10815480
+  timestamp: 1753211182626
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.2.0-hb617929_1.conda
+  sha256: b6dbc342293d6ce0c7b37c9f29f734b3e1856cff9405a02fb33cedd1b36528e6
+  md5: 86fd4c25f6accaf646c86adf0f1382d3
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libstdcxx >=13
+  - level-zero >=1.23.1,<2.0a0
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2021.13.0
+  purls: []
+  size: 1261488
+  timestamp: 1753211212823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.2.0-hd41364c_1.conda
+  sha256: 334733396d4c9a9b2b2d7d7d850e8ee8deca1f9becd0368d106010076ceb20ca
+  md5: 75e595d9f2019a60f6dcb500266da615
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libstdcxx >=14
   - pugixml >=1.15,<1.16.0a0
   purls: []
-  size: 206013
-  timestamp: 1742047080381
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.0.0-h0e684df_3.conda
-  sha256: 5ce66c01f6ea365a497f488e8eecea8930b6a016f9809db7f33b8a1ebbe5644e
-  md5: 7cd3272c3171c1d43ed1c2b3d6795269
+  size: 204890
+  timestamp: 1753211224567
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.2.0-h1862bb8_1.conda
+  sha256: 3937b028e7192ed3805581ac0ea171725843056c8544537754fad45a1791e864
+  md5: 68f5ad9d8e3979362bb9dfc9388980aa
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
-  - libabseil >=20250127.0,<20250128.0a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libprotobuf >=5.29.3,<5.29.4.0a0
-  - libstdcxx >=13
+  - libabseil >=20250512.1,<20250513.0a0
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
   purls: []
-  size: 1668681
-  timestamp: 1742047094228
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.0.0-h0e684df_3.conda
-  sha256: 826507ac4ea2d496bdbec02dd9e3c8ed2eab253daa9d7f9119a8bc05c516d026
-  md5: 5b66cbc9965b429922b8e69cd4e464d7
+  size: 1724503
+  timestamp: 1753211235981
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.2.0-h1862bb8_1.conda
+  sha256: c7ac3d4187323ab37ef62ec0896a41c8ca7da426c7f587494c72fe74852269e5
+  md5: a032d03468dee9fb5b8eaf635b4571c2
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
-  - libabseil >=20250127.0,<20250128.0a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libprotobuf >=5.29.3,<5.29.4.0a0
-  - libstdcxx >=13
+  - libabseil >=20250512.1,<20250513.0a0
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
   purls: []
-  size: 690226
-  timestamp: 1742047109935
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.0.0-h5888daf_3.conda
-  sha256: fda07e70a23aac329be68ae488b790f548d687807f0e47bae7129df34f0adb5b
-  md5: a6ece96eff7f60b2559ba699156b0edf
+  size: 744746
+  timestamp: 1753211248776
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.2.0-hecca717_1.conda
+  sha256: 2d4a680a16509b8dd06ccd7a236655e46cc7c242bb5b6e88b83a834b891658db
+  md5: cd40cf2d10a3279654c9769f3bc8caf5
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libstdcxx >=13
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libstdcxx >=14
   purls: []
-  size: 1123885
-  timestamp: 1742047125703
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.0.0-h684f15b_3.conda
-  sha256: e02990fccd4676e362a026acff3d706b5839ebf6ae681d56a2903f62a63e03ef
-  md5: e1aeb108f4731db088782c8a20abf40a
+  size: 1243134
+  timestamp: 1753211260154
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.2.0-h0767aad_1.conda
+  sha256: 311ec1118448a28e76f0359c4393c7f7f5e64761c48ac7b169bf928a391eae77
+  md5: f71c6b4e342b560cc40687063ef62c50
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
-  - libabseil >=20250127.0,<20250128.0a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libprotobuf >=5.29.3,<5.29.4.0a0
-  - libstdcxx >=13
-  - snappy >=1.2.1,<1.3.0a0
+  - libabseil >=20250512.1,<20250513.0a0
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  - snappy >=1.2.2,<1.3.0a0
   purls: []
-  size: 1313789
-  timestamp: 1742047140816
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.0.0-h5888daf_3.conda
-  sha256: 236569eb4d472d75412a3384c2aad92b006afed721feec23ca08730a25932da7
-  md5: a6fe9c25b834988ac88651aff731dd31
+  size: 1325059
+  timestamp: 1753211272484
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.2.0-hecca717_1.conda
+  sha256: 581f4951e645e820c4a6ffe40fb0174b56d6e31fb1fefd2d64913fea01f8f69e
+  md5: fd9dacd7101f80ff1110ea6b76adb95d
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libopenvino 2025.0.0 hdc3f47d_3
-  - libstdcxx >=13
+  - libgcc >=14
+  - libopenvino 2025.2.0 hb617929_1
+  - libstdcxx >=14
   purls: []
-  size: 488142
-  timestamp: 1742047155790
+  size: 497047
+  timestamp: 1753211285617
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.5.2-hd0c01bc_0.conda
   sha256: 786d43678d6d1dc5f88a6bad2d02830cfd5a0184e84a8caa45694049f0e3ea5f
   md5: b64523fb87ac6f87f0790f324ad43046
@@ -5622,46 +6546,46 @@ packages:
   purls: []
   size: 28424
   timestamp: 1749901812541
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.50-h421ea60_1.conda
-  sha256: e75a2723000ce3a4b9fd9b9b9ce77553556c93e475a4657db6ed01abc02ea347
-  md5: 7af8e91b0deb5f8e25d1a595dea79614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.53-h421ea60_0.conda
+  sha256: 8acdeb9a7e3d2630176ba8e947caf6bf4985a5148dec69b801e5eb797856688b
+  md5: 00d4e66b1f746cb14944cad23fffb405
   depends:
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 317390
-  timestamp: 1753879899951
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.6-h3675c94_2.conda
-  sha256: 8a078b33f65c5521ae1ed9545ea21efdc46630ff618cdd01aa6a3e698149b27d
-  md5: e2c2f4c4c20a449b3b4a218797bd7c03
+  size: 317748
+  timestamp: 1764981060755
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
+  sha256: 06a8ace6cc5ee47b85a5e64fad621e5912a12a0202398f54f302eb4e8b9db1fd
+  md5: a4769024afeab4b32ac8167c2f92c7ac
   depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=75.1,<76.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - libgcc >=14
   - openldap >=2.6.10,<2.7.0a0
-  - openssl >=3.5.2,<4.0a0
+  - openssl >=3.5.4,<4.0a0
   license: PostgreSQL
   purls: []
-  size: 2726071
-  timestamp: 1757976008927
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.29.3-h7460b1f_2.conda
-  sha256: 674635c341a7838138a0698fc5704eab3b9a3a14f85e6f47a9d7568b8fa01a11
-  md5: 25b96b519eb2ed19faeef1c12954e82b
+  size: 2649881
+  timestamp: 1763565297202
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_2.conda
+  sha256: 1679f16c593d769f3dab219adb1117cbaaddb019080c5a59f79393dc9f45b84f
+  md5: 94cb88daa0892171457d9fdc69f43eca
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
-  - libabseil >=20250127.1,<20250128.0a0
+  - libabseil >=20250512.1,<20250513.0a0
   - libgcc >=14
   - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3475015
-  timestamp: 1753801238063
+  size: 4645876
+  timestamp: 1760550892361
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.4-h9969a89_0.conda
   sha256: 96bbd009b3d7f82e9af37e980af9285431ecd5c6f098a0f1afe0021d8d02b88a
   md5: e4fdd13a67d5b30459463e925b9e7e1f
@@ -5711,23 +6635,36 @@ packages:
   purls: []
   size: 4579364
   timestamp: 1759964758456
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
-  sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
-  md5: ef1910918dd895516a769ed36b5b3a4e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.4.0-h2a15e64_16.conda
+  sha256: 2582a3e4d916126aaf68132df82679542ad478d474736ae2216b0af645c431f0
+  md5: 80fd201b3d58b526bc2c855b8ae5eecd
   depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13.4.0
+  - libstdcxx >=13.4.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 6438911
+  timestamp: 1765255895156
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+  sha256: 57cb5f92110324c04498b96563211a1bca6a74b2918b1e8df578bfed03cc32e4
+  md5: 067590f061c9f6ea7e61e3b2112ed6b3
+  depends:
+  - __glibc >=2.17,<3.0.a0
   - lame >=3.100,<3.101.0a0
-  - libflac >=1.4.3,<1.5.0a0
-  - libgcc-ng >=12
-  - libogg >=1.3.4,<1.4.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libstdcxx-ng >=12
+  - libflac >=1.5.0,<1.6.0a0
+  - libgcc >=14
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.5.2,<2.0a0
+  - libstdcxx >=14
   - libvorbis >=1.3.7,<1.4.0a0
-  - mpg123 >=1.32.1,<1.33.0a0
+  - mpg123 >=1.32.9,<1.33.0a0
   license: LGPL-2.1-or-later
   license_family: LGPL
   purls: []
-  size: 354372
-  timestamp: 1695747735668
+  size: 355619
+  timestamp: 1765181778282
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
   sha256: 6d9c32fc369af5a84875725f7ddfbfc2ace795c28f246dc70055a79f9b2003da
   md5: 0b367fad34931cb79e0d6b7e5c06bb1c
@@ -5739,6 +6676,17 @@ packages:
   purls: []
   size: 932581
   timestamp: 1753948484112
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.1-h0c1763c_0.conda
+  sha256: 6f0e8a812e8e33a4d8b7a0e595efe28373080d27b78ee4828aa4f6649a088454
+  md5: 2e1b84d273b01835256e53fd938de355
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  purls: []
+  size: 938979
+  timestamp: 1764359444435
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -5765,6 +6713,29 @@ packages:
   purls: []
   size: 3898269
   timestamp: 1759968103436
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
+  sha256: 813427918316a00c904723f1dfc3da1bbc1974c5cfe1ed1e704c6f4e0798cbc6
+  md5: 68f68355000ec3f1d6f26ea13e8f525f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_16
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_16
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 5856456
+  timestamp: 1765256838573
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.4.0-h6963c3b_116.conda
+  sha256: 5372b4efc2ef87518091ca319815a1ef58aade0631b3a82d631fdecd4212fdeb
+  md5: 025a49b5e6486ffa65dafa309c031fb6
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 18969039
+  timestamp: 1765255710120
 - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.4.0-hba01cd7_107.conda
   sha256: f40f7c336eff57fe26306885070c61ca7a7cb46a58af37f2bbcb26d141fcdc92
   md5: 81a790d5f292f459d87533e5467fbdf9
@@ -5785,21 +6756,27 @@ packages:
   purls: []
   size: 29343
   timestamp: 1759968157195
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.9-h996ca69_0.conda
-  sha256: 6b063df2d13dc9cedeae7b1591b1917ced7f4e1b04f7246e66cc7fb0088dea07
-  md5: b6d222422c17dc11123e63fae4ad4178
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
+  sha256: 81f2f246c7533b41c5e0c274172d607829019621c4a0823b5c0b4a8c7028ee84
+  md5: 1b3152694d236cf233b76b8c56bf0eae
+  depends:
+  - libstdcxx 15.2.0 h934c35e_16
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 27300
+  timestamp: 1765256885128
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_3.conda
+  sha256: b3a7f89462dc95c1bba9f663210d20ff3ac5f7db458684e0f3a7ae5784f8c132
+  md5: 70d1de6301b58ed99fea01490a9802a3
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libcap >=2.76,<2.77.0a0
+  - libcap >=2.77,<2.78.0a0
   - libgcc >=14
-  - libgcrypt-lib >=1.11.1,<2.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - zstd >=1.5.7,<1.6.0a0
   license: LGPL-2.1-or-later
   purls: []
-  size: 492733
-  timestamp: 1757520335407
+  size: 491268
+  timestamp: 1765552759709
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libtheora-1.1.1-h4ab18f5_1006.conda
   sha256: 50c8cd416ac8425e415264de167b41ae8442de22a91098dfdd993ddbf9f13067
   md5: 553281a034e9cf8693c9df49f6c78ea1
@@ -5832,17 +6809,17 @@ packages:
   purls: []
   size: 437211
   timestamp: 1758278398952
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.9-h085a93f_0.conda
-  sha256: 1c8f0b02c400617a9f2ea8429c604b28e25a10f51b3c8d73ce127b4e7b462297
-  md5: 973f365f19c1d702bda523658a77de26
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
+  sha256: 977e7e4955ea1581e441e429c2c1b498bc915767f1cac77a97b283c469d5298c
+  md5: 3934f4cf65a06100d526b33395fb9cd2
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libcap >=2.76,<2.77.0a0
+  - libcap >=2.77,<2.78.0a0
   - libgcc >=14
   license: LGPL-2.1-or-later
   purls: []
-  size: 144265
-  timestamp: 1757520342166
+  size: 145023
+  timestamp: 1765552781358
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
   sha256: 71c8b9d5c72473752a0bb6e91b01dd209a03916cb71f36cc6a564e3a2a132d7a
   md5: e179a69edd30d75c0144d7a380b88f28
@@ -5888,6 +6865,24 @@ packages:
   purls: []
   size: 89551
   timestamp: 1748856210075
+- pypi: https://files.pythonhosted.org/packages/f0/43/5a2331615693b56221a902869fb2094d9a0b9a764a8706c8ba16e915f77c/libusb_package-1.0.26.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: libusb-package
+  version: 1.0.26.3
+  sha256: a83067c3dfdbb3856badb4532eaea22e8502b52ce4245f5ab46acf93d7fbd471
+  requires_dist:
+  - importlib-resources
+  requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-h5347b49_1.conda
+  sha256: 030447cf827c471abd37092ab9714fde82b8222106f22fde94bc7a64e2704c40
+  md5: 41f5c09a211985c3ce642d60721e7c3e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 40235
+  timestamp: 1764790744114
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
   sha256: e5ec6d2ad7eef538ddcb9ea62ad4346fde70a4736342c4ad87bd713641eb9808
   md5: 80c07c68d2f6870250959dcc95b209d1
@@ -5910,27 +6905,27 @@ packages:
   purls: []
   size: 895108
   timestamp: 1753948278280
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h4f16b4b_2.conda
-  sha256: e0df324fb02fa05a05824b8db886b06659432b5cff39495c59e14a37aa23d40f
-  md5: 2c65566e79dc11318ce689c656fb551c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
+  sha256: 255c7d00b54e26f19fad9340db080716bced1d8539606e2b8396c57abd40007c
+  md5: 25813fe38b3e541fc40007592f12bae5
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libdrm >=2.4.124,<2.5.0a0
+  - libdrm >=2.4.125,<2.5.0a0
   - libegl >=1.7.0,<2.0a0
-  - libgcc >=13
+  - libgcc >=14
   - libgl >=1.7.0,<2.0a0
   - libglx >=1.7.0,<2.0a0
   - libxcb >=1.17.0,<2.0a0
-  - wayland >=1.23.1,<2.0a0
+  - wayland >=1.24.0,<2.0a0
   - wayland-protocols
-  - xorg-libx11 >=1.8.11,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
   - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 217567
-  timestamp: 1740897682004
+  size: 221308
+  timestamp: 1765652453244
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
   sha256: ca494c99c7e5ecc1b4cd2f72b5584cef3d4ce631d23511184411abcbb90a21a5
   md5: b4ecbefe517ed0157c37f8182768271c
@@ -5946,6 +6941,21 @@ packages:
   purls: []
   size: 285894
   timestamp: 1753879378005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
+  sha256: bf0010d93f5b154c59bd9d3cc32168698c1d24f2904729f4693917cce5b27a9f
+  md5: a41a299c157cc6d0eff05e5fc298cc45
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - intel-media-driver >=25.3.3,<25.4.0a0
+  - libva >=2.22.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 287944
+  timestamp: 1757278954789
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
   sha256: e7d2daf409c807be48310fcc8924e481b62988143f582eb3a58c5523a6763b13
   md5: cde393f461e0c169d9ffb2fc70f81c33
@@ -6025,9 +7035,9 @@ packages:
   purls: []
   size: 791328
   timestamp: 1754703902365
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.8-h04c0eec_1.conda
-  sha256: 03deb1ec6edfafc5aaeecadfc445ee436fecffcda11fcd97fde9b6632acb583f
-  md5: 10bcbd05e1c1c9d652fccb42b776a9fa
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.9-h04c0eec_0.conda
+  sha256: 5d12e993894cb8e9f209e2e6bef9c90fa2b7a339a1f2ab133014b71db81f5d88
+  md5: 35eeb0a2add53b1e50218ed230fa6a02
   depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=75.1,<76.0a0
@@ -6038,8 +7048,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 698448
-  timestamp: 1754315344761
+  size: 697033
+  timestamp: 1761766011241
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h7a3aeb2_0.conda
   sha256: 35ddfc0335a18677dd70995fa99b8f594da3beb05c11289c87b6de5b930b47a3
   md5: 31059dc620fa57d787e3899ed0421e6d
@@ -6052,6 +7062,20 @@ packages:
   purls: []
   size: 244399
   timestamp: 1753273455036
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzenohc-1.5.1-hfad6b34_0.conda
+  sha256: 76b01f2e3a6d716603e5c189e770f16417cf7349272d187364c9d6936812d4d6
+  md5: 7b349cf7a3da44dabc4a6cacc957c9cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - zenoh-rust-abi >=1.5.1.1.85.0,<1.5.1.1.85.1.0a0
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 OR EPL-2.0
+  purls: []
+  size: 4531745
+  timestamp: 1757054523402
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
   sha256: 991e7348b0f650d495fb6d8aa9f8c727bdf52dabf5853c0cc671439b160dce48
   md5: a7b27c075c9b7f459f1c022090697cba
@@ -6094,7 +7118,7 @@ packages:
 - pypi: ./
   name: lsy-drone-racing
   version: 0.0.1
-  sha256: af62b6c572dfd79eeb5d3af762033b15026c5bf1f81b3914d243081e43165e3c
+  sha256: a0ecad701fde19d4f907bb68f13fd7b75cdeff25c7a88bcce30a37c6f1c7c11c
   requires_dist:
   - fire>=0.6.0
   - numpy
@@ -6102,14 +7126,14 @@ packages:
   - gymnasium[array-api]>=1.2.0 ; extra == 'sim'
   - ml-collections>=1.0 ; extra == 'sim'
   - packaging>=24.0 ; extra == 'sim'
-  - drone-models @ git+https://github.com/utiasDSL/drone-models.git@adr_ws25 ; extra == 'sim'
-  - drone-controllers @ git+https://github.com/utiasDSL/drone-controllers.git@adr_ws25 ; extra == 'sim'
-  - crazyflow @ git+https://github.com/utiasDSL/crazyflow.git@adr_ws25 ; extra == 'sim'
+  - drone-models ; extra == 'sim'
+  - drone-controllers ; extra == 'sim'
+  - crazyflow @ git+https://github.com/utiasDSL/crazyflow.git@0.1.0b0 ; extra == 'sim'
   - jax>=0.7 ; extra == 'sim'
   - warp-lang ; extra == 'sim'
   - jax[cuda12] ; extra == 'gpu'
   - cfclient ; extra == 'deploy'
-  - drone-estimators @ git+https://github.com/utiasDSL/drone-estimators.git@adr_ws25 ; extra == 'deploy'
+  - drone-estimators ; extra == 'deploy'
   - torch==2.8.0 ; extra == 'rl'
   - wandb ; extra == 'rl'
   requires_python: '>=3.10'
@@ -6142,21 +7166,22 @@ packages:
   - pkg:pypi/lxml?source=hash-mapping
   size: 1604566
   timestamp: 1758535320510
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.4-py312h5d89b6d_1.conda
-  sha256: 672bd94e67feff49461b7eb7a3ca08100681ebf76456e1f98fa0f08b17a04d2e
-  md5: bdcd58b62f85ad9554b5b6b5020683b8
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.5-py312h3d67a73_1.conda
+  sha256: e8ae9141c7afcc95555fca7ff5f91d7a84f094536715211e750569fd4bb2caa4
+  md5: a669145a2c834895bdf3fcba1f1e5b9c
   depends:
+  - python
+  - lz4-c
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - lz4-c >=1.10.0,<1.11.0a0
-  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
+  - lz4-c >=1.10.0,<1.11.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/lz4?source=hash-mapping
-  size: 40272
-  timestamp: 1756752102787
+  size: 44154
+  timestamp: 1765026394687
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
   md5: 9de5350a85c4a20c685259b889aa6393
@@ -6218,9 +7243,9 @@ packages:
   version: 3.0.3
   sha256: ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.7-py312he3d6523_0.conda
-  sha256: a86bf43f40c8afa3dbe846c62e54dc7496493cc882acdf366b5197205e7709d8
-  md5: 066291f807305cff71a8ec1683fc9958
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.8-py312he3d6523_0.conda
+  sha256: 70cf0e7bfd50ef50eb712a6ca1eef0ef0d63b7884292acc81353327b434b548c
+  md5: b8dc157bbbb69c1407478feede8b7b42
   depends:
   - __glibc >=2.17,<3.0.a0
   - contourpy >=1.0.1
@@ -6245,9 +7270,9 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
-  size: 8536303
-  timestamp: 1760560544102
+  - pkg:pypi/matplotlib?source=hash-mapping
+  size: 8442149
+  timestamp: 1763055517581
 - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
   sha256: 9b0037171dad0100f0296699a11ae7d355237b55f42f9094aebc0f41512d96a1
   md5: 827064ddfe0de2917fb29f1da4f8f533
@@ -6292,6 +7317,22 @@ packages:
   - pylint>=2.6.0 ; extra == 'dev'
   - pyink ; extra == 'dev'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: ml-dtypes
+  version: 0.5.4
+  sha256: 9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff
+  requires_dist:
+  - numpy>=1.21
+  - numpy>=1.21.2 ; python_full_version >= '3.10'
+  - numpy>=1.23.3 ; python_full_version >= '3.11'
+  - numpy>=1.26.0 ; python_full_version >= '3.12'
+  - numpy>=2.1.0 ; python_full_version >= '3.13'
+  - absl-py ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - pylint>=2.6.0 ; extra == 'dev'
+  - pyink ; extra == 'dev'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
   sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
   md5: c7f302fd11eeb0987a6a5e1f3aed6a21
@@ -6322,9 +7363,9 @@ packages:
   version: 1.1.2
   sha256: fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_0.conda
-  sha256: a09850eaef2d941c6215cc50714b81717e94e9e8ae34ab4729371b40495b2a23
-  md5: 43ef66a3b00b749383617e0ab6718d1d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
+  sha256: 94068fd39d1a672f8799e3146a18ba4ef553f0fcccefddb3c07fbdabfd73667a
+  md5: 2e489969e38f0b428c39492619b5e6e5
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -6335,12 +7376,25 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/msgpack?source=hash-mapping
-  size: 102521
-  timestamp: 1759930708977
+  size: 102525
+  timestamp: 1762504116832
 - pypi: https://files.pythonhosted.org/packages/e7/a9/2633ce0a5d11d884fcc8420279d58888d41a0bd08002efe14d334394e26e/mujoco-3.3.7-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: mujoco
   version: 3.3.7
   sha256: 1657312f4f4591ade7c7a21187065e3ab16e6a45d9c8c6abe8772fdc4b585789
+  requires_dist:
+  - absl-py
+  - etils[epath]
+  - glfw
+  - numpy
+  - pyopengl
+  - usd-core ; extra == 'usd'
+  - pillow ; extra == 'usd'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/c6/10/fa6b8762efbb02bd349503a39fb9dbbcf9e12041b0c5b29d484cafc09355/mujoco-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: mujoco
+  version: 3.4.0
+  sha256: 8e5a36e61495be2a855f61194813e1277ab4b330cc180e50c8e3c7a459dc40b6
   requires_dist:
   - absl-py
   - etils[epath]
@@ -6364,20 +7418,46 @@ packages:
   - trimesh
   - warp-lang==1.9.1 ; extra == 'warp'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.3-py312h178313f_0.conda
-  sha256: c703d148a85ffb4f11001d31b7c4c686a46ad554eeeaa02c69da59fbf0e00dbb
-  md5: f4e246ec4ccdf73e50eefb0fa359a64e
+- pypi: https://files.pythonhosted.org/packages/29/2f/8c2f734a0c4762416895ae3a7a9f46b10a3a8f3d72c0457d72b31d329c34/mujoco_mjx-3.4.0-py3-none-any.whl
+  name: mujoco-mjx
+  version: 3.4.0
+  sha256: b64e0e33e367027e912893701cce905efd1397e2234bca171c73990b9f088171
+  requires_dist:
+  - absl-py
+  - etils[epath]
+  - jax
+  - jaxlib
+  - mujoco>=3.4.0.dev0
+  - scipy
+  - trimesh
+  - warp-lang==1.10.0 ; extra == 'warp'
+  requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.0-py312h8a5da7c_0.conda
+  sha256: e56ac750fee1edb47a0390984c4725d8ce86c243f27119e30ceaac5c68e300cf
+  md5: 9fe4c848dd01cde9b8d0073744d4eef8
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/multidict?source=hash-mapping
-  size: 97272
-  timestamp: 1751310833783
+  - pkg:pypi/multidict?source=compressed-mapping
+  size: 99537
+  timestamp: 1765460650128
+- pypi: https://files.pythonhosted.org/packages/56/b3/7c69b37f03260a061883bec0e7b05be7117c1b1c85f5212c72c8c2bc3c8c/munch-4.0.0-py2.py3-none-any.whl
+  name: munch
+  version: 4.0.0
+  sha256: 71033c45db9fb677a0b7eb517a4ce70ae09258490e419b0e7f00d1e386ecb1b4
+  requires_dist:
+  - importlib-metadata>=1.7.0 ; python_full_version < '3.8'
+  - astroid>=2.0 ; extra == 'testing'
+  - pylint~=2.3.1 ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - coverage ; extra == 'testing'
+  - pyyaml>=5.1.0 ; extra == 'yaml'
+  requires_python: '>=3.6'
 - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609
@@ -6440,6 +7520,18 @@ packages:
   - pytest-mpl ; extra == 'test-extras'
   - pytest-randomly ; extra == 'test-extras'
   requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
+  sha256: 6f7d59dbec0a7b00bf5d103a4306e8886678b796ff2151b62452d4582b2a53fb
+  md5: b518e9e92493721281a60fa975bddc65
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 186323
+  timestamp: 1763688260928
 - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
   sha256: fd2cbd8dfc006c72f45843672664a8e4b99b2f8137654eaae8c3d46dca776f63
   md5: 16c2a0e9c4a166e53632cfca4f68d020
@@ -6450,9 +7542,9 @@ packages:
   purls: []
   size: 136216
   timestamp: 1758194284857
-- conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.37-h29cc59b_0.conda
-  sha256: 472306630dcd49a221863b91bd89f5b8b81daf1b99adf1968c9f12021176d873
-  md5: d73ccc379297a67ed921bd55b38a6c6a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.38-h29cc59b_0.conda
+  sha256: e3664264bd936c357523b55c71ed5a30263c6ba278d726a75b1eb112e6fb0b64
+  md5: e235d5566c9cc8970eb2798dd4ecf62f
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -6460,42 +7552,23 @@ packages:
   license: MPL-2.0
   license_family: MOZILLA
   purls: []
-  size: 230951
-  timestamp: 1752841107697
-- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.117-h445c969_0.conda
-  sha256: 85f2d6d93199454818866b355834a8c5dc64a87e14da3b242208c9dc2156852a
-  md5: 970af0bfac9644ddbf7e91c1336b231b
+  size: 228588
+  timestamp: 1762348634537
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.118-h445c969_0.conda
+  sha256: 44dd98ffeac859d84a6dcba79a2096193a42fc10b29b28a5115687a680dd6aea
+  md5: 567fbeed956c200c1db5782a424e58ee
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libsqlite >=3.50.4,<4.0a0
+  - libsqlite >=3.51.0,<4.0a0
   - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
-  - nspr >=4.37,<5.0a0
+  - nspr >=4.38,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
   purls: []
-  size: 2045760
-  timestamp: 1759509411326
-- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
-  sha256: fe3459c75cf84dcef6ef14efcc4adb0ade66038ddd27cadb894f34f4797687d8
-  md5: d8285bea2a350f63fab23bf460221f3f
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/numpy?source=hash-mapping
-  size: 7484186
-  timestamp: 1707225809722
+  size: 2057773
+  timestamp: 1763485556350
 - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.3-py313hf6604e3_0.conda
   sha256: 88d45c6dbedabbc8ebb19555bb3d04b5e2846ae8a7dfc2c0204b54f5f6efaef7
   md5: 3122d20dc438287e125fb5acff1df170
@@ -6517,15 +7590,46 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 8888776
   timestamp: 1757505485589
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.5-py312h33ff503_0.conda
+  sha256: 68b5dd7e4d12295c44130e3a777462dbc8886ca0a7d141f1ff5ab0375df5da30
+  md5: 1570db96376f9f01cf495afe203672e5
+  depends:
+  - python
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libcblas >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  - python_abi 3.12.* *_cp312
+  - liblapack >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=compressed-mapping
+  size: 8820654
+  timestamp: 1763351074641
 - pypi: https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl
   name: nvidia-cublas-cu12
   version: 12.8.4.1
   sha256: 8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/77/3c/aa88abe01f3be3d1f8f787d1d33dc83e76fec05945f9a28fbb41cfb99cd5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_x86_64.whl
+  name: nvidia-cublas-cu12
+  version: 12.9.1.4
+  sha256: 453611eb21a7c1f2c2156ed9f3a45b691deda0440ec550860290dc901af5b4c2
+  requires_python: '>=3'
 - pypi: https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: nvidia-cuda-cupti-cu12
   version: 12.8.90
   sha256: ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182
+  requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl
+  name: nvidia-cuda-cupti-cu12
+  version: 12.9.79
+  sha256: 096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f
   requires_python: '>=3'
 - pypi: https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
   name: nvidia-cuda-nvcc-cu12
@@ -6537,10 +7641,20 @@ packages:
   version: 12.8.93
   sha256: a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
+  name: nvidia-cuda-nvrtc-cu12
+  version: 12.9.86
+  sha256: 210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4
+  requires_python: '>=3'
 - pypi: https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: nvidia-cuda-runtime-cu12
   version: 12.8.90
   sha256: adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90
+  requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: nvidia-cuda-runtime-cu12
+  version: 12.9.79
+  sha256: 25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3
   requires_python: '>=3'
 - pypi: https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl
   name: nvidia-cudnn-cu12
@@ -6549,10 +7663,24 @@ packages:
   requires_dist:
   - nvidia-cublas-cu12
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/b1/b1/6b944dd4cf0a1d1e70d659f35a2202c735916cbd47cb93beccc4f2e8e696/nvidia_cudnn_cu12-9.17.0.29-py3-none-manylinux_2_27_x86_64.whl
+  name: nvidia-cudnn-cu12
+  version: 9.17.0.29
+  sha256: 55e49fca81d6873c585eb724a47dfdf17faeceae501e9428bb1c527a085ab4d6
+  requires_dist:
+  - nvidia-cublas-cu12
+  requires_python: '>=3'
 - pypi: https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: nvidia-cufft-cu12
   version: 11.3.3.83
   sha256: 4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74
+  requires_dist:
+  - nvidia-nvjitlink-cu12
+  requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: nvidia-cufft-cu12
+  version: 11.4.1.4
+  sha256: c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28
   requires_dist:
   - nvidia-nvjitlink-cu12
   requires_python: '>=3'
@@ -6575,10 +7703,26 @@ packages:
   - nvidia-nvjitlink-cu12
   - nvidia-cusparse-cu12
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl
+  name: nvidia-cusolver-cu12
+  version: 11.7.5.82
+  sha256: 15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88
+  requires_dist:
+  - nvidia-cublas-cu12
+  - nvidia-nvjitlink-cu12
+  - nvidia-cusparse-cu12
+  requires_python: '>=3'
 - pypi: https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: nvidia-cusparse-cu12
   version: 12.5.8.93
   sha256: 1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b
+  requires_dist:
+  - nvidia-nvjitlink-cu12
+  requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: nvidia-cusparse-cu12
+  version: 12.5.10.65
+  sha256: 73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78
   requires_dist:
   - nvidia-nvjitlink-cu12
   requires_python: '>=3'
@@ -6591,10 +7735,20 @@ packages:
   version: 2.27.3
   sha256: adf27ccf4238253e0b826bce3ff5fa532d65fc42322c8bfdfaf28024c0fbe039
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/4a/4e/44dbb46b3d1b0ec61afda8e84837870f2f9ace33c564317d59b70bc19d3e/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_x86_64.whl
+  name: nvidia-nccl-cu12
+  version: 2.28.9
+  sha256: 485776daa8447da5da39681af455aa3b2c2586ddcf4af8772495e7c532c7e5ab
+  requires_python: '>=3'
 - pypi: https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
   name: nvidia-nvjitlink-cu12
   version: 12.8.93
   sha256: 81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88
+  requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
+  name: nvidia-nvjitlink-cu12
+  version: 12.9.86
+  sha256: e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9
   requires_python: '>=3'
 - pypi: https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: nvidia-nvshmem-cu12
@@ -6628,6 +7782,16 @@ packages:
   purls: []
   size: 6061149
   timestamp: 1755474368034
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openblas-0.3.30-pthreads_h6ec200e_4.conda
+  sha256: c2451f69728b318a1558db14f7a55a6ddec951340a752b09e008a7f7b02854eb
+  md5: 379ec5261b0b8fc54f2e7bd055360b0c
+  depends:
+  - libopenblas 0.3.30 pthreads_h94d23a6_4
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 6044349
+  timestamp: 1763114684496
 - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
   sha256: 2b6ce54174ec19110e1b3c37455f7cd138d0e228a75727a9bba443427da30a36
   md5: 45c3d2c224002d6d0d7769142b29f986
@@ -6640,21 +7804,21 @@ packages:
   purls: []
   size: 55357
   timestamp: 1749853464518
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.5-h09fa569_0.conda
-  sha256: db6bac8013542227eda2153b7473b10faef11fd2bae57591d1f729993109e152
-  md5: f46ae82586acba0872546bd79261fafc
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.5-h608838b_1.conda
+  sha256: d07e5997570678bfd562052e23f4dae8ec2223de24ad0e0fa58bd34c89aecf46
+  md5: 0d8aa07938b8ac5b0aaec781793d39a1
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - imath >=3.2.1,<3.2.2.0a0
   - libdeflate >=1.24,<1.25.0a0
   - libzlib >=1.3.1,<2.0a0
-  - imath >=3.1.12,<3.1.13.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 1326814
-  timestamp: 1753614941084
+  size: 1325690
+  timestamp: 1755533954562
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
   sha256: 3f231f2747a37a58471c82a9a8a80d92b7fece9f3fce10901a5ac888ce00b747
   md5: b28cf020fd2dead0ca6d113608683842
@@ -6709,6 +7873,18 @@ packages:
   purls: []
   size: 3119624
   timestamp: 1759324353651
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
+  sha256: a47271202f4518a484956968335b2521409c8173e123ab381e775c358c67fe6d
+  md5: 9ee58d5c534af06558933af3c845a780
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3165399
+  timestamp: 1762839186699
 - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
   name: opt-einsum
   version: 3.4.0
@@ -6773,6 +7949,45 @@ packages:
   - chex ; extra == 'testing'
   - aiofiles ; extra == 'testing'
   - safetensors ; extra == 'testing'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/da/3a/abbc3c5cac2e082e88cfec2161bf837f18fef786caaa3f007594c839fc8c/orbax_checkpoint-0.11.31-py3-none-any.whl
+  name: orbax-checkpoint
+  version: 0.11.31
+  sha256: b00e39cd61cbd6c7c78b091ccac0ed1bbf3cf7788e761618e7070761195bfcc0
+  requires_dist:
+  - absl-py
+  - etils[epath,epy]
+  - typing-extensions
+  - msgpack
+  - jax>=0.6.0
+  - numpy
+  - pyyaml
+  - tensorstore>=0.1.74
+  - nest-asyncio
+  - aiofiles
+  - protobuf
+  - humanize
+  - simplejson>=3.16.0
+  - psutil
+  - flax ; extra == 'docs'
+  - google-cloud-logging ; extra == 'docs'
+  - grain ; extra == 'docs'
+  - aiofiles ; extra == 'docs'
+  - tensorflow-datasets ; extra == 'docs'
+  - opencv-python ; extra == 'docs'
+  - safetensors ; extra == 'docs'
+  - clu ; extra == 'docs'
+  - google-cloud-logging ; extra == 'testing'
+  - mock ; extra == 'testing'
+  - flax ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-xdist ; extra == 'testing'
+  - chex ; extra == 'testing'
+  - aiofiles ; extra == 'testing'
+  - safetensors ; extra == 'testing'
+  - torch ; extra == 'testing'
+  - clu ; extra == 'testing'
+  - tensorflow ; extra == 'testing'
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.3-hecca717_0.conda
   sha256: f1ac73e2a809a0e838e55afd521313a441d2d159621d2295a65700c7d519ead8
@@ -6964,29 +8179,29 @@ packages:
   - trove-classifiers>=2024.10.12 ; extra == 'tests'
   - defusedxml ; extra == 'xmp'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py312h7b42cdd_3.conda
-  sha256: ad4a22899819a2bb86550d1fc3833a44e073aac80ea61529676b5e73220fcc2b
-  md5: 1d7f05c3f8bb4e98d02fca45f0920b23
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.0.0-py312h50c33e8_2.conda
+  sha256: 58c4589d7dc2d2bf66fc57fc21abd43ca85b23d14b24466d8e8bef60ca51185b
+  md5: f2aef8ecea68f4d35330f0c48949bff2
   depends:
   - python
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - openjpeg >=2.5.4,<3.0a0
   - lcms2 >=2.17,<3.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
   - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - tk >=8.6.13,<8.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - python_abi 3.12.* *_cp312
   - libxcb >=1.17.0,<2.0a0
-  - libtiff >=4.7.0,<4.8.0a0
   - libfreetype >=2.14.1
   - libfreetype6 >=2.14.1
-  - python_abi 3.12.* *_cp312
-  - openjpeg >=2.5.3,<3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - zlib-ng >=2.3.1,<2.4.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=hash-mapping
-  size: 1028547
-  timestamp: 1758208668856
+  - pkg:pypi/pillow?source=compressed-mapping
+  size: 1028596
+  timestamp: 1764330106863
 - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh145f28c_0.conda
   sha256: 20fe420bb29c7e655988fd0b654888e6d7755c1d380f82ca2f1bd2493b95d650
   md5: e7ab34d5a93e0819b62563c78635d937
@@ -6998,19 +8213,19 @@ packages:
   - pkg:pypi/pip?source=hash-mapping
   size: 1179951
   timestamp: 1753925011027
-- conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
-  sha256: ec9ed3cef137679f3e3a68e286c6efd52144684e1be0b05004d9699882dadcdd
-  md5: dfce4b2af4bfe90cdcaf56ca0b28ddf5
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
+  sha256: b67692da1c0084516ac1c9ada4d55eaf3c5891b54980f30f3f444541c2706f1e
+  md5: c55515ca43c6444d2572e0f0d93cb6b9
   depends:
-  - python >=3.9,<3.13.0a0
+  - python >=3.10,<3.13.0a0
   - setuptools
   - wheel
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pip?source=hash-mapping
-  size: 1177168
-  timestamp: 1753924973872
+  - pkg:pypi/pip?source=compressed-mapping
+  size: 1177534
+  timestamp: 1762776258783
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
   sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
   md5: c01af13bdc553d1a8fbfff6e8db075f0
@@ -7062,6 +8277,18 @@ packages:
   - pkg:pypi/pluggy?source=hash-mapping
   size: 24246
   timestamp: 1747339794916
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  sha256: e14aafa63efa0528ca99ba568eaf506eb55a0371d12e6250aaaa61718d2eb62e
+  md5: d7585b6550ad04c8c5e21097ada2888e
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pluggy?source=compressed-mapping
+  size: 25877
+  timestamp: 1764896838868
 - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
   sha256: bae453e5cecf19cab23c2e8929c6e30f4866d996a8058be16c797ed4b935461f
   md5: fd5062942bfa1b0bd5e0d2a4397b099e
@@ -7105,6 +8332,11 @@ packages:
   - pkg:pypi/propcache?source=hash-mapping
   size: 54233
   timestamp: 1744525107433
+- pypi: https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl
+  name: protobuf
+  version: 6.33.2
+  sha256: 1f8017c48c07ec5859106533b682260ba3d7c5567b1ca1f24297ce03384d1b4f
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-6.32.1-py313h50fafe1_2.conda
   sha256: 1592ef1bfa3d31b38d376cd5e9ba09967c6dd0055646019562d48ce64dbe2e32
   md5: 8eeff37d3534c39a00274b9c381118fa
@@ -7125,20 +8357,20 @@ packages:
   - pkg:pypi/protobuf?source=hash-mapping
   size: 487543
   timestamp: 1760429990541
-- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.1-py312h4c3975b_0.conda
-  sha256: 92fe5c84e6892262e2dfb2a1f90516eadf887b469805509b547c0575e2811901
-  md5: 8713607fa1730cbd870fed86a3230926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.3-py312h5253ce2_0.conda
+  sha256: 1b679202ebccf47be64509a4fc2a438a66229403257630621651b2886b882597
+  md5: 82ce56c5a4a55165aed95e04923ab363
   depends:
-  - __glibc >=2.17,<3.0.a0
+  - python
   - libgcc >=14
-  - python >=3.12,<3.13.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/psutil?source=hash-mapping
-  size: 471697
-  timestamp: 1760894200351
+  size: 495011
+  timestamp: 1762092914381
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -7162,39 +8394,39 @@ packages:
   purls: []
   size: 118488
   timestamp: 1736601364156
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a8bead_2.conda
-  sha256: 8a6729861c9813a756b0438c30bd271722fb3f239ded3afc3bf1cb03327a640e
-  md5: b6f21b1c925ee2f3f7fc37798c5988db
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+  sha256: 0a0858c59805d627d02bdceee965dd84fde0aceab03a2f984325eec08d822096
+  md5: b8ea447fdf62e3597cb8d2fae4eb1a90
   depends:
   - __glibc >=2.17,<3.0.a0
   - dbus >=1.16.2,<2.0a0
   - libgcc >=14
-  - libglib >=2.86.0,<3.0a0
+  - libglib >=2.86.1,<3.0a0
   - libiconv >=1.18,<2.0a0
   - libsndfile >=1.2.2,<1.3.0a0
-  - libsystemd0 >=257.7
+  - libsystemd0 >=257.10
   - libxcb >=1.17.0,<2.0a0
   constrains:
-  - pulseaudio 17.0 *_2
+  - pulseaudio 17.0 *_3
   license: LGPL-2.1-or-later
   license_family: LGPL
   purls: []
-  size: 761857
-  timestamp: 1757472971364
-- conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.11.0-qt6_py312h0c4a6be_609.conda
-  sha256: 3a4613a75e650981c405ef337e180e87803dd222ae529224d16d8fc98f64f515
-  md5: cebc6fbdab790a8fadd8f8d5f8c6ca33
+  size: 750785
+  timestamp: 1763148198088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.12.0-qt6_py312h598be00_603.conda
+  sha256: a32137cdaa7b9ed94743f66b78ac529e0b8dc246b033c2be9a87294b1ecc8a6e
+  md5: aec3807dc48e393a5e663cf20206ef59
   depends:
-  - libopencv 4.11.0 qt6_py312h4381209_609
-  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libopencv 4.12.0 qt6_py312hbf51571_603
+  - libprotobuf >=6.31.1,<6.31.2.0a0
   - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1155759
-  timestamp: 1750898943629
+  size: 1153856
+  timestamp: 1755993630744
 - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
   sha256: 2558727093f13d4c30e124724566d16badd7de532fd8ee7483628977117d02be
   md5: 70ece62498c769280f791e836ac53fff
@@ -7250,9 +8482,9 @@ packages:
   - pkg:pypi/pybullet?source=hash-mapping
   size: 62838622
   timestamp: 1761041325516
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.28.0-py312h2596900_1.conda
-  sha256: 06ab769633caa9b091fbcbaeede9c7fe91ee324adab050267e6877135692c499
-  md5: f35e3f72488d3fb2cf6809feb9aa1086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py312h2596900_0.conda
+  sha256: f0c2cdc875f75af9a9e15b4dc84bb5b3c321c46c40343b5995869a10697119d7
+  md5: 3ae03fed8f1d543f46066b07721029a4
   depends:
   - __glibc >=2.17,<3.0.a0
   - cairo >=1.18.4,<2.0a0
@@ -7264,8 +8496,8 @@ packages:
   license: LGPL-2.1-only OR MPL-1.1
   purls:
   - pkg:pypi/pycairo?source=hash-mapping
-  size: 117977
-  timestamp: 1756304213181
+  size: 120332
+  timestamp: 1763046400508
 - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
   sha256: 1950f71ff44e64163e176b1ca34812afc1a104075c3190de50597e1623eb7d53
   md5: 85815c6a22905c080111ec8d56741454
@@ -7357,6 +8589,21 @@ packages:
   - pkg:pypi/pygments?source=hash-mapping
   size: 889287
   timestamp: 1750615908735
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pygraphviz-1.14-py312hdfa1987_2.conda
+  sha256: df1a5b61ddd37ae2d3e673481e555419159684eab2271ee45f8eb2fcd1790b7d
+  md5: 87066d64e7688ca972e1279e40e0d5f4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - graphviz >=13.1.2,<14.0a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pygraphviz?source=hash-mapping
+  size: 146677
+  timestamp: 1759598305098
 - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
   name: pyopengl
   version: 3.1.10
@@ -7370,7 +8617,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyparsing?source=compressed-mapping
+  - pkg:pypi/pyparsing?source=hash-mapping
   size: 104044
   timestamp: 1758436411254
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py312h82c0db2_2.conda
@@ -7406,20 +8653,20 @@ packages:
   - pkg:pypi/pyqt5?source=hash-mapping
   size: 5282965
   timestamp: 1759498005783
-- conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-builder-1.15.4-pyhd8ed1ab_1.conda
-  sha256: 7000bf38da6e5235b4501567a947b98c16bd3a64ed24a2b3810ee7952d93becf
-  md5: e7e42825f9277818ad114fea56385dae
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-builder-1.18.2-pyhd8ed1ab_0.conda
+  sha256: 081d82179da39117d29a46235b2304c24600ee7c4f842307eb9f62789942837f
+  md5: 3c99b35c07931fffc1928aff181bdc4b
   depends:
   - packaging
-  - python >=3.9
+  - python >=3.10
   - sip
   - toml
-  license: GPL-3.0-only
-  license_family: GPL
+  license: BSD-2-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/pyqt-builder?source=hash-mapping
-  size: 2965472
-  timestamp: 1742182116448
+  size: 2965224
+  timestamp: 1763427646500
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py312h1289d80_2.conda
   sha256: d1f8665889ace76677084d5a0399b2a488553fc5e8efafe9e97ee7e2641e2496
   md5: 14b1c131cab3002a6d2c2db647550084
@@ -7438,6 +8685,37 @@ packages:
   - pkg:pypi/pyqt5-sip?source=hash-mapping
   size: 85800
   timestamp: 1759495565076
+- pypi: https://files.pythonhosted.org/packages/e4/d3/8789879c05cfe06127c4b59258632bd175fcdd9eaaadaf0c897b458fb91d/PyQt6-6.7.1-1-cp38-abi3-manylinux_2_28_x86_64.whl
+  name: pyqt6
+  version: 6.7.1
+  sha256: c2f202b7941aa74e5c7e1463a6f27d9131dbc1e6cabe85571d7364f5b3de7397
+  requires_dist:
+  - pyqt6-sip>=13.8,<14
+  - pyqt6-qt6>=6.7.0,<6.8.0
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/88/4d/26ca7239f7223e5b95b58a58537a09b069582ebb4dfa38234113a9f898ab/PyQt6_Qt6-6.7.3-py3-none-manylinux_2_28_x86_64.whl
+  name: pyqt6-qt6
+  version: 6.7.3
+  sha256: cb525fdd393332de60887953029276a44de480fce1d785251ae639580f5e7246
+- pypi: https://files.pythonhosted.org/packages/11/fd/04adac969ba70bb042d52e13c99c968fce0e1fa6a52146f03a974168a848/pyqt6_sip-13.10.3-cp312-cp312-manylinux1_x86_64.manylinux_2_5_x86_64.whl
+  name: pyqt6-sip
+  version: 13.10.3
+  sha256: 3f3e2a79738319b795f0d1b2a555b1ea669b1a306b604bac876c84833cabb008
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/32/36/4c242f81fdcbfa4fb62a5645f6af79191f4097a0577bd5460c24f19cc4ef/pyqtgraph-0.14.0-py3-none-any.whl
+  name: pyqtgraph
+  version: 0.14.0
+  sha256: 7abb7c3e17362add64f8711b474dffac5e7b0e9245abdf992e9a44119b7aa4f5
+  requires_dist:
+  - numpy>=1.25.0
+  - colorama
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl
+  name: pyserial
+  version: '3.5'
+  sha256: c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0
+  requires_dist:
+  - hidapi ; extra == 'cp2110'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac
@@ -7470,6 +8748,27 @@ packages:
   - pkg:pypi/pytest?source=hash-mapping
   size: 276734
   timestamp: 1757011891753
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+  sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
+  md5: 2b694bad8a50dc2f712f5368de866480
+  depends:
+  - pygments >=2.7.2
+  - python >=3.10
+  - iniconfig >=1.0.1
+  - packaging >=22
+  - pluggy >=1.5,<2
+  - tomli >=1
+  - colorama >=0.4
+  - exceptiongroup >=1
+  - python
+  constrains:
+  - pytest-faulthandler >=2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pytest?source=hash-mapping
+  size: 299581
+  timestamp: 1765062031645
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
   sha256: d0f45586aad48ef604590188c33c83d76e4fc6370ac569ba0900906b24fd6a26
   md5: 6891acad5e136cb62a8c2ed2679d6528
@@ -7510,15 +8809,16 @@ packages:
   - pkg:pypi/pytest-rerunfailures?source=hash-mapping
   size: 19613
   timestamp: 1760091441792
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hfe2f287_0_cpython.conda
-  sha256: 5386d8c8230b6478ae165ff34f57d498891ac160e871629cbb4d4256e69cc542
-  md5: ceada987beec823b3c702710ee073fba
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_1_cpython.conda
+  build_number: 1
+  sha256: 39898d24769a848c057ab861052e50bdc266310a7509efa3514b840e85a2ae98
+  md5: 5c00c8cea14ee8d02941cab9121dce41
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
   - libexpat >=2.7.1,<3.0a0
-  - libffi >=3.4.6,<3.5.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
   - liblzma >=5.8.1,<6.0a0
   - libnsl >=2.0.1,<2.1.0a0
@@ -7535,8 +8835,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
   purls: []
-  size: 31547362
-  timestamp: 1760367376467
+  size: 31537229
+  timestamp: 1761176876216
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.9-h2b335a9_100_cp313.conda
   build_number: 100
   sha256: 317ee7a38f4cc97336a2aedf9c79e445adf11daa0d082422afa63babcd5117e4
@@ -7654,6 +8954,11 @@ packages:
   - pkg:pypi/pytz?source=hash-mapping
   size: 189015
   timestamp: 1742920947249
+- pypi: https://files.pythonhosted.org/packages/28/b8/27e6312e86408a44fe16bd28ee12dd98608b39f7e7e57884a24e8f29b573/pyusb-1.3.1-py3-none-any.whl
+  name: pyusb
+  version: 1.3.1
+  sha256: bf9b754557af4717fe80c2b07cc2b923a9151f5c08d17bdb5345dac09d6a0430
+  requires_python: '>=3.9.0'
 - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: pyyaml
   version: 6.0.3
@@ -7674,6 +8979,13 @@ packages:
   - pkg:pypi/pyyaml?source=hash-mapping
   size: 204539
   timestamp: 1758892248166
+- pypi: https://files.pythonhosted.org/packages/81/b1/57db58cfc8af592ce94f40649bd1804369c05b2190e4cbc0a2dad572baeb/pyzmq-26.4.0-cp312-cp312-manylinux_2_28_x86_64.whl
+  name: pyzmq
+  version: 26.4.0
+  sha256: ef8c6ecc1d520debc147173eaa3765d53f06cd8dbe7bd377064cdbc53ab456f5
+  requires_dist:
+  - cffi ; implementation_name == 'pypy'
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
   sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
   md5: 353823361b1d27eb3960efb076dfcaf6
@@ -7830,6 +9142,18 @@ packages:
   purls: []
   size: 282480
   timestamp: 1740379431762
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 345073
+  timestamp: 1765813471974
 - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
   sha256: 8dc54e94721e9ab545d7234aa5192b74102263d3e704e6d0c8aa7008f2da2a7b
   md5: db0c6b99149880c8ba515cf4abe93ee4
@@ -7867,713 +9191,716 @@ packages:
   - markdown-it-py>=2.2.0
   - pygments>=2.13.0,<3.0.0
   requires_python: '>=3.8.0'
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-msgs-2.0.3-np126py312h3bd2861_10.conda
-  sha256: 1b8a875e47775e899830d48cfccb1d258d3bfd702f69914ccc49567fc467e8b5
-  md5: ff46c9e8166e2255a2c9830e9bc6c4a7
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.0-np2py312h31f38b3_14.conda
+  sha256: cd18ce49b10f009de08053c8c217cd6c258b9615bab1e88bed7a6b008c67fd62
+  md5: e52f361b2e40fd23c662f37c0441bf09
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-core-runtime
-  - ros-jazzy-service-msgs
-  - ros-jazzy-unique-identifier-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  size: 152182
-  timestamp: 1759136410687
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-tutorials-cpp-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 42394ed6055911a94144e22a54d01a70b8a026ae3b63629b1ea20fe21caa8eb2
-  md5: b974a86265d34d423493372ef38d4342
-  depends:
-  - python
-  - ros-jazzy-action-tutorials-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-action
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  size: 132333
-  timestamp: 1759138528614
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-tutorials-interfaces-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 611ee2fb1a961f5a87d80e871f50664a6dc54cd46f8b606c88e0586b1b319e2c
-  md5: 264e7c8c2ccad2f44ed21dfacfb88714
-  depends:
-  - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
-  license: BSD-3-Clause
-  size: 184860
-  timestamp: 1759136622678
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-tutorials-py-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 09f18ea6710a39258ab1a018eccd81c5b614155199b2d1d9eead6ff57403b38e
-  md5: 580f84d14bfaa668b0be3b8cbe6a419b
-  depends:
-  - python
-  - ros-jazzy-action-tutorials-interfaces
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-core-runtime
+  - ros-kilted-service-msgs
+  - ros-kilted-unique-identifier-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 30726
-  timestamp: 1759138254116
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-actionlib-msgs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: 32de8131c73f7198b2e5d0cf6fed066d3888451bb53aa4833a131780f27fb981
-  md5: 4b2a4459c8af98c31ae1348e8352d5cf
+  size: 150594
+  timestamp: 1759312218237
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-tutorials-cpp-0.36.2-np2py312h31f38b3_14.conda
+  sha256: 049d83f96e5230b90bc1eb47a85a088804a1d6ccf1da89abfbe0b5a1ab3273d9
+  md5: 4ca42be1e179caf0c485e2db34cabd9a
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-example-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 136059
+  timestamp: 1759314385799
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-tutorials-py-0.36.2-np2py312h31f38b3_14.conda
+  sha256: 50c67f9ed5f0b7aa1db1d25a5d5fc5b3554be702a6bd35c4270df70e4a8cbe90
+  md5: 0516461d7d20ff90c2093234317350f2
+  depends:
+  - python
+  - ros-kilted-example-interfaces
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 111170
-  timestamp: 1759136885319
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-2.5.4-np126py312h3bd2861_10.conda
-  sha256: da8dd702f6b270346c303f855cbcddc73e3cb2cc2a5e0b3d7c1dc22dce44702a
-  md5: d515c31f480d0de07aa5d21786600ac6
+  size: 24682
+  timestamp: 1759314102631
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: a7d56065e588aab4fa33a1217afba9e2a40afae7b1aa6b65fca9d33c59a930b0
+  md5: ebc4798ee4b706b95edf35bfaf136f85
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-cmake-export-definitions
-  - ros-jazzy-ament-cmake-export-dependencies
-  - ros-jazzy-ament-cmake-export-include-directories
-  - ros-jazzy-ament-cmake-export-interfaces
-  - ros-jazzy-ament-cmake-export-libraries
-  - ros-jazzy-ament-cmake-export-link-flags
-  - ros-jazzy-ament-cmake-export-targets
-  - ros-jazzy-ament-cmake-gen-version-h
-  - ros-jazzy-ament-cmake-libraries
-  - ros-jazzy-ament-cmake-python
-  - ros-jazzy-ament-cmake-target-dependencies
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ament-cmake-version
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 110446
+  timestamp: 1759312573379
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 655ae089e73b91f28d62ce86c40c9a527bc42be2aa00df54800a353d448f4ed0
+  md5: 93fe4f1d8371e1fda1b340fd6c24d995
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-export-definitions
+  - ros-kilted-ament-cmake-export-dependencies
+  - ros-kilted-ament-cmake-export-include-directories
+  - ros-kilted-ament-cmake-export-interfaces
+  - ros-kilted-ament-cmake-export-libraries
+  - ros-kilted-ament-cmake-export-link-flags
+  - ros-kilted-ament-cmake-export-targets
+  - ros-kilted-ament-cmake-gen-version-h
+  - ros-kilted-ament-cmake-libraries
+  - ros-kilted-ament-cmake-python
+  - ros-kilted-ament-cmake-target-dependencies
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-cmake-version
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - cmake
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 23133
-  timestamp: 1759134416228
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-auto-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 457ce4b76dd74c939acbcd9938c454042c2462e4ab9222426aad89bff89708b1
-  md5: 7e5141f0b6cb15905e5cf03d3d5c05b7
+  size: 23168
+  timestamp: 1759310455644
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 7d36c04270cc05783e324bbb8db94e8b0eb9c3e31960ef45ce96ff54ebb1033f
+  md5: 1e2317e986a13ba3317d4b2d6e6f1201
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ament-cmake-gmock
-  - ros-jazzy-ament-cmake-gtest
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-cmake
+  - ros-kilted-ament-cmake-gmock
+  - ros-kilted-ament-cmake-gtest
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 27239
-  timestamp: 1759134487157
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-copyright-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 8a4a685ddd9192f70d514028e3284569e0b2da454fc8bb8744ce3c8c28214a21
-  md5: 74aaf390755615f89bad8e5765748805
+  size: 28036
+  timestamp: 1759310565166
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h31f38b3_14.conda
+  sha256: f28bec131639d03b23da4df063fe2ec781e1d496fae29c5c323fc721c7d1b2f2
+  md5: 7824ce4c5d5b9f1f74677556a686f490
   depends:
   - python
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ament-copyright
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-copyright
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 22540
-  timestamp: 1759134598637
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-core-2.5.4-np126py312h3bd2861_10.conda
-  sha256: fbdb102ca21ac8339b407cd5e95194ad38b6de823f3ab343ec3078f7b56a7621
-  md5: 1320afd8f5ac3e13de730ae0b3a24036
+  size: 22556
+  timestamp: 1759310796509
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-core-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 42d5ae7c3bb4d3c8e7d22cb0b64334d274ad293c638d44296ddfd17f5fd6d540
+  md5: 8427fcc2bc26afc6387bd0115f5f4565
   depends:
   - catkin_pkg
   - python
-  - ros-jazzy-ament-package
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-package
+  - ros2-distro-mutex 0.12.* kilted_*
   - cmake
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  license: BSD-3-Clause
-  size: 44602
-  timestamp: 1759133832453
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cppcheck-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 057fd3c14e6816725bd9649a92a7d01abda25c4edda6e662d956a34041ce645d
-  md5: a469fee178503acbc9691d10f4682489
-  depends:
-  - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ament-cppcheck
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  license: BSD-3-Clause
-  size: 24145
-  timestamp: 1759134739203
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cpplint-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 5865778dd7d0ab8dcc2847dc5daa26216720f44c769e776ae19be58ee08fa610
-  md5: cea76e84cdc5a61005e7bfdf5659bd4d
-  depends:
-  - python
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ament-cpplint
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 23166
-  timestamp: 1759134782570
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-definitions-2.5.4-np126py312h3bd2861_10.conda
-  sha256: ef005d7fb3bac97e56f95b9b7771bb69dc226574d9e282abfc499c04052e4c31
-  md5: 70d6722a575b2457fa58daab5c2badb5
+  size: 44776
+  timestamp: 1759309988709
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 60123d833f1f06352370c62d12d1b396c42df4ad5f4a544353e7c475817d4373
+  md5: c33226238dd317e68dd9abb4d531f5c4
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-cppcheck
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 21928
-  timestamp: 1759133959384
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-dependencies-2.5.4-np126py312h3bd2861_10.conda
-  sha256: bb05409ba9a68e3eeec6e8fd811f957191fedbb42d5511dfb7dbb1a24dacf65d
-  md5: 591a40185a935ba5d1663db318d59309
+  size: 24194
+  timestamp: 1759310838992
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h31f38b3_14.conda
+  sha256: fcee0a0eb0de258dee48ebc9da8609608f43ea516a9573950ba84fbb5395057f
+  md5: 8aa094c06618c80168014a9e577a272a
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-cmake-libraries
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-cpplint
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 22822
-  timestamp: 1759134075185
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-include-directories-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 1ab6d0ccb814415bab5c4def1065a63f71764314ffd261e65ffddcb5e79dc110
-  md5: 2c6d7567d6ff94d0d4f3d31590a65b3b
+  size: 23198
+  timestamp: 1759310867159
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-definitions-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 7a712b0bfae69e3cf7bab6c62408067414929041d31f397b18fb542985e19a8d
+  md5: af0947d07d7f41ba77ad0cbb83ab0f77
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 22313
-  timestamp: 1759133955377
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-interfaces-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 2b1487576c4f83cfe3de7deb8fa618a124e0757877a3748fba5675db3794d9b8
-  md5: 9bd5f96a85e35c2f769f4281d6e6215e
+  size: 21901
+  timestamp: 1759310115932
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-dependencies-2.7.3-np2py312h31f38b3_14.conda
+  sha256: ffa490ac1d0ddffc72b1a0f8b608de0461f35362e299adf2b4f74ab781ffbab3
+  md5: 36fd57ccf93b406b92f108f1f9c00183
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-cmake-export-libraries
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 22521
-  timestamp: 1759134052942
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-libraries-2.5.4-np126py312h3bd2861_10.conda
-  sha256: f9947aeb9a7af1e95ab85bf6f6fd308ba24600ea30d0322f88032917903e3089
-  md5: 23e5475abbc527069e52a58b97bc1301
+  size: 22812
+  timestamp: 1759310178470
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-include-directories-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 6550b746bd6696f9c8e8dbc2c3afeb6b2aab20d5a6b0b2ad4dcb6c225473912a
+  md5: 7bb1fe2bad3c9b4bf25084834d21e502
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 22320
+  timestamp: 1759310111792
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-interfaces-2.7.3-np2py312h31f38b3_14.conda
+  sha256: c5696223a395d7e602440008a5b940809555d023dc7b29cd307c6d68857fa0ce
+  md5: 95b30aca364718936368582c7103247b
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-export-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 22513
+  timestamp: 1759310159533
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-libraries-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 61fd213b35c4f16d97e2cb57eee1223fe2481cba6220bd0c7e9710de363a24ca
+  md5: b6a7d48258c020ce7702e3578105a315
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
   size: 23851
-  timestamp: 1759133934452
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-link-flags-2.5.4-np126py312h3bd2861_10.conda
-  sha256: a2e1c9fd6734c3dfb52e7d9354d2e4664740a5e26a2e01497e7e0fffdd5f2add
-  md5: 4bf8e57b7f3d0f39d61cb914342eeac6
+  timestamp: 1759310089240
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-link-flags-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 78d7853c47d9798826bbc597e2fffe7cdfda49e2572707df118b23bc5fcd2c86
+  md5: 38773b52ea4a4a07d18e23b3cbfbb1bb
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 21862
-  timestamp: 1759133951470
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-targets-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 9284f224865194d32c95be170377ea6fe82692fd23523465b64ff8cbba7d46fc
-  md5: 3435ad804d61112efa0ad8bc67fe9ba8
+  size: 21834
+  timestamp: 1759310107706
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-targets-2.7.3-np2py312h31f38b3_14.conda
+  sha256: fee7a5d10ca6fe9a7e56b2a7066a6bae3dbb096981ebc6fce42a54b077ca7e53
+  md5: fe6e58e38c45eca2b38ecf59c502ee3c
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-cmake-export-libraries
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-export-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 22622
-  timestamp: 1759134083673
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-flake8-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 7e4323ab2ada33f1109077261c55f7b3ce6fef33a72889735d7c718f3d3028ae
-  md5: 3ab7241cb3e4e32bb68ee4bb0bbd9bf0
+  size: 22669
+  timestamp: 1759310186815
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 2ad24c10ad38f50b8f6c7da46462d6b47a745c5307404b233cd5ec21060ba044
+  md5: abacf69c75952174b525451d5c1049b7
   depends:
   - python
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ament-flake8
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-flake8
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 24166
-  timestamp: 1759134777625
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gen-version-h-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 68f86ebc83c162fe616c37e66a2b39a36a844bee11deccb1bd31b610fe441f4c
-  md5: 10f12182fabce09e326bc28635921582
+  size: 24219
+  timestamp: 1759310862883
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gen-version-h-2.7.3-np2py312h31f38b3_14.conda
+  sha256: fd8e51b5a68c7f228717a05a9a24e56b9a35fa4401c6d8c93018902542ada564
+  md5: dad988f521babe21dbdb644bfa79a9f8
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 24657
-  timestamp: 1759134302877
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gmock-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 89e91f052b66ddb4f9f722159be85d619a270ad14665c535caad4400a780b094
-  md5: 53e5c1cbb0c3a4c439507e0eff40a40f
+  size: 24634
+  timestamp: 1759310369249
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gmock-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 2f9cca54ed78a441292724d8607d53d4ec7f1ed60c187c7536e6a1d17405172b
+  md5: 1eab53054c54beaf69419148eb3c8cc7
   depends:
   - gmock
   - python
-  - ros-jazzy-ament-cmake-gtest
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-gmock-vendor
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-gtest
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-gmock-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 24766
-  timestamp: 1759134310146
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gtest-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 3271e75e2695121cfed4fefba600e41e405bdb751396bf6fb6c7d50f37d36209
-  md5: 2fbc03a4d11983ef7e2e7d45007bc5c4
+  size: 24741
+  timestamp: 1759310376966
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gtest-2.7.3-np2py312h31f38b3_14.conda
+  sha256: a14fc08bd9e1cc0b499d265c0f0c84ec002cb7e2f406eb8443886c3bbb07c677
+  md5: 693ad1a55c189b784dc41f95252f5e74
   depends:
   - gtest
   - python
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-gtest-vendor
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-gtest-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   - gtest >=1.17.0,<1.17.1.0a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 24522
-  timestamp: 1759134185222
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-include-directories-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 7193e6896a70e5f3d0d2b233dd1efade6ddc35e896fa5f1a2993152aaff552b0
-  md5: 40e460086dd375ef4096cc352f95eece
+  size: 24511
+  timestamp: 1759310272596
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-include-directories-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 5082021f5d3816f5b2f530601413ab86339787d1e40d3f21f7606e19dd4044a3
+  md5: f7ce3467cf35a0aad792b7be91deb5ea
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 21789
-  timestamp: 1759133966450
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-libraries-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 4e7c17261e8fb54c91202c4b01948b067f9e531f8f8d96965208447e41d4aa9d
-  md5: 7cafa7a9acb195a46c7800d859a23c47
+  size: 21775
+  timestamp: 1759310119158
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-libraries-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 614051815762326781d485ccafe4733b29ee883a55e6bb1830a9e957cba6674b
+  md5: 59a0c875934a062dac20075088c5faaf
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 21459
-  timestamp: 1759133962441
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-lint-cmake-0.17.3-np126py312h3bd2861_10.conda
-  sha256: c95829ab3e08b0ca9efd0105009305df3d4984554a84055d530e626ef2b242ba
-  md5: 9de96e0a472ed377c64c51df60e3ec14
+  size: 21474
+  timestamp: 1759310115135
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 1d5a8ff385490a6b799ce92dde3a2d9193de318d0d622de8a1dc28a4033ec778
+  md5: 381804aaec3614dcc5c7b457750806fe
   depends:
   - python
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ament-lint-cmake
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-lint-cmake
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 22234
-  timestamp: 1759134486649
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pep257-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 48272f00f6f83b3cca6c12cb4016bddddd51bf5c88af2b9e22b12469e43ad8fa
-  md5: f2fa0bbb788526a5b363a2bc36134b4f
+  size: 22242
+  timestamp: 1759310656926
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h31f38b3_14.conda
+  sha256: a659f5b1b1d63556106a0c5ad3ea5cc5da27a728d9e32b2dd4e23cc9c0b5e783
+  md5: b086d5f55ce453bdf37a4e71f54059b1
   depends:
   - python
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ament-pep257
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-pep257
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 22947
-  timestamp: 1759134772680
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pytest-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 686c39b6ccacc370d982e53e6510c7ecafd60ce5fdff55d35548660a12ee4175
-  md5: f0d8dba6c1ae9e31ae548f785ec377a5
+  size: 23010
+  timestamp: 1759310858362
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pytest-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 9c78c02a4eb278b9a5a33e57d25d96b4760695505c818ab69224ebb30ea7dad6
+  md5: 5500d104b5648493a87b9b45d652c205
   depends:
   - pytest
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 24660
-  timestamp: 1759134171332
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-python-2.5.4-np126py312h3bd2861_10.conda
-  sha256: d8ed05e93039229c49afe5a211c98128cecdea9bc32880947b126bba4a44d5ea
-  md5: 2dfe91c923a3c63f5a374e94dec1fbe8
+  size: 24697
+  timestamp: 1759310288864
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-python-2.7.3-np2py312h31f38b3_14.conda
+  sha256: d3e66a6cdf9012e7c56021c206b07c5e9eaec1097131430304f60f42fa93d70c
+  md5: 30f7187aadea517d1146494467bc9665
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 24026
-  timestamp: 1759133950758
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-ros-0.12.0-np126py312h3bd2861_10.conda
-  sha256: 5e30081736cc5715c1c50ace6fe4fdcda97db043af8a87d52963c64eda90aab2
-  md5: 5675917194d623b947c721b891ca90a5
+  size: 24035
+  timestamp: 1759310103246
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-0.14.3-np2py312h31f38b3_14.conda
+  sha256: 5cb9213909920a230e60fdc7dfdd1997c2db21eef3bed9a90175a0ee7eae0315
+  md5: e25a3e1a0a0b7044299aca5490a144da
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ament-cmake-gmock
-  - ros-jazzy-ament-cmake-gtest
-  - ros-jazzy-ament-cmake-pytest
-  - ros-jazzy-domain-coordinator
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake
+  - ros-kilted-ament-cmake-gmock
+  - ros-kilted-ament-cmake-gtest
+  - ros-kilted-ament-cmake-pytest
+  - ros-kilted-ament-cmake-ros-core
+  - ros-kilted-rmw-test-fixture-implementation
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 31057
-  timestamp: 1759135157872
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-target-dependencies-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 5af99e38e0f12bcff9d88c8dad6aa594662e01e7641a5679e05202e3fff31d0b
-  md5: 2bc3c4d9b2fd625252b6655ac991abcd
+  size: 31046
+  timestamp: 1759313333614
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-core-0.14.3-np2py312h31f38b3_14.conda
+  sha256: 4323a97346acd931116a44a05cb76709970beda53df267d55525c16ff6182216
+  md5: 016877a4b66946c7fe8be4c7d65f7842
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-cmake-include-directories
-  - ros-jazzy-ament-cmake-libraries
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 23452
-  timestamp: 1759134079465
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-test-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 3218389dab2fe118003bb27856a54c427967d202cd065b817407adaa12892fab
-  md5: 6a9e03a04772d82d44a36f3f99691164
+  size: 26644
+  timestamp: 1759311214649
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-target-dependencies-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 2546cf8bb1c363e136bc3ee7490513b61c13e95e954ae50c558121c7ffb4feaa
+  md5: 07675de162127309194ef3d24b4868ae
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-include-directories
+  - ros-kilted-ament-cmake-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 35962
-  timestamp: 1759134067824
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-uncrustify-0.17.3-np126py312h3bd2861_10.conda
-  sha256: d161b232b731ffc4433514861e96319c43d4554dc3e01c42ca10e30e2b23dc38
-  md5: 63639073778df79369ef6585977371bd
+  size: 23726
+  timestamp: 1759310182651
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-test-2.7.3-np2py312h31f38b3_14.conda
+  sha256: c8262a85a40b5ad8daa206e4e62684238057cb783aed504b8ff56a935c943b83
+  md5: 4e8eeba9d33555a3a75a3bdebe773987
   depends:
   - python
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ament-uncrustify
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 23554
-  timestamp: 1759134766752
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-version-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 421c9f272d211494564851ac1edc2cc3cc8da813a35006bb1b8a6af4e697fe47
-  md5: e4a57c0d18ec4b143c866d979bb74550
+  size: 35917
+  timestamp: 1759310171028
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 51479f0e53cbc3fc00ecd32a6d9f91ff3ffda991462a066fb4c4649d7a798a94
+  md5: ce61617820d4235ec9ee18e786795e29
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-uncrustify
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 21647
-  timestamp: 1759133947231
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-xmllint-0.17.3-np126py312h3bd2861_10.conda
-  sha256: fbb8dbff45ba3f21300bc33d7cc4ad6db3c58f184ec9a5965139922a7989c1d1
-  md5: 28d611b42482111174aeecf6fd3a4d59
+  size: 23541
+  timestamp: 1759310853837
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-version-2.7.3-np2py312h31f38b3_14.conda
+  sha256: 1d0361d181e73dcebbdcc906428234546853e2839d96350d7c12eb0bae0f6d41
+  md5: 2f75a3741d942114263af08f9ad29592
   depends:
   - python
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ament-xmllint
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 22878
-  timestamp: 1759134752915
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-copyright-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 3540bc6881fea171074bf2bd3d06532e853cbc62541ad1781056ead5cc405527
-  md5: 191c3e8515f29479e25c9ec9af67d374
+  size: 21663
+  timestamp: 1759310103478
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h31f38b3_14.conda
+  sha256: c1cb8ddd4d9c050b32574a8a0b869a5f509615680e83addba3c0f6d87c1fb019
+  md5: 12b04af15ca70b0450b9008472b63049
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-xmllint
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 22863
+  timestamp: 1759310840078
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-copyright-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 79ff1ca3603a57f36cc29b287a1dd8529774c0ececab7c56102e854ea4140ac1
+  md5: 5e0bc4382c60416d6ec9925d0f25011f
   depends:
   - importlib-metadata
   - python
-  - ros-jazzy-ament-lint
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-lint
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 66384
-  timestamp: 1759134288237
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cppcheck-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 0d1c849eca4bbd215658bdbc0d7e714fd541353f4b3a651e0c0320524a4e1b9f
-  md5: 1a428d58bd65774b99fb4b6541645674
+  size: 66495
+  timestamp: 1759310354532
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cppcheck-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 02a66d81cfb70657694267e24d340935455ad9db62cacc4b929fba3f654eea80
+  md5: 0d735e1178ac2f1cfb50d011d083c14a
   depends:
   - cppcheck
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 29727
-  timestamp: 1759134435250
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cpplint-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 558550657ad4de03cda5c0bc5c26ca6ccde42994e1da73bc699205e000221a4e
-  md5: 70a9e0c4c63f464b9cab132720a17f13
+  size: 29968
+  timestamp: 1759310683612
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cpplint-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 406abdfd444b2054ac37abe804d73a19245a5dd65461027ba37d39fee08de267
+  md5: ab2da246a014f20a58b1004b874ee3a3
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 168508
-  timestamp: 1759134429635
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-flake8-0.17.3-np126py312h3bd2861_10.conda
-  sha256: e14771d2b63d98fbf81fc85199e756cf6f57b9302d6e9f6574aec518d4e86f85
-  md5: 0ee380510b6161bde6021ae0b6409624
+  size: 169132
+  timestamp: 1759310579688
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-flake8-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 34c77fc70ffde7f4938dff9b9cd3992375a43132ab3c369865a00dffe2fc2fd0
+  md5: c49bbd2075ce45dd98ab0437da85521d
   depends:
   - flake8
   - flake8-builtins
@@ -8582,5872 +9909,5975 @@ packages:
   - flake8-import-order
   - flake8-quotes
   - python
-  - ros-jazzy-ament-lint
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-lint
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 28199
-  timestamp: 1759134054135
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-cpp-1.8.1-np126py312h3bd2861_10.conda
-  sha256: e833b1bec68df1eb14c0762ae19b569916c1f430f63b3f15f66dd9b15d3d3e68
-  md5: 8455c02a66a9c9007b3655adb6d17d0f
+  size: 28173
+  timestamp: 1759310158077
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-cpp-1.11.0-np2py312h31f38b3_14.conda
+  sha256: af537a085cb2385c8fce62bd069ae996e03c172c09d97377c9ec9fb6aa1772da
+  md5: 02bbfa670f703638a72aef28d332b60d
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 46717
-  timestamp: 1759135470380
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-python-1.8.1-np126py312h3bd2861_10.conda
-  sha256: 0495ec46605fbb98ff48cbbaa32db1ec06d2184bb9d35f7a8ad196f60baf09d4
-  md5: 631a7aecb0be6a68f940d599500d3f1b
+  size: 46307
+  timestamp: 1759311536638
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-python-1.11.0-np2py312h31f38b3_14.conda
+  sha256: 6390244c4c5af3c6974a623625aa9793acc8d657e1f5238de14a9a1ef863e547
+  md5: 5ca3f188e7a1b156a94022991b4a27ee
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 29534
-  timestamp: 1759134402900
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-0.17.3-np126py312h3bd2861_10.conda
-  sha256: fd143a729d7931fcbbdb8a75fbbbb836cca851377f9ce57818bb5696c12969e7
-  md5: 3dd09189cde6cc9dff17c0df07386914
+  size: 30342
+  timestamp: 1759310670879
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 219c8cf79dd3dbd3ab4b606fd0c662cae54d3626d672cd4e57f11d4211332b1d
+  md5: 03136b50eab0f0424d6c7d1879ea7261
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 17540
-  timestamp: 1759133935127
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-auto-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 913abc207b5ab235471d2a9a5778ab11abfc94669628603244b7bd624f7236fc
-  md5: c836fde9af8088682b0b27e4682b6f67
+  size: 17521
+  timestamp: 1759310088415
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-auto-0.19.2-np2py312h31f38b3_14.conda
+  sha256: fb2f5502c08ba422a8a17e7b44ee1c4e695e33aefb1dbac96419a9190c06bb16
+  md5: cfc619d5f4f2a39327c0f942c403a813
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 21888
-  timestamp: 1759134202194
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-cmake-0.17.3-np126py312h3bd2861_10.conda
-  sha256: a77728c9d0b7dce62b324edfeaac0d4395ae2391778bc545ddb4de37b9824606
-  md5: 0f624e9729b1f7ebc15a838cccb2de4f
+  size: 21874
+  timestamp: 1759310284831
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h31f38b3_14.conda
+  sha256: bbd319c143202f8e707300384a9329ad8d9ea29df07ed9996d35ecf310b83aec
+  md5: ccf540c0176e1d71d5cd107967a14249
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 39292
-  timestamp: 1759134402296
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-common-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 3bd63f96d48e299a7c740819d50eb07b2a2a58fd675d377bca9a7d81544ad2ed
-  md5: 818fc97317ef6ce402483b8ea4287cc9
+  size: 39556
+  timestamp: 1759310549075
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-common-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 3c375ab20249d8ac5bdead4c764b6dea9689fc244ddb281c63451e68392cdfe3
+  md5: eb179678bb7ee1431bbfae04c0c53b63
   depends:
   - python
-  - ros-jazzy-ament-cmake-copyright
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-cmake-cppcheck
-  - ros-jazzy-ament-cmake-cpplint
-  - ros-jazzy-ament-cmake-flake8
-  - ros-jazzy-ament-cmake-lint-cmake
-  - ros-jazzy-ament-cmake-pep257
-  - ros-jazzy-ament-cmake-uncrustify
-  - ros-jazzy-ament-cmake-xmllint
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-cmake-copyright
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-cppcheck
+  - ros-kilted-ament-cmake-cpplint
+  - ros-kilted-ament-cmake-flake8
+  - ros-kilted-ament-cmake-lint-cmake
+  - ros-kilted-ament-cmake-pep257
+  - ros-kilted-ament-cmake-uncrustify
+  - ros-kilted-ament-cmake-xmllint
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 22182
-  timestamp: 1759134824441
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-package-0.16.4-np126py312h3bd2861_10.conda
-  sha256: aba2a3caa178275121077d78eaa0bb543ca78a15fad489ef0934440cf1384818
-  md5: 219e221ff912c30fa84d10e21e67ad16
+  size: 22168
+  timestamp: 1759310894021
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-package-0.17.2-np2py312h31f38b3_14.conda
+  sha256: 15e167a6b89e9ed7cf01ff318b804ae02f088cef8471684f8d4c3471f4a52ad4
+  md5: 7308f3713b5501ffe45b5df37815c928
   depends:
   - importlib-metadata
   - importlib_resources
   - python
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros2-distro-mutex 0.12.* kilted_*
   - setuptools
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 42819
-  timestamp: 1759133819428
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-pep257-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 054807a1024f4e016c28d5996d0a6913a83c39aa54fdcfb68ea7c593315d882b
-  md5: 36c3e341e6316533dcd10526dc37f302
+  size: 42860
+  timestamp: 1759309976878
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 21159cd020b47ee77a503fb3f056b085ce65d856fa477f34c2c33236ed2d9719
+  md5: 161b3846330a276fd04b1190dc433633
   depends:
   - pydocstyle
   - python
-  - ros-jazzy-ament-lint
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-lint
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 26874
-  timestamp: 1759134170804
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-uncrustify-0.17.3-np126py312h3bd2861_10.conda
-  sha256: 6a8c9a9fc05d6e70751464a626e8ad7db197781b17cb4a22b4aa00b160e683e7
-  md5: b320c684c834fab56dbec576acc8937f
+  size: 26881
+  timestamp: 1759310258025
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h31f38b3_14.conda
+  sha256: 304666d2acaa8fc15cc41d0751c13f6b42d0ccb5eb4d2752a29d23113d88c0e7
+  md5: e74ad16efc5044beb4bdd5d2f0b1889e
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-uncrustify-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-uncrustify-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 67974
-  timestamp: 1759134614981
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-xmllint-0.17.3-np126py312h3bd2861_10.conda
-  sha256: d90654f8fc6d81d96dc0dda64c978275ef1249b8876271d007c05bb38a69a52f
-  md5: b02d4a6562f12b2ee42984e6523c474c
+  size: 68203
+  timestamp: 1759310678260
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h31f38b3_14.conda
+  sha256: e72b73dba680d925aa7acc96c2e5af7a8ea5c322b3fb91aabdaaab7c5e380d72
+  md5: 002220547fe4ee68462dc622c69f7a17
   depends:
   - libxml2
   - python
-  - ros-jazzy-ament-lint
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-lint
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 27918
-  timestamp: 1759134423741
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-angles-1.16.1-np126py312h3bd2861_10.conda
-  sha256: 9cdb0608062c540952abd7e2fcdca543a9d11436d72351bdabdaaa1da9f0c5df
-  md5: 2160deca977b5174682ef4c0557ceb96
+  size: 27906
+  timestamp: 1759310441032
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-angles-1.16.1-np2py312h31f38b3_14.conda
+  sha256: f6e87c7ab2caa5a2b61ed7b52e58e571f9d71fac7d10e7e4bc010c1826dc602d
+  md5: 54c8454b6a713512351de2e40360baa3
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 33829
-  timestamp: 1759134515576
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-builtin-interfaces-2.0.3-np126py312h3bd2861_10.conda
-  sha256: 61591684d33300b93566ad1cca53a3650ec16733ae4a68cd032e4f20812d03ce
-  md5: 01a602042c395cf018dabdadd12482ac
+  size: 33817
+  timestamp: 1759310586944
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.0-np2py312h31f38b3_14.conda
+  sha256: 507b42d73b4d9ce9259899bfb13e07a86fea50b92e7490ec891c5a252a2274f0
+  md5: 83c58dc63deca446446399c0413f3a72
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-core-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-core-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 79473
-  timestamp: 1759136335359
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-class-loader-2.7.0-np126py312h3bd2861_10.conda
-  sha256: be0277d168c4d3b5496569c5efdc5b79caafad2ce5997e57f1b033f7ec413257
-  md5: e3c6ff36d580c6426ebc93f10e76493e
-  depends:
-  - console_bridge
-  - python
-  - ros-jazzy-console-bridge-vendor
-  - ros-jazzy-rcpputils
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - console_bridge >=1.0.2,<1.1.0a0
-  - numpy >=1.26.4,<2.0a0
-  license: BSD-3-Clause
-  size: 73708
-  timestamp: 1759135857274
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-common-interfaces-5.3.6-np126py312h3bd2861_10.conda
-  sha256: f865a5168219a651a5d40febb0bfd38c9503a30269a53aed842740be4d84718a
-  md5: ec33b0f7639ac1fe6207e7d570a0e3cb
-  depends:
-  - python
-  - ros-jazzy-actionlib-msgs
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-diagnostic-msgs
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-nav-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-shape-msgs
-  - ros-jazzy-std-msgs
-  - ros-jazzy-std-srvs
-  - ros-jazzy-stereo-msgs
-  - ros-jazzy-trajectory-msgs
-  - ros-jazzy-visualization-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  license: BSD-3-Clause
-  size: 26507
-  timestamp: 1759137733906
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-composition-0.33.7-np126py312h3bd2861_10.conda
-  sha256: cb0123db76f0b0d01f30a3cd7ca1ba9647ab9c1a7f416d6c327c79f9f9f528d6
-  md5: e6ac1599e1602f356076bfaa3a7e4c4a
-  depends:
-  - python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-launch-ros
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  size: 324840
-  timestamp: 1759138935288
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-composition-interfaces-2.0.3-np126py312h3bd2861_10.conda
-  sha256: 60009f8ca7a7d52c31a72ea24c173d841d71b38782266e7762eb75c4cd740580
-  md5: 3043bfc380012c98998147d2d467e112
-  depends:
-  - python
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
-  license: BSD-3-Clause
-  size: 224044
-  timestamp: 1759136883969
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-console-bridge-vendor-1.7.1-np126py312h3bd2861_10.conda
-  sha256: a498919faaf268a0d220690dc39a40e6636acf34cc38805e87db5a347aa79436
-  md5: 0cf0cff7381665453727e12cb1bcf831
+  size: 77927
+  timestamp: 1759312158551
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.0-np2py312h31f38b3_14.conda
+  sha256: 1811acc37d8c97bd44c565c90a86c1dd6a64947a8a979bd4da9044d65a98ebf8
+  md5: 804ccaf6b67fa17ab4d7a34e44587a02
   depends:
   - console_bridge
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-console-bridge-vendor
+  - ros-kilted-rcpputils
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
   - console_bridge >=1.0.2,<1.1.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 27417
-  timestamp: 1759135565658
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-cv-bridge-4.1.0-np126py312h5cbfcd5_10.conda
-  sha256: 746243a71ed58d06d689672ebfb530ecdad098d2cb3aa19b9444de312702acb4
-  md5: 08b9fdee47efea0fad4fde93b3e16a30
+  size: 77876
+  timestamp: 1759313392814
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.0-np2py312h31f38b3_14.conda
+  sha256: ac174074f4b9605cb790330eb0ce5a89bfec4e8ae0b8479d64e4bb8fd5c91ccf
+  md5: 8753e25ae443c5bbef0e9ef51901be68
+  depends:
+  - python
+  - ros-kilted-actionlib-msgs
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-diagnostic-msgs
+  - ros-kilted-geometry-msgs
+  - ros-kilted-nav-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-shape-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-std-srvs
+  - ros-kilted-stereo-msgs
+  - ros-kilted-trajectory-msgs
+  - ros-kilted-visualization-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 26471
+  timestamp: 1759313243215
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-composition-0.36.2-np2py312h31f38b3_14.conda
+  sha256: 711e268f2588be464041bcc1297121d29a614340e7c18ea13a0816d8b45e6226
+  md5: 62f0d1cc14a71bd5f226eb2de3c69048
+  depends:
+  - python
+  - ros-kilted-example-interfaces
+  - ros-kilted-launch-ros
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 317098
+  timestamp: 1759314828391
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.0-np2py312h31f38b3_14.conda
+  sha256: 10647d6c676ecfa9434918ddd07672d3ecfa4e4cc8a5022445b5ce12b60f4cb6
+  md5: b3d3d477b97cf3a7c96eb95bb57e5d6c
+  depends:
+  - python
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 229108
+  timestamp: 1759312574886
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h31f38b3_14.conda
+  sha256: 6feb63de78f1aef38bb4ba8685b79d6991e6dae504c346b12d9cc9d5719cc680
+  md5: aa266228f2335ce49a28407fb302d875
+  depends:
+  - console_bridge
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - console_bridge >=1.0.2,<1.1.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 27414
+  timestamp: 1759311606913
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-cv-bridge-4.1.0-np2py312h887a3b3_14.conda
+  sha256: 73b5fc8d77cf46cd04735e1670e9dbee9410a72f4097be539f596b9b8d9fabf2
+  md5: b296fd0b651d0874969e091bbc3901dc
   depends:
   - libboost-python
   - libopencv
   - numpy
   - py-opencv
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rcpputils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-python
+  - ros-kilted-rclcpp
+  - ros-kilted-rcpputils
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - xorg-libxext >=1.3.6,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - python_abi 3.12.* *_cp312
-  - libopencv >=4.11.0,<4.11.1.0a0
-  - libopengl >=1.7.0,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libboost-python >=1.86.0,<1.87.0a0
+  - libopencv >=4.12.0,<4.12.1.0a0
   - libboost >=1.86.0,<1.87.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
-  - numpy >=1.26.4,<2.0a0
-  - py-opencv >=4.11.0,<5.0a0
-  - libboost-python >=1.86.0,<1.87.0a0
+  - py-opencv >=4.12.0,<5.0a0
   - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - xorg-libxext >=1.3.6,<2.0a0
   license: BSD-3-Clause
-  size: 206747
-  timestamp: 1759138428709
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-cyclonedds-0.10.5-np126py312h3bd2861_10.conda
-  sha256: 215189a1a3943b68bffe815fbd28c871f578c40015df68f70bb59fc3d6ee38ea
-  md5: dd85d860da3116391d794ece4dc97c79
+  size: 212690
+  timestamp: 1759314115984
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h31f38b3_14.conda
+  sha256: ff2d6efe581c2c7257e527d5d02bb1205893cba7428db702c1046d1f56bd2eab
+  md5: e748294eb8a1bc67ed697cd5f253c3a1
   depends:
   - openssl
   - python
-  - ros-jazzy-iceoryx-binding-c
-  - ros-jazzy-iceoryx-hoofs
-  - ros-jazzy-iceoryx-posh
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-iceoryx-binding-c
+  - ros-kilted-iceoryx-hoofs
+  - ros-kilted-iceoryx-posh
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - openssl >=3.5.3,<4.0a0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 1199357
-  timestamp: 1759134314376
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-demo-nodes-cpp-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 00ce7632d5ba6ac44918c6c9c0ebeb1fabe8ef8ed166f533c1975bae2a06570b
-  md5: 387bf3e8733bb92bb1288c0fb23a4159
+  size: 1193154
+  timestamp: 1759310381087
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-demo-nodes-cpp-0.36.2-np2py312h31f38b3_14.conda
+  sha256: 778f7fecb6ab4f7964ffaf0ac1049397209ef80bbc5bdd2d2f793d182666e1c8
+  md5: cc64cce71dd3fbca85d8a3728d9ea90c
   depends:
   - python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-launch-ros
-  - ros-jazzy-launch-xml
-  - ros-jazzy-rcl
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-example-interfaces
+  - ros-kilted-launch-ros
+  - ros-kilted-launch-xml
+  - ros-kilted-rcl
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 1250223
-  timestamp: 1759139013297
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-demo-nodes-cpp-native-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 7bb2b269febc1742dceaed6aa356b329c7d5071ca321dfb54186ccf091097001
-  md5: 8f990dd838acfcd16327396f338d1329
+  size: 1242054
+  timestamp: 1759314704839
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-demo-nodes-cpp-native-0.36.2-np2py312h31f38b3_14.conda
+  sha256: afbdff8d4387f2c8e50ca257b8f2016d81a26400561a94c2ea018a5a690681c4
+  md5: 78cddddf626db5252ff3b2e921f1d861
   depends:
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-rmw-fastrtps-cpp
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-rmw-fastrtps-cpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 119980
-  timestamp: 1759138999080
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-demo-nodes-py-0.33.7-np126py312h3bd2861_10.conda
-  sha256: db19e752a133098fe79e7b16bc38d4c98023289c5070f2d6aad963ca8fd8f619
-  md5: 0fbd522da24f1357701bbb010b3876d8
+  size: 116608
+  timestamp: 1759314688071
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-demo-nodes-py-0.36.2-np2py312h31f38b3_14.conda
+  sha256: 28333631f57549e079d443fe18fcc8becd5a612a2cbd0111f8202cf0df6edb20
+  md5: cd7ceaee6e6c3d81394e3c6500ba2308
   depends:
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-example-interfaces
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 43000
-  timestamp: 1759138322806
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-depthimage-to-laserscan-2.5.1-np126py312h5cbfcd5_10.conda
-  sha256: fa2bf1a5ea5d14795541f845466249bb2e17e6611688f3f504be4efaef2b12c9
-  md5: b6e11cdebe95bb00d185ebab67c0626d
+  size: 43385
+  timestamp: 1759314132226
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-depthimage-to-laserscan-2.5.1-np2py312h887a3b3_14.conda
+  sha256: dcf4705c232f9a2b64fb1cb1978075b52568fb2a72bddf4ce792c3b139900556
+  md5: b108c3d35b2b8c8c0a8601df7cf1c264
   depends:
   - libopencv
   - py-opencv
   - python
-  - ros-jazzy-image-geometry
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-image-geometry
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libgcc >=14
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - libgl >=1.7.0,<2.0a0
-  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - py-opencv >=4.12.0,<5.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
-  - libopencv >=4.11.0,<4.11.1.0a0
-  - py-opencv >=4.11.0,<5.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libopencv >=4.12.0,<4.12.1.0a0
   - python_abi 3.12.* *_cp312
+  - libgl >=1.7.0,<2.0a0
   - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.23,<3
+  - libopengl >=1.7.0,<2.0a0
   license: BSD-3-Clause
-  size: 285736
-  timestamp: 1759138489994
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-desktop-0.11.0-np126py312h3bd2861_10.conda
-  sha256: 551776c0cde8ecd6ad9ece55809927cc97f5c8674184d68f58be12d875df01c7
-  md5: ddd5626991c5cb7e72d95f5fbb717b55
+  size: 287014
+  timestamp: 1759314354434
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-desktop-0.12.0-np2py312h31f38b3_14.conda
+  sha256: 5b7951c1cae2d13862e0faa40e95cae9db8674511317fbb64defcd9fee45211b
+  md5: ad6dcf4c28471d6dce95d76b7a15f297
   depends:
   - python
-  - ros-jazzy-action-tutorials-cpp
-  - ros-jazzy-action-tutorials-interfaces
-  - ros-jazzy-action-tutorials-py
-  - ros-jazzy-angles
-  - ros-jazzy-composition
-  - ros-jazzy-demo-nodes-cpp
-  - ros-jazzy-demo-nodes-cpp-native
-  - ros-jazzy-demo-nodes-py
-  - ros-jazzy-depthimage-to-laserscan
-  - ros-jazzy-dummy-map-server
-  - ros-jazzy-dummy-robot-bringup
-  - ros-jazzy-dummy-sensors
-  - ros-jazzy-examples-rclcpp-minimal-action-client
-  - ros-jazzy-examples-rclcpp-minimal-action-server
-  - ros-jazzy-examples-rclcpp-minimal-client
-  - ros-jazzy-examples-rclcpp-minimal-composition
-  - ros-jazzy-examples-rclcpp-minimal-publisher
-  - ros-jazzy-examples-rclcpp-minimal-service
-  - ros-jazzy-examples-rclcpp-minimal-subscriber
-  - ros-jazzy-examples-rclcpp-minimal-timer
-  - ros-jazzy-examples-rclcpp-multithreaded-executor
-  - ros-jazzy-examples-rclpy-executors
-  - ros-jazzy-examples-rclpy-minimal-action-client
-  - ros-jazzy-examples-rclpy-minimal-action-server
-  - ros-jazzy-examples-rclpy-minimal-client
-  - ros-jazzy-examples-rclpy-minimal-publisher
-  - ros-jazzy-examples-rclpy-minimal-service
-  - ros-jazzy-examples-rclpy-minimal-subscriber
-  - ros-jazzy-image-tools
-  - ros-jazzy-intra-process-demo
-  - ros-jazzy-joy
-  - ros-jazzy-lifecycle
-  - ros-jazzy-logging-demo
-  - ros-jazzy-pcl-conversions
-  - ros-jazzy-pendulum-control
-  - ros-jazzy-pendulum-msgs
-  - ros-jazzy-quality-of-service-demo-cpp
-  - ros-jazzy-quality-of-service-demo-py
-  - ros-jazzy-ros-base
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-common-plugins
-  - ros-jazzy-rviz-default-plugins
-  - ros-jazzy-rviz2
-  - ros-jazzy-teleop-twist-joy
-  - ros-jazzy-teleop-twist-keyboard
-  - ros-jazzy-tlsf
-  - ros-jazzy-tlsf-cpp
-  - ros-jazzy-topic-monitor
-  - ros-jazzy-turtlesim
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-action-tutorials-cpp
+  - ros-kilted-action-tutorials-py
+  - ros-kilted-angles
+  - ros-kilted-composition
+  - ros-kilted-demo-nodes-cpp
+  - ros-kilted-demo-nodes-cpp-native
+  - ros-kilted-demo-nodes-py
+  - ros-kilted-depthimage-to-laserscan
+  - ros-kilted-dummy-map-server
+  - ros-kilted-dummy-robot-bringup
+  - ros-kilted-dummy-sensors
+  - ros-kilted-examples-rclcpp-minimal-action-client
+  - ros-kilted-examples-rclcpp-minimal-action-server
+  - ros-kilted-examples-rclcpp-minimal-client
+  - ros-kilted-examples-rclcpp-minimal-composition
+  - ros-kilted-examples-rclcpp-minimal-publisher
+  - ros-kilted-examples-rclcpp-minimal-service
+  - ros-kilted-examples-rclcpp-minimal-subscriber
+  - ros-kilted-examples-rclcpp-minimal-timer
+  - ros-kilted-examples-rclcpp-multithreaded-executor
+  - ros-kilted-examples-rclpy-executors
+  - ros-kilted-examples-rclpy-minimal-action-client
+  - ros-kilted-examples-rclpy-minimal-action-server
+  - ros-kilted-examples-rclpy-minimal-client
+  - ros-kilted-examples-rclpy-minimal-publisher
+  - ros-kilted-examples-rclpy-minimal-service
+  - ros-kilted-examples-rclpy-minimal-subscriber
+  - ros-kilted-image-tools
+  - ros-kilted-intra-process-demo
+  - ros-kilted-joy
+  - ros-kilted-lifecycle
+  - ros-kilted-logging-demo
+  - ros-kilted-pcl-conversions
+  - ros-kilted-pendulum-control
+  - ros-kilted-pendulum-msgs
+  - ros-kilted-quality-of-service-demo-cpp
+  - ros-kilted-quality-of-service-demo-py
+  - ros-kilted-ros-base
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-common-plugins
+  - ros-kilted-rviz-default-plugins
+  - ros-kilted-rviz2
+  - ros-kilted-teleop-twist-joy
+  - ros-kilted-teleop-twist-keyboard
+  - ros-kilted-tlsf
+  - ros-kilted-tlsf-cpp
+  - ros-kilted-topic-monitor
+  - ros-kilted-turtlesim
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 23503
-  timestamp: 1759143393640
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-msgs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: a5cccc345c27213dde73d0cff7a785a08250a01813b29a892adbd7f6c7d6c045
-  md5: 726ff775d169cc0441e200e37b752a1c
+  size: 23472
+  timestamp: 1759319671269
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: 40cd3546e8dca8d233c6126752e5ccf1f3a0b2dc003ce2bdc3ccaff225f47a13
+  md5: 7a08e2ae465d0f2c2a9e6c8202f424c1
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 207181
-  timestamp: 1759137061241
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-domain-coordinator-0.12.0-np126py312h3bd2861_10.conda
-  sha256: a5ff0e936b903f3e86fb2524c6a7f594ab24dac3fad910a53e97b36ae5413637
-  md5: 7c0173e23b895b5be8e3fd15a4a77f59
+  size: 211272
+  timestamp: 1759312649373
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-dummy-map-server-0.36.2-np2py312h31f38b3_14.conda
+  sha256: 8b78da866620aa8eb48a6a6ba800c5b9f0f6c1835dce89a58b64febd0a5be6f0
+  md5: adfe5f994ddda209323407ac8d36433e
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-nav-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 20968
-  timestamp: 1759134414484
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-dummy-map-server-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 8009ce2e11aecc3629d087061782a42edf9eb6b658c349b40e93d8d93db00d9e
-  md5: 7225e2152e7837a604ab1da35ae7a705
+  size: 86521
+  timestamp: 1759314152564
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-dummy-robot-bringup-0.36.2-np2py312h31f38b3_14.conda
+  sha256: c34b01fe518bc8f1c283c5a3b2f7ce4846c5cffc00684a8c10a4a86feb6a9670
+  md5: 2619cbb76d803c07178ace93ea1c1928
   depends:
   - python
-  - ros-jazzy-nav-msgs
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-dummy-map-server
+  - ros-kilted-dummy-sensors
+  - ros-kilted-launch
+  - ros-kilted-launch-ros
+  - ros-kilted-robot-state-publisher
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 89138
-  timestamp: 1759138312095
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-dummy-robot-bringup-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 28aa5f6c44181ddbbc8ddd8a847d28bab5daf59823cc50437fee0f544c019928
-  md5: be0ffa7e3ecd23e47b8a6e768c7da87d
+  size: 30295
+  timestamp: 1759315259846
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-dummy-sensors-0.36.2-np2py312h31f38b3_14.conda
+  sha256: be99769bc2ea7bc8eca9af85ee4e54cd96640199ebd87124e09bc0b441269088
+  md5: b6cc895712d9f1676c16284ed6e9223f
   depends:
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-dummy-map-server
-  - ros-jazzy-dummy-sensors
-  - ros-jazzy-launch
-  - ros-jazzy-launch-ros
-  - ros-jazzy-robot-state-publisher
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 30336
-  timestamp: 1759139562695
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-dummy-sensors-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 2536d356424352750c6d00a12c9dc6fa9d8159caafadf015911c1d11ccfde5d7
-  md5: 75700df5fe7c02b6ddc97ca10a855431
+  size: 119039
+  timestamp: 1759314138503
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h31f38b3_14.conda
+  sha256: 8ec120467ada7c3bb14ba1366f5f42c7ec21850a0a527dd0f2d23e456fec4329
+  md5: d76bb4b688d63b15273a83463790abf2
   depends:
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 118414
-  timestamp: 1759138298663
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-eigen3-cmake-module-0.3.0-np126py312h3bd2861_10.conda
-  sha256: a738c67eb7b3af2dba229eaa0c38198617f1236387b347d3cc5027c65afaca79
-  md5: 4400d09ab5f92b6e3ca1332931bf9399
+  size: 23403
+  timestamp: 1759310868002
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-example-interfaces-0.13.0-np2py312h31f38b3_14.conda
+  sha256: 2f9442a44d99995d42be35f50876ceedbe0da3a7bb8abe9353361c62589a98fa
+  md5: f0de882b741f3f9512626e3c9ee29e72
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 23328
-  timestamp: 1759134760262
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-example-interfaces-0.12.0-np126py312h3bd2861_10.conda
-  sha256: e9341fa475da18f4b97e255fe5c37a0c70590312e311209e209226d9d87453c1
-  md5: ad466ae2b3770b15b7301a412e469d24
+  size: 536161
+  timestamp: 1759312356219
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-action-client-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 7c670ec26fcb22e35c4126e3aab97b9f09ce75360b30d21c924aa4d754cce375
+  md5: c191da7ad842456416636272a9770505
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-example-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 537161
-  timestamp: 1759136591779
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-action-client-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 7ad4a25397b1c5f7cf2eb0762626fc0526cd1dcded84ba911c87fcfe0cc18471
-  md5: cdb561a1bd8c5732056ba3429e8b7685
+  size: 155206
+  timestamp: 1759314339700
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-action-server-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 9207c5349267f9ae40bef3362a32d5de8c910c68a465330b48b83987dbef7d04
+  md5: 6f2d67475370c290259e1bdfd826621e
   depends:
   - python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-action
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-example-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 158211
-  timestamp: 1759138655075
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-action-server-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 73e0a6962c753c100b313177f7b0802eb5777854d5f1f788fcd24334777ee0fa
-  md5: afc4caa8d2c4ad3a5e3baf7a2ad02444
+  size: 88774
+  timestamp: 1759314328282
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-client-0.20.5-np2py312h31f38b3_14.conda
+  sha256: ecc35ba85bd1eced5c66e6dee39356180e738eb2cb6d1bf1835d2ceaf689573d
+  md5: de2a0510641dcce9cc65014885a41443
   depends:
   - python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-action
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-example-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 90438
-  timestamp: 1759138642822
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-client-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 64298e7a69389f00167aa4d5787842c6a1c5da59ba09316a47e94c5b6bbd821d
-  md5: 32aa8c83e87f030ba158ca5f0ff9bcbb
+  size: 66333
+  timestamp: 1759314172012
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-composition-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 2a1346dd06bfe7d030f57da61e5c07531629ab3059007356c74d28c2e8cd09de
+  md5: 8b589041ae0e6788aa5cf0cde57b2e0b
   depends:
   - python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 69947
-  timestamp: 1759138323929
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-composition-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 6239f7c11ff9925820c6a17b57825c4132435727edfe82ad0bf5bbbef91c1f14
-  md5: 521943c2ffc0abd6803f71b8cd7b09ae
+  size: 186283
+  timestamp: 1759314299530
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-publisher-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 19fc329f5a32c1f24760fe71e016d650ad862ca3e3e63638b71593e8f8b37187
+  md5: 9e7a5b805245d0e3ae824ce1b4b1a028
   depends:
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 190367
-  timestamp: 1759138622532
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-publisher-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 8c0f965861e46ddad32d63092652a14c72acacc5098ad7ad2248c32fdd2f724b
-  md5: fffdf857e96a403edd47d212ec836b29
+  size: 198815
+  timestamp: 1759314151720
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-service-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 59966b5f14d0063bdfb8fa82e22c58d4c763e020955e072c77c9b456a1e44cd8
+  md5: 59e434dbee4c7d3129068d575503204e
   depends:
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-example-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 201074
-  timestamp: 1759138302676
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-service-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 27d3a3f62518489deaebbc2a0622cb3db8fcdfce3ce629d27f5a7a4fe823476a
-  md5: 04526ab379bbe28751e144ac6ce1178b
+  size: 58889
+  timestamp: 1759314140897
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-subscriber-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 54061f49f3df0f0b294de388993213b4de6571dd75423f98afd2027afbb0d961
+  md5: 3094c41da71aa775425d46b08541f283
   depends:
   - python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 60388
-  timestamp: 1759138290620
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-subscriber-0.19.6-np126py312h3bd2861_10.conda
-  sha256: bdd52a128236f2530c4d1fb0a7a7ca70e1bbcbcc338b8c56e217525c327d04c3
-  md5: 0db0df355515b3c051a0dd6e5a819c28
+  size: 569808
+  timestamp: 1759314443454
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-minimal-timer-0.20.5-np2py312h31f38b3_14.conda
+  sha256: ddcce566186320c49c43d9d3c602944d72af51345610f2b0e836175a2f5366e9
+  md5: 4f78c1527bf7d62dae2e8607816a5ea6
   depends:
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 573149
-  timestamp: 1759138566088
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-minimal-timer-0.19.6-np126py312h3bd2861_10.conda
-  sha256: d2b09d82cccfdf920bc3e0f08b37fc9eb0a1c74d146739a99136d73b8e43dccd
-  md5: c70c4a39abb3a67dd3414c248fb372e1
+  size: 51058
+  timestamp: 1759314131577
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclcpp-multithreaded-executor-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 381ef9bbf5f034dec2ce759f9cde5316212f13328afa70adb608ef27bbf57969
+  md5: 84e12eaf4581a20eeb57715ebeb76a70
   depends:
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 52604
-  timestamp: 1759138280759
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclcpp-multithreaded-executor-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 4c7ad5a740b1ebb4883aeec6836aac13ca54adae90ab58c1fa6c0ab1d517fe32
-  md5: 2c9c03cab804c152a5e99cf036a5cf6b
+  size: 166062
+  timestamp: 1759314105613
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-executors-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 98ff2fed428eaee1b22251ab41b66b35e3e5f3299c387cdc030e6eee737e0056
+  md5: fed6fc45e9723bd5785ffca75db165fa
   depends:
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 166848
-  timestamp: 1759138253891
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-executors-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 258fd1b3a40f52e57f1fb6f16f090a207b7ce7d80f111f3f2b34e1bb75f7ff48
-  md5: 77eeb82f44f23d270d94a9ef515ebe32
+  size: 27757
+  timestamp: 1759314125115
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-action-client-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 080653587d58ee469a438b3b639d66ad8f8a0fef3920e3c77ab09469015161ed
+  md5: 920a39ae5e509bd12ca67a89aaf32bab
   depends:
   - python
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-action-msgs
+  - ros-kilted-example-interfaces
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 27922
-  timestamp: 1759138276083
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-action-client-0.19.6-np126py312h3bd2861_10.conda
-  sha256: c7e8c00fa2b60356a62d330d05304f42bf7310947d0d7fe26c0c8c2c9a43a018
-  md5: 2a8d180f04625c2b8abbf80143ed8674
+  size: 26930
+  timestamp: 1759314121204
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-action-server-0.20.5-np2py312h31f38b3_14.conda
+  sha256: d5ae9123a39205725a2a63bf25801b4932a60d48c2e82b060a46505b2d230b53
+  md5: 66f32874f7f699c3a7bb01be4bc9bce4
   depends:
   - python
-  - ros-jazzy-action-msgs
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-example-interfaces
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 26451
-  timestamp: 1759138272187
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-action-server-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 46a3cede1c844d820b700b3b475bb282c02f2bc021f979022cd6c2ad002ff839
-  md5: 3764aac26522fb6d54336b0c05ca58ac
+  size: 28031
+  timestamp: 1759314117341
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-client-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 78cb78fd10ad091490d9ec48b153d0114b021f0ed1c8ecf6810f60b41c2fbadc
+  md5: dfa6e27c2e45edd0a65f6a579eb4381a
   depends:
   - python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-example-interfaces
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 27625
-  timestamp: 1759138268081
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-client-0.19.6-np126py312h3bd2861_10.conda
-  sha256: b2e043beb8b6b71b883df9ed7b9538be61fbb895c3289b40915120b1441a9f14
-  md5: 591c98d77af5f4f3d4f19cbe4eaef069
+  size: 24162
+  timestamp: 1759314113156
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-publisher-0.20.5-np2py312h31f38b3_14.conda
+  sha256: a46bd9b752dcd0bc04f372f245d3207d729ad3779cce8cc6f701d32ab9c781c2
+  md5: b2a31f2b9579fdfe8d03e30c2e98bbf3
   depends:
   - python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 23508
-  timestamp: 1759138263648
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-publisher-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 063e9f111f2f06e72c30c742a2bf9fe0b22dba9e96da6e266d74972a997984d1
-  md5: c90bd545e4965b65e122718435a0d074
+  size: 24383
+  timestamp: 1759314102090
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-service-0.20.5-np2py312h31f38b3_14.conda
+  sha256: 0905df268970e62fb677b3501cab65cfbdc9c30b6546af50a4e1fdf8936b024f
+  md5: 10b2da24fc170a9db71b9c763b37b097
   depends:
   - python
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-example-interfaces
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 24046
-  timestamp: 1759138252879
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-service-0.19.6-np126py312h3bd2861_10.conda
-  sha256: a78c4d3ec1e8343e2912b0df653ea533696a7835f7b3a4e485a1945399a2dcfd
-  md5: d9e532122e31e5e6da2313060eab753d
+  size: 21639
+  timestamp: 1759314150148
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-examples-rclpy-minimal-subscriber-0.20.5-np2py312h31f38b3_14.conda
+  sha256: d587ccb07129edb244a05e8529115e25c38660d90d4e92c51b31826cf0b5bab7
+  md5: f8874ef445af2175b55ced5b3baccebe
   depends:
   - python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 21226
-  timestamp: 1759138353354
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-examples-rclpy-minimal-subscriber-0.19.6-np126py312h3bd2861_10.conda
-  sha256: 645b24a82226d2220d3271dea00a6c6f63c60dc9dd2836d1d77fc9400a7fefd5
-  md5: ba768adddaa9a6007c5465be70237482
+  size: 22189
+  timestamp: 1759314143804
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.0-np2py312h31f38b3_14.conda
+  sha256: e230223ee52bc9e79513ac11aafb4221f0d9ccbae9c3263b93312b1eb931b135
+  md5: d49e20a0ffea33e54426f395ec5aeee8
   depends:
   - python
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 21808
-  timestamp: 1759138347383
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastcdr-2.2.5-np126py312h3bd2861_10.conda
-  sha256: 7b4737c7fe822a8449685ba5f57edf6adf9d32e611c8cb4ed0242db0578c6627
-  md5: 658d8fd55a9fdcb15ff5e57708aa0874
-  depends:
-  - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
-  license: BSD-3-Clause
-  size: 88286
-  timestamp: 1759134519610
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-2.14.5-np126py312h3bd2861_10.conda
-  sha256: 758024f49b2848bf43b6f3dff1309a1bd2a6251bbe7194d076e452037d16e457
-  md5: 17195143e89af3cc92c875ea6b057d7c
+  size: 88929
+  timestamp: 1759310549615
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.2-np2py312h31f38b3_14.conda
+  sha256: 52a03e592d1fd974d0aacf95b4a01957bda6b4489cc37d41d7eda121f9eb08fc
+  md5: 330a79d74a4959daa6c4a99dbdbe4093
   depends:
   - openssl
   - python
-  - ros-jazzy-fastcdr
-  - ros-jazzy-foonathan-memory-vendor
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-fastcdr
+  - ros-kilted-foonathan-memory-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - tinyxml2
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - openssl >=3.5.3,<4.0a0
-  license: BSD-3-Clause
-  size: 4289370
-  timestamp: 1759135144417
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-cmake-module-3.6.2-np126py312h3bd2861_10.conda
-  sha256: 0a1e9032d4dc0c628269a4e4745d8f4580c74f324378d6a659afcee5d58ec5af
-  md5: f5db45c7a0798d404cdcbd4b19218afe
-  depends:
-  - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - tinyxml2 >=11.0.0,<11.1.0a0
   license: BSD-3-Clause
-  size: 27248
-  timestamp: 1759135131215
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-foonathan-memory-vendor-1.3.1-np126py312h3bd2861_10.conda
-  sha256: cb8c94ec85adb43f1ad85fabff560bb4d08b41634eaee6f6f5144ed548e1f482
-  md5: cef3439419d6b3f1224b340baf4ddc75
+  size: 4835994
+  timestamp: 1759311189808
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h31f38b3_14.conda
+  sha256: b1e731c5e31966e1eb431ace17a10cc7e47f6f5262fb45448f39ce20ef41533e
+  md5: c6a428ca8ce83ba4fef28cc4ccf582a6
   depends:
   - foonathan-memory
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - cmake
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   - foonathan-memory >=0.7.3,<0.7.4.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 19317
-  timestamp: 1759134837854
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-geometry-msgs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: 98f6fdd49e83b3c82f8a5e4a8ece736d89a4e79e0859bc0a4d5c0932f1ebc8cc
-  md5: b44c3ce4a96fa7db5eea3e27ded3e72b
+  size: 19309
+  timestamp: 1759310914840
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: b049429ab24887be8d0136a3eb1a93dd040f241443f1f5ee593bcee60194a3d6
+  md5: d078d7e4092b717b87fdb82fa11eb7d3
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 377935
-  timestamp: 1759136906913
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-geometry2-0.36.14-np126py312h3bd2861_10.conda
-  sha256: 7be3c543f11cb68a2a4b7054087723145509089ce94feaf4657bc244ad6880e8
-  md5: cc9ffab9ace24cff340d5b4032ec3e3c
+  size: 377094
+  timestamp: 1759312590607
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry2-0.41.2-np2py312h31f38b3_14.conda
+  sha256: b155ba9192f805f0f2efba35c60bc030394fbe06513463202292b28f6d565bc5
+  md5: fa7afadc40498e940a7208f1284ca3ca
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tf2
-  - ros-jazzy-tf2-bullet
-  - ros-jazzy-tf2-eigen
-  - ros-jazzy-tf2-eigen-kdl
-  - ros-jazzy-tf2-geometry-msgs
-  - ros-jazzy-tf2-kdl
-  - ros-jazzy-tf2-msgs
-  - ros-jazzy-tf2-py
-  - ros-jazzy-tf2-ros
-  - ros-jazzy-tf2-sensor-msgs
-  - ros-jazzy-tf2-tools
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-bullet
+  - ros-kilted-tf2-eigen
+  - ros-kilted-tf2-eigen-kdl
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-kdl
+  - ros-kilted-tf2-msgs
+  - ros-kilted-tf2-py
+  - ros-kilted-tf2-ros
+  - ros-kilted-tf2-sensor-msgs
+  - ros-kilted-tf2-tools
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 22328
-  timestamp: 1759139513004
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gmock-vendor-1.14.9000-np126py312h3bd2861_10.conda
-  sha256: 9d5e5875ec8401fb2817326e38beef97b0cbd2756b78fc314993a7c2b44fe95a
-  md5: afcf2ee3fffc54b8b34953e699839bad
+  size: 22313
+  timestamp: 1759315327350
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h31f38b3_14.conda
+  sha256: f2f050dbc1e7f053026e51e607d53cbb64def69c07e38db178970755718bcd1c
+  md5: 8223eeb1fb5247b279a2cbd4a9edb7ca
   depends:
   - python
-  - ros-jazzy-gtest-vendor
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-gtest-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 122315
-  timestamp: 1759134065861
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gtest-vendor-1.14.9000-np126py312h3bd2861_10.conda
-  sha256: 25a1b01f399bcbafb4412ab0b5efe4b90a6b49ea3a637e862cfe0249a4f5c1e3
-  md5: d70d6583728901de9696557fca2f30e5
+  size: 122289
+  timestamp: 1759310174697
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h31f38b3_14.conda
+  sha256: 1c221c912c2f841fd386c6e800dc0eb611d0ddb301348d608148a6ba55374e00
+  md5: 10d812ffa7281e3be081ab50d5e6bc27
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 208735
-  timestamp: 1759133958435
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-cmake-vendor-0.0.10-np126py312h3bd2861_10.conda
-  sha256: a2c28acbd2e65eb9b650b12a05fbc9716f5f9d41fb0f3adb40d26a5aca94d8cc
-  md5: 320feb88e07dd3b22e7dd0c1a506ccd5
+  size: 208724
+  timestamp: 1759310110824
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-cmake-vendor-0.2.2-np2py312h31f38b3_14.conda
+  sha256: c8611f5208c2885b54cd16d6e540379f9ae894159e238ae0c755dc3f9a0ba875
+  md5: f82aaefcb8b4e9a42712c74af56f6af1
   depends:
-  - gz-cmake3
+  - gz-cmake4
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - libgz-cmake4 >=4.2.0,<5.0a0
   - python_abi 3.12.* *_cp312
-  - libgz-cmake3 >=3.5.3,<4.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 24435
-  timestamp: 1759134843754
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-math-vendor-0.0.8-np126py312h3bd2861_10.conda
-  sha256: d69388d02ba36ee0ffa4d898aea8ca1484054df551254eba1f49032e8d40f1df
-  md5: b92b3af57222902f7766a3c8c6f11662
+  size: 23910
+  timestamp: 1759310919801
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-math-vendor-0.2.5-np2py312h31f38b3_14.conda
+  sha256: 9a137dcf2d6751125c1f9d871294f2f5ddea8c2a8457face4df10db85f193bbf
+  md5: 771a7e841cfadd86b4f94278ae059433
   depends:
   - eigen
-  - gz-math7
+  - gz-math8
   - python
-  - ros-jazzy-gz-cmake-vendor
-  - ros-jazzy-gz-utils-vendor
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-gz-cmake-vendor
+  - ros-kilted-gz-utils-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - libgz-math7 >=7.5.2,<8.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libgz-math8 >=8.2.0,<9.0a0
   license: BSD-3-Clause
-  size: 27847
-  timestamp: 1759135546682
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-utils-vendor-0.0.5-np126py312h3bd2861_10.conda
-  sha256: 7910cc33699aa5cc4de352af5ac8b0eda4c5f8b3ed97c1cb78b31cde4c6018ed
-  md5: 8a9cdcb0d0292a5e963aa48a1b7b83a3
+  size: 27837
+  timestamp: 1759311747240
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h31f38b3_14.conda
+  sha256: de337e8a251dbd55118c55d7ec79d00d56bf2109ce5a7ebdaab9e2bd3847ab1b
+  md5: 7df7add25a818260ec0af9218948fe6a
   depends:
-  - gz-utils2
+  - gz-utils3
   - python
-  - ros-jazzy-gz-cmake-vendor
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-gz-cmake-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-spdlog-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libgz-utils2 >=2.2.0,<3.0a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 25766
-  timestamp: 1759135143290
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-binding-c-2.0.6-np126py312h3bd2861_10.conda
-  sha256: a0f6cb479e432c1e49ab9a5baf837e8c2a40c15999b98c1da6db7c4068da15e9
-  md5: c5bd1e766e134b1eba20db9ea3db187b
+  size: 25885
+  timestamp: 1759311573227
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h31f38b3_14.conda
+  sha256: fb5ca1b0e68a9d2255f78fa35589840627fd90ad0dba44a0203bafaaa4bb9770
+  md5: 1153d03f8633c67ff4eaacca65b684ab
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 92732
-  timestamp: 1759134188843
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-hoofs-2.0.6-np126py312h3bd2861_10.conda
-  sha256: 0e863a15142e5da8da31d39a6ea07ab418a02ac10b8a8633d50be231ba9554a3
-  md5: 8bcd51c6a2ef2d39834472111423a5ee
+  size: 90813
+  timestamp: 1759310272385
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h31f38b3_14.conda
+  sha256: 5ea3ceb76ace1d89bb196697f506742ec2ade85cc2b29acdf6f6ceff95fbd424
+  md5: 6d0c0ae3d14e5ed30db042e1749b351a
   depends:
   - libacl
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   - libacl >=2.3.2,<2.4.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 263628
-  timestamp: 1759133934792
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-posh-2.0.6-np126py312h3bd2861_10.conda
-  sha256: a734989bf0b048a932ef9511d1cb1c053d3393fab5904c90927fbb8e3f886578
-  md5: 9147ed0273d8c604324c0831895292e2
+  size: 260866
+  timestamp: 1759310124823
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h31f38b3_14.conda
+  sha256: 22a801bc545035908a1b4d8d2a36de83774e5ebcdd78c181a83d9aa6369d75a8
+  md5: b092f5cc27716b3258ca1ee90a3139da
   depends:
   - python
-  - ros-jazzy-iceoryx-hoofs
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-iceoryx-hoofs
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 573580
-  timestamp: 1759134069976
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-geometry-4.1.0-np126py312h5cbfcd5_10.conda
-  sha256: 8a66b03494174ee3b980c2ab2f99025ab82f3aac0bf05253aa7acd14d66c5f72
-  md5: ce44fa3555d989cec31567510a64ebcf
+  size: 567381
+  timestamp: 1759310179784
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-geometry-4.1.0-np2py312h887a3b3_14.conda
+  sha256: c4ad3b0afaad12db24794010fb650802d295621f721d6cb9bfa37421e513ef28
+  md5: d7c004f4b25d96592e810f63006890fe
   depends:
   - deprecated
   - libopencv
   - py-opencv
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - libopengl >=1.7.0,<2.0a0
+  - py-opencv >=4.12.0,<5.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
-  - python_abi 3.12.* *_cp312
   - xorg-libxext >=1.3.6,<2.0a0
-  - numpy >=1.26.4,<2.0a0
-  - libopencv >=4.11.0,<4.11.1.0a0
-  - py-opencv >=4.11.0,<5.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - libgl >=1.7.0,<2.0a0
+  - libopencv >=4.12.0,<4.12.1.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 88179
-  timestamp: 1759137306486
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-tools-0.33.7-np126py312h5cbfcd5_10.conda
-  sha256: f43eb16626f4cdcc326bb804fd64cf40b8aca099f0a422c727b3c22988007c48
-  md5: 11f059ae4f47bd6151a014ac0c77e6b8
+  size: 90781
+  timestamp: 1759313412034
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-tools-0.36.2-np2py312h887a3b3_14.conda
+  sha256: a4473fcee0da8c3b92605b46a72229c09b71d6bb628d7f3e3d62436192ff4fca
+  md5: 7bb01255ae5af7399c06fae47c90bb73
   depends:
   - libopencv
   - libopencv * *qt6*
   - py-opencv
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   - xorg-libxext >=1.3.6,<2.0a0
-  - python_abi 3.12.* *_cp312
+  - py-opencv >=4.12.0,<5.0a0
   - libopengl >=1.7.0,<2.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
-  - py-opencv >=4.11.0,<5.0a0
+  - libopencv >=4.12.0,<4.12.1.0a0
   - libgl >=1.7.0,<2.0a0
-  - libopencv >=4.11.0,<4.11.1.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 298454
-  timestamp: 1759138968815
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-transport-5.1.7-np126py312h3bd2861_10.conda
-  sha256: 6bb95146d40565b21750bcdf01f75122aa41d5470bb875742bae83df159c6927
-  md5: b95fbb1a3ff9e3222c241a5b4a325f6e
+  size: 299568
+  timestamp: 1759314662647
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-transport-6.1.2-np2py312h31f38b3_14.conda
+  sha256: 75c99546c408b79e28904965aa956e14fb49c5fc40ad47030c41abccafcbc63b
+  md5: d456b2ce4d4950e6c5198aa53d8ecd3d
   depends:
   - python
-  - ros-jazzy-message-filters
-  - ros-jazzy-pluginlib
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-message-filters
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 578403
-  timestamp: 1759138982065
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-interactive-markers-2.5.4-np126py312h3bd2861_10.conda
-  sha256: 1cf16f833d708e09e94988e4f1b014e769675866bd632da68373d45fa43b3411
-  md5: 8506a1d913fef0b77b2b6e7f4f5ff078
+  size: 561832
+  timestamp: 1759314652820
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-interactive-markers-2.7.0-np2py312h31f38b3_14.conda
+  sha256: f664cacc1db1878307e4cf1616676513cd0db711175b6cc9d965c2af7a53ab4a
+  md5: 176c350a7e6ab7dde7495d4669ad436f
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclpy
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros-jazzy-tf2
-  - ros-jazzy-tf2-geometry-msgs
-  - ros-jazzy-visualization-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-visualization-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 306785
-  timestamp: 1759139586281
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-intra-process-demo-0.33.7-np126py312h5cbfcd5_10.conda
-  sha256: dccb86816cfd8601f79e59aba7a463eb5e4d27b57ae28e37b51b03d115178c3b
-  md5: 7da3423fa4091bb60dbd7cc0405ba782
+  size: 312894
+  timestamp: 1759315317503
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-intra-process-demo-0.36.2-np2py312h887a3b3_14.conda
+  sha256: 2a229e39e49cc8c86d2561386ba8230f34242bc3622af31158957f66553ccd52
+  md5: a83ae661fa024d1dca61d74040f3d94a
   depends:
-  - libopencv
   - libopencv * *qt6*
+  - libopencv
   - py-opencv
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - py-opencv >=4.11.0,<5.0a0
-  - libopencv >=4.11.0,<4.11.1.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - libgl >=1.7.0,<2.0a0
   - libopengl >=1.7.0,<2.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libopencv >=4.12.0,<4.12.1.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - xorg-libxext >=1.3.6,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - py-opencv >=4.12.0,<5.0a0
   license: BSD-3-Clause
-  size: 498439
-  timestamp: 1759138296940
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joy-3.3.0-np126py312h3bd2861_10.conda
-  sha256: 66b8a36315d913aab5889a39112ab9615807c0bc34298857344518dadd1c1537
-  md5: d2187aa19e8497e64d1ce2e50b8490e8
+  size: 498876
+  timestamp: 1759314603759
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joy-3.3.0-np2py312h31f38b3_14.conda
+  sha256: 2367a40a1ec948bbfd48ba233afcd3822412422c6705771414ef2aa3cca40179
+  md5: 539ffc2cbc8ce181c260196fbbeac7c0
   depends:
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sdl2-vendor
-  - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-sdl2-vendor
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 282109
-  timestamp: 1759138507190
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kdl-parser-2.11.0-np126py312h3bd2861_10.conda
-  sha256: b0582c3dd1b398a7a29069dc7ecd1aad2d3deec0efba74e9b23fb70aac85d08d
-  md5: 27c591ed624b3f3dadab12f1d064c743
+  size: 281102
+  timestamp: 1759314301425
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-kdl-parser-2.12.1-np2py312h31f38b3_14.conda
+  sha256: 4bca899d0302a0574f67979c246955e8b41468bea366e1a98a74f26c294d0372
+  md5: 495f8e0c263c2148b323c4c7bdff333d
   depends:
   - python
-  - ros-jazzy-orocos-kdl-vendor
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-urdf
-  - ros-jazzy-urdfdom-headers
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-urdf
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 46827
-  timestamp: 1759136183528
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-keyboard-handler-0.3.1-np126py312h3bd2861_10.conda
-  sha256: 4efdc6d11495cdaf2672f81bc28c39db167748004369d4c7ace5b4a8623d2cb4
-  md5: 17e7852e273c661dd51f0bb3028fde29
+  size: 50171
+  timestamp: 1759313879544
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-keyboard-handler-0.4.0-np2py312h31f38b3_14.conda
+  sha256: 5788751b98d597c473c9d067b8870af9593d8836cc2f1a831fdbb0564c74d11b
+  md5: 1fb6d9db77da0d249d5a89516cdd1870
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 55944
-  timestamp: 1759135170312
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-laser-geometry-2.7.1-np126py312h3bd2861_10.conda
-  sha256: 46114ae39a02998fe3384f29f78edc768a1267ac325c489af8fcdc4677a96efc
-  md5: 6e939d0fca0dc1de5383a83e86847fe2
+  size: 56989
+  timestamp: 1759311219049
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-laser-geometry-2.10.1-np2py312h31f38b3_14.conda
+  sha256: 5da60d8223860623a2ad89fcb36f5582271515b4f2527986e96674b3cf4832ff
+  md5: 872565d9309235254e2e11407c341a1d
   depends:
   - eigen
   - numpy
   - python
-  - ros-jazzy-eigen3-cmake-module
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-sensor-msgs-py
-  - ros-jazzy-tf2
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-eigen3-cmake-module
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-sensor-msgs-py
+  - ros-kilted-tf2
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 61104
-  timestamp: 1759138292165
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-3.4.6-np126py312h3bd2861_10.conda
-  sha256: a7fcdc856ee4477544a37854b136a024e7c24602357ae87f7aaff5562384679a
-  md5: 326bbc2e67a04b1e23e25bb2d4fc3480
+  size: 63141
+  timestamp: 1759314144741
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-3.8.3-np2py312h31f38b3_14.conda
+  sha256: f1c060dcbf10a361a715d0246b9a069fb07d3d675f4eb88ff4d51ae3751e12b2
+  md5: f6974d1f562e6689da563b42a054eb13
   depends:
   - importlib-metadata
   - lark-parser
   - python
   - pyyaml
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-osrf-pycommon
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-osrf-pycommon
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 233908
-  timestamp: 1759134505669
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-ros-0.26.9-np126py312h3bd2861_10.conda
-  sha256: 2fc3f0f078a804fc375728e5245ee912b377cb9b3fed3f122dfcba04aab1ab80
-  md5: 6b738447fc1524a1e119dde4e2cad426
+  size: 245153
+  timestamp: 1759310808134
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.3-np2py312h31f38b3_14.conda
+  sha256: 58f007a0e6863c522d07c9d49af2e45fdfff34ea67d69441c3a1fb4536c7c183
+  md5: 9432655147e0bfde6d3ee7ed4274a798
   depends:
   - importlib-metadata
   - python
   - pyyaml
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-composition-interfaces
-  - ros-jazzy-launch
-  - ros-jazzy-lifecycle-msgs
-  - ros-jazzy-osrf-pycommon
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-python
+  - ros-kilted-composition-interfaces
+  - ros-kilted-launch
+  - ros-kilted-lifecycle-msgs
+  - ros-kilted-osrf-pycommon
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 127683
-  timestamp: 1759138274528
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-3.4.6-np126py312h3bd2861_10.conda
-  sha256: 0fcf605086eb23fa483723d8cef95469ca9feb87b4356a1863e4a9d912e61aeb
-  md5: 36a256ce8f858150471caef61ee19866
+  size: 113626
+  timestamp: 1759314125555
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.3-np2py312h31f38b3_14.conda
+  sha256: 8a522b33c221eaddb8798297b1cd3c3e8dbc4fd8b921c8f37f19c1e3fdd36b94
+  md5: ada35fae00bd4e4f246ad5715c543f37
   depends:
   - pytest
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-launch
-  - ros-jazzy-launch-xml
-  - ros-jazzy-launch-yaml
-  - ros-jazzy-osrf-pycommon
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-python
+  - ros-kilted-launch
+  - ros-kilted-launch-xml
+  - ros-kilted-launch-yaml
+  - ros-kilted-osrf-pycommon
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 115764
-  timestamp: 1759134753497
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ament-cmake-3.4.6-np126py312h3bd2861_10.conda
-  sha256: cd2809493252f7ce6ccbc49163bb53ee8c0db881730211333da4dda01ee50d28
-  md5: e384d0a73a7aa48087ea3ace278a9737
+  size: 116031
+  timestamp: 1759310908311
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ament-cmake-3.8.3-np2py312h31f38b3_14.conda
+  sha256: 2e19da91bc4138b327389bfdc568a7fc51a22e7c0a15022cd5f0e0786e65c43a
+  md5: d38cb714007e12a6707bc9b5a4572faf
   depends:
   - python
-  - ros-jazzy-ament-cmake-test
-  - ros-jazzy-launch-testing
-  - ros-jazzy-python-cmake-module
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-launch-testing
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 27109
-  timestamp: 1759135532796
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ros-0.26.9-np126py312h3bd2861_10.conda
-  sha256: 6d54a4bccd0d176ff2c17ee65d63caf320269a1662ac439752a21ab2c966d52c
-  md5: 8340621821dbbc847f00b09433c89017
+  size: 26942
+  timestamp: 1759311209153
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.3-np2py312h31f38b3_14.conda
+  sha256: 55f98582b00e53d963b2d677fd85b24e646fc54920ca17480b875d55588f1778
+  md5: 7f1c493bf675ce95e5f44009bd81664c
   depends:
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-launch-ros
-  - ros-jazzy-launch-testing
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-python
+  - ros-kilted-launch-ros
+  - ros-kilted-launch-testing
+  - ros-kilted-rclpy
+  - ros-kilted-rmw-test-fixture-implementation
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 51888
-  timestamp: 1759138508212
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-xml-3.4.6-np126py312h3bd2861_10.conda
-  sha256: 1697643b99012afbb64976a8de321cfd6c6765030a1b961cd0024f69976b6fe1
-  md5: 759cb1325ec0f298925d693426a1d147
+  size: 55903
+  timestamp: 1759314313076
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.3-np2py312h31f38b3_14.conda
+  sha256: 409cd7ca09d16bd238a89ebaa58cfa592672d46f6c5a3c673ade989dcb65b221
+  md5: e33efedee9d112bb07e0211866191644
   depends:
   - python
-  - ros-jazzy-launch
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-launch
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 26009
-  timestamp: 1759134629285
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-yaml-3.4.6-np126py312h3bd2861_10.conda
-  sha256: 490f519a470238d4e80187fb22612d84172063201ef295cb95cd3bbcf92cb45b
-  md5: 06cfefea6ce54ca5a06fe729c8308e86
+  size: 25587
+  timestamp: 1759310857904
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.3-np2py312h31f38b3_14.conda
+  sha256: 5e148385b365822c4b4793c42db35d5f5fcbd122c353e01bf99845ff6798aab8
+  md5: 029c5a50aab99cd6ddb94e4c739d3e47
   depends:
   - python
-  - ros-jazzy-launch
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-launch
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 26580
-  timestamp: 1759134622224
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libcurl-vendor-3.4.4-np126py312h3bd2861_10.conda
-  sha256: 41015760b8efee178b35b36c7224f5cdd2940c5faa5f240dd1e98b71a7e7e7bf
-  md5: 414627a2421a5b2f78cc2b500287b2ac
+  size: 26139
+  timestamp: 1759310851520
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libcurl-vendor-3.7.0-np2py312h31f38b3_14.conda
+  sha256: 88b69b5d365d71c09f4e12c0cd8c9c3f7afc8982e49e12525e56064070914a49
+  md5: fb216f0c74a2cc79631999f1aca8071b
   depends:
   - libcurl
   - pkg-config
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - libcurl >=8.14.1,<9.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 23734
-  timestamp: 1759134507600
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-liblz4-vendor-0.26.9-np126py312h3bd2861_10.conda
-  sha256: 8f21680a54a22c66cc423615d3215ff1aa4bf6374b8eeea7c4624aaf0e3700df
-  md5: 36170527cd000311cf24eaff7e8a90cb
+  size: 23759
+  timestamp: 1759310586289
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-liblz4-vendor-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 59b8f3556a16870514cdce512208b98c61e23a90f0c3b17b64357e3118b9e419
+  md5: 351689f9adb482337769a0b4b098f632
   depends:
   - lz4
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 23958
-  timestamp: 1759134522228
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libstatistics-collector-1.7.4-np126py312h3bd2861_10.conda
-  sha256: e928c84cff58af3e436b3bf16e39d9e0ad9acb37e1b739ebd358171c7aad97a4
-  md5: d4a046a08d54c85300b5ed9c0297f44b
+  size: 24071
+  timestamp: 1759310550736
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h31f38b3_14.conda
+  sha256: 9ef1dc270c0691230100ccb859b7294562a9d43065455e9adb2d1247e8d1a8f7
+  md5: bdae1170bc009c49ba70165b1db67096
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-rcl
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-statistics-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-rcl
+  - ros-kilted-rcpputils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-statistics-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 58238
-  timestamp: 1759137892565
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libyaml-vendor-1.6.3-np126py312h3bd2861_10.conda
-  sha256: ce3af2e97af8da05bf3af031bdb8aa85fa3d9a29b86eb5d2d1ae0848841f8740
-  md5: b5eff53b16c8541dc20228599fa5445c
+  size: 58445
+  timestamp: 1759313836879
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h31f38b3_14.conda
+  sha256: 601ebbc55856f5987ff5df6c138fe9d1243769741a2ef43d063f18a0e2573dad
+  md5: 78d8f3f45c2510cd73051b88cf8423f2
   depends:
   - pkg-config
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - yaml
   - yaml-cpp
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - yaml-cpp >=0.8.0,<0.9.0a0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   - yaml >=0.2.5,<0.3.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 29475
-  timestamp: 1759135559646
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-lifecycle-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 26fe591b3240894e5826c664aca3f12c3cf685cfe91531d59bb4ee68ab58eb40
-  md5: ade85117b4ba5d0f5d9628877d4ad9ab
+  size: 29459
+  timestamp: 1759311601029
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-lifecycle-0.36.2-np2py312h31f38b3_14.conda
+  sha256: 555f0c0b9e9c09ac0f012870c86b5a145e20056d9632a73375d363b9fafb477e
+  md5: e906165d50043972b9433dfe04bafad6
   depends:
   - python
-  - ros-jazzy-lifecycle-msgs
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-lifecycle
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-lifecycle-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 266261
-  timestamp: 1759139540900
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-lifecycle-msgs-2.0.3-np126py312h3bd2861_10.conda
-  sha256: b52aaa5d92156e8da5b79c0a8f13d8ea984fc9c6c4de96dafd613a0498d2dbd3
-  md5: e24a3e9ceaf4ddc096180eb218682da5
+  size: 264925
+  timestamp: 1759315237959
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h31f38b3_14.conda
+  sha256: 1b8c5e763d2c3233fcea928cd8462fed3ee07e13051a55549a4610b63f737955
+  md5: 0032a0605bcb311141d4bd2d44eebd4f
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 268176
-  timestamp: 1759136537008
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-logging-demo-0.33.7-np126py312h3bd2861_10.conda
-  sha256: d18f21c97eadea855e1afb8507588dd359f6a7916c3dab81bf2f095d418aa147
-  md5: 35fa710f6ac0509d3df450c3332e8ce2
+  size: 267882
+  timestamp: 1759312305358
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-logging-demo-0.36.2-np2py312h31f38b3_14.conda
+  sha256: 0b26eb786f52218a331375fda5bd6247ebcf86b2332d88ddfc95f7d594ea80e3
+  md5: f906eccea8f4592f64a6d0333346a258
   depends:
   - python
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 216408
-  timestamp: 1759138945703
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-map-msgs-2.4.1-np126py312h3bd2861_10.conda
-  sha256: 1eff4107bc2d61c2acaa8ddd7140f7e90b6915082184c5d4c9aaacab39dc3ed7
-  md5: 7b169411354347b577b40bd22a6cb972
+  size: 214873
+  timestamp: 1759314771330
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-map-msgs-2.5.0-np2py312h31f38b3_14.conda
+  sha256: a0f5ff0af2971a0bb9fb96c8762db0d9635196760af4c91af5fe0459c0467320
+  md5: 4ef448f4b5239838a352266f14ed5c2c
   depends:
   - python
-  - ros-jazzy-nav-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-nav-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 346101
-  timestamp: 1759137241981
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-mcap-vendor-0.26.9-np126py312h3bd2861_10.conda
-  sha256: 3d68ebe29a197233e7814ce0881994c79f67a091ec0e04c10da5419020e48f91
-  md5: 11af03a622b4b1acfe0af496271a050e
+  size: 346732
+  timestamp: 1759312815970
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-mcap-vendor-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 11a6a4d8bd5c8c690364fe76571ea1d2079ccc65000c597be628ca8119b5a20e
+  md5: 2cc632690fe5be4503085ecfa134c02e
   depends:
   - python
-  - ros-jazzy-liblz4-vendor
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-zstd-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-liblz4-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-zstd-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 172747
-  timestamp: 1759134634406
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-message-filters-4.11.7-np126py312h3bd2861_10.conda
-  sha256: 54d7694ab42a3d76fbd6eecd7427b89e1851472316b577930dfa1ac44913ce0f
-  md5: 09bd33dc72e836ac22dd66fef868a631
+  size: 174333
+  timestamp: 1759310669297
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.2-np2py312h31f38b3_14.conda
+  sha256: 955d721a9555e99619c9fec13b211d5d4bcd76120a33ab5d6ef82e82e3326e90
+  md5: 3a901a270d0b15a9826529d18ff865cd
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclpy
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 81063
-  timestamp: 1759138525501
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-nav-msgs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: 563ff9aaaa0354246a9fd943466c1e80cd6dac2754e365d94075d9972868763b
-  md5: 9c49e0a5c328ff0fb570448a37ff689b
+  size: 86500
+  timestamp: 1759314328833
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: 014ad1ece10651449f62cac9ae98a789598ed7a11fc7780228e8760c3a27dcfe
+  md5: 0c7c17f432d25d215d522d4340c0a9a2
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 315161
-  timestamp: 1759137015247
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-orocos-kdl-vendor-0.5.1-np126py312h3bd2861_10.conda
-  sha256: 81cbeea376699425b90740844f842d2f357fc23c619431a4efa8e6c5cfff0ac5
-  md5: 1f68c127fabe330d36821aaa453f7010
+  size: 320059
+  timestamp: 1759312705042
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h31f38b3_14.conda
+  sha256: cb8e66be4d8d0368f63c8010d2e05e4396c4cf75d1e01992cede5281c0d9c22b
+  md5: 96a91044a4d54702a5dbcf69f4defd1e
   depends:
   - eigen
   - orocos-kdl
   - python
-  - ros-jazzy-eigen3-cmake-module
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-eigen3-cmake-module
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - orocos-kdl >=1.5.1,<1.6.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 27832
-  timestamp: 1759135159739
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-osrf-pycommon-2.1.7-np126py312h3bd2861_10.conda
-  sha256: 2d00d4558e363230e5088ea8ae395a92ececf27aacf625c93f543792d6cba2e7
-  md5: 014b2eb2645428433f6200bbdc1b889b
+  size: 27848
+  timestamp: 1759311210262
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h31f38b3_14.conda
+  sha256: 79a689a3ab80e40cf5e9f81cd2ff9cc14019ad5337f40529a263d5dd40d53c78
+  md5: f77f054b05f31a42f318d83ecd2bbc1b
   depends:
   - importlib-metadata
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 64428
-  timestamp: 1759133952499
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pcl-conversions-2.6.2-np126py312h3bd2861_10.conda
-  sha256: 3d6f8fd10a91408ae163b4b7aa4241747ecc36f3f84dcf5149bad3de5ddb4206
-  md5: e65ecb9e2cb2a48e349a14a784b5b618
+  size: 64454
+  timestamp: 1759310086635
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pcl-conversions-2.7.3-np2py312h43d1557_14.conda
+  sha256: 5e9762251bbe9852649a3764b15f47394127839daadb599004e7dc0d810bb412
+  md5: f0f46dccf9b4d2a8ebba0ed974f9e411
   depends:
   - eigen
   - libboost-devel
   - pcl
   - python
-  - ros-jazzy-message-filters
-  - ros-jazzy-pcl-msgs
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-message-filters
+  - ros-kilted-pcl-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - vtk-base
   - xorg-libx11
   - xorg-libxext
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - pcl >=1.15.0,<1.15.1.0a0
-  - numpy >=1.26.4,<2.0a0
-  - libboost >=1.86.0,<1.87.0a0
-  - vtk-base >=9.4.2,<9.4.3.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
-  - libopengl >=1.7.0,<2.0a0
-  - libgl >=1.7.0,<2.0a0
   - xorg-libxext >=1.3.6,<2.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - vtk-base >=9.4.2,<9.4.3.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - pcl >=1.15.0,<1.15.1.0a0
   license: BSD-3-Clause
-  size: 69712
-  timestamp: 1759139039698
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pcl-msgs-1.0.0-np126py312h3bd2861_10.conda
-  sha256: eb0b4c6af7872d4954cdce5f8752718db271d9d6c9a5053b2f65befa0149ed63
-  md5: a61dff1aacbc686c1d32042b797d7310
+  size: 70496
+  timestamp: 1759314743397
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pcl-msgs-1.0.0-np2py312h31f38b3_14.conda
+  sha256: d63d60c8567eef850f1ec04675a1bd05325e3d4d09c2ce3b7253f013ab74d0d9
+  md5: fbd638e88ed588403746a531c9dfc099
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 170174
-  timestamp: 1759137231881
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pendulum-control-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 3c7331ffacc1dfee2363c56654e71f800f25dc54ed0c8a5378d540136a878d07
-  md5: 93468000e21d63c7288b625afcde33f4
+  size: 169718
+  timestamp: 1759312848260
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pendulum-control-0.36.2-np2py312h31f38b3_14.conda
+  sha256: b550ebbdf426ed14e0de56bad32170d048c16f2418e3a61e771814b795cc638e
+  md5: ec09564d871bed3ffac019ba23795367
   depends:
   - python
-  - ros-jazzy-pendulum-msgs
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rttest
-  - ros-jazzy-tlsf-cpp
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-pendulum-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-rttest
+  - ros-kilted-tlsf-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 346809
-  timestamp: 1759139510634
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pendulum-msgs-0.33.7-np126py312h3bd2861_10.conda
-  sha256: df5b046457aa369c1905f72badbfb392fdea7db46441be638d42f38de3b20671
-  md5: 90bec498b804f4187f61d344530e0f7d
+  size: 338396
+  timestamp: 1759315208645
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pendulum-msgs-0.36.2-np2py312h31f38b3_14.conda
+  sha256: 91b27cf69b89b8d61cc9a5014154c9500824700ed6164d7f62159e5f4a02ab40
+  md5: cdbf635ff72b4e225aba055b29fc6667
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 99945
-  timestamp: 1759136608978
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pluginlib-5.4.2-np126py312h3bd2861_10.conda
-  sha256: 39a0d734a0b41c602b11d7f193b56da78b6866c506bd4404bc12b207c55de8b6
-  md5: fc60f4769217c95dfcd6c4220fd5bbf7
+  size: 96796
+  timestamp: 1759312301587
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.0-np2py312h31f38b3_14.conda
+  sha256: 8321fcd0af84e8adfce3eb238fddddbfb4d15b9a5606dce75b05ac61e71599d8
+  md5: 9336f57375044be6e3d8d3209b78f4fe
   depends:
   - python
-  - ros-jazzy-ament-index-cpp
-  - ros-jazzy-class-loader
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tinyxml2-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-class-loader
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-tinyxml2-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 41030
-  timestamp: 1759135903496
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-point-cloud-transport-4.0.4-np126py312h3bd2861_11.conda
-  sha256: 4c4e83c8f27c7398ffa67df2ee491b854c5e92d1cb3b17a2ce1919f9ba6ca11c
-  md5: 83f2532056d0e6fca287bf5869a4f6dc
+  size: 44447
+  timestamp: 1759313602427
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-point-cloud-transport-5.1.3-np2py312h31f38b3_14.conda
+  sha256: 462e0749cac0345e91e195e21c77023b1278e663adc8eaee249dfda2b04a27fb
+  md5: 02be6bc7b72ee5f6808618fa7c9b7682
   depends:
   - python
-  - ros-jazzy-message-filters
-  - ros-jazzy-pluginlib
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-message-filters
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-rcpputils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 457019
-  timestamp: 1760720456371
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pybind11-vendor-3.1.3-np126py312h3bd2861_10.conda
-  sha256: 531fc2b9f72a66aee15aafe92abeba472bf874e773ad37c84e49d6c9b4535c43
-  md5: 8a9427040947a6fec2cf13041b52c4ed
+  size: 454766
+  timestamp: 1759314602810
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pybind11-vendor-3.2.0-np2py312h31f38b3_14.conda
+  sha256: 5db32d7341147306802e0bc7361f9849648296a0a97fb1939c7f7e462ef9f109
+  md5: 8952cb018e2171b9962e6f949c9658ad
   depends:
   - pybind11
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 23052
-  timestamp: 1759134499243
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-cmake-module-0.11.1-np126py312h3bd2861_10.conda
-  sha256: 7e63c152f78759fe99d79f4f2218a16edebfb0f0e406b585c35d2c31782b0959
-  md5: 8d8268a354f258950e2381bce6c628c0
-  depends:
-  - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  license: BSD-3-Clause
-  size: 27606
-  timestamp: 1759135131754
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np126py312h3bd2861_10.conda
-  sha256: ff596163b73b99c77b87f2c5ea9407db42d110977377d926e93d625959f600d1
-  md5: 5712f9a4ff564f044404044f79c56c29
+  size: 23058
+  timestamp: 1759310582303
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h31f38b3_14.conda
+  sha256: 09d83127d121adddad524cd6d790edc25ebac1664f173b15bcf91715697c1416
+  md5: 90bb257072626aa0912d511dfe17e449
   depends:
   - python
   - python-orocos-kdl
-  - ros-jazzy-orocos-kdl-vendor
-  - ros-jazzy-pybind11-vendor
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-pybind11-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python-orocos-kdl >=1.5.1,<1.6.0a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 27335
-  timestamp: 1759135553018
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-qt-binding-2.2.1-np126py312h3bd2861_10.conda
-  sha256: 9875560a39d357f7fe0f9bac6c12f937004c73e95df71a01b0ba0b99f4f4d0c1
-  md5: 5f68a70fb380cc50c7404419e4cf94a5
+  size: 27274
+  timestamp: 1759311585704
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-python-qt-binding-2.3.1-np2py312h31f38b3_14.conda
+  sha256: d992b1ad1823336cdf9d4ad48a23fafef48e13a0dbfa82e5c91c2db7f751a1b6
+  md5: f6eee6820faa68fc1536120b6f7d5927
   depends:
   - pyqt
   - pyqt-builder
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - qt-main >=5.15.15,<5.16.0a0
+  - libgcc >=13
   - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.23,<3
   - libgl >=1.7.0,<2.0a0
-  - pyqt >=5.15.11,<5.16.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - libopengl >=1.7.0,<2.0a0
   - python_abi 3.12.* *_cp312
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - pyqt >=5.15.11,<5.16.0a0
   license: BSD-3-Clause
-  size: 60606
-  timestamp: 1759135131389
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-qt-dotgraph-2.7.5-np126py312hd4d1b83_10.conda
-  sha256: 9bb87947fd7f44d56c7eb1d6a4eedb40a0d88c54004e40c9263d24c18652485c
-  md5: 703c7fecfde2c96cd4732eff94c6b87c
+  size: 60654
+  timestamp: 1759311215788
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-qt-dotgraph-2.9.1-np2py312h31f38b3_14.conda
+  sha256: 9ed77a648f7669e3ed7c8acbfc7c06f57f67652ba2f701ed6c661482bdc73751
+  md5: e95241fb668cfac1f102b3fdddf204ae
   depends:
   - pydot
+  - pygraphviz
   - python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-python-qt-binding
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - graphviz >=13.1.2,<14.0a0
   license: BSD-3-Clause
-  size: 64032
-  timestamp: 1759135565777
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-qt-gui-2.7.5-np126py312h3bd2861_10.conda
-  sha256: 397bbc1aff364c1cfb43563b148f13e6092caf1e38c34ec6413dff6737661922
-  md5: eba9fca100284833f4f9bb22ca7a7308
+  size: 42823
+  timestamp: 1759311580212
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-qt-gui-2.9.1-np2py312h31f38b3_14.conda
+  sha256: be8610133cb1644d199f323fb0131da7acbadefb87c3b64ba63712932c717b63
+  md5: 1977d04287e3259d0c43844fc8e7f1b4
   depends:
   - catkin_pkg
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tango-icons-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-ros-workspace
+  - ros-kilted-tango-icons-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - pyqt >=5.15.11,<5.16.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - qt-main >=5.15.15,<5.16.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
   - libopengl >=1.7.0,<2.0a0
   - libgl >=1.7.0,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
+  - pyqt >=5.15.11,<5.16.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - xorg-libxext >=1.3.6,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 171754
-  timestamp: 1759135534973
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-qt-gui-cpp-2.7.5-np126py312h3bd2861_10.conda
-  sha256: b5b9f8d691bdcbb4b5a4f1df82300011e26fadc905a7105cda9d72a7c3aa49a1
-  md5: 577411bc2c8f00e93776667a3b70818c
+  size: 171777
+  timestamp: 1759311597659
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-qt-gui-cpp-2.9.1-np2py312h31f38b3_14.conda
+  sha256: 887b3c4a471590f46b2f0361f8ffbfd587768a98e1d79b2ce057a683d68096d8
+  md5: 42b57b533db651251d5ccceae4bca0a6
   depends:
   - pep517
   - pyqt-builder
   - python
-  - ros-jazzy-pluginlib
-  - ros-jazzy-qt-gui
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tinyxml2-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-pluginlib
+  - ros-kilted-qt-gui
+  - ros-kilted-ros-workspace
+  - ros-kilted-tinyxml2-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - libopengl >=1.7.0,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - qt-main >=5.15.15,<5.16.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - libgl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - xorg-libxext >=1.3.6,<2.0a0
-  license: BSD-3-Clause
-  size: 510364
-  timestamp: 1759136023765
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-qt-gui-py-common-2.7.5-np126py312h3bd2861_10.conda
-  sha256: 63e83ff1f9a4145848af0e9e61072e42233e456c7a79f303eb67a6feccea8ac5
-  md5: cb9bbc027e41cccbb4e967cfb57eb2aa
-  depends:
-  - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 39052
-  timestamp: 1759135554419
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-quality-of-service-demo-cpp-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 6495dd85cc943bc3eae674fe066ab9a3a50d9ddc225289f5b8d382c0a9cb9a93
-  md5: 7aa676a79cca9c9bcb905c90a6909629
+  size: 510425
+  timestamp: 1759313729844
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-qt-gui-py-common-2.9.1-np2py312h31f38b3_14.conda
+  sha256: 18c4c5d2309feaf87d1510fab391d5885083a7f56e0bc40d1a2ba13a3c1cef3b
+  md5: 9a0ebbf1abf56adb342b3081e9673579
   depends:
   - python
-  - ros-jazzy-example-interfaces
-  - ros-jazzy-launch-ros
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 39008
+  timestamp: 1759311609841
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-quality-of-service-demo-cpp-0.36.2-np2py312h31f38b3_14.conda
+  sha256: c55529cea1f4b5c7384d0c2b639513b21d9a6027ccabd2bf5483766b0aeb3a0f
+  md5: 2d576ccb11df76b9bd5c929c8052f42a
+  depends:
+  - python
+  - ros-kilted-example-interfaces
+  - ros-kilted-launch-ros
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 598422
-  timestamp: 1759138489774
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-quality-of-service-demo-py-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 9f2a2f907544317aa2bda9022c6e2f3450605758405dac9d38c4a6fc98ae9cf6
-  md5: 8c2b4a77e5c0958c6619c922d3689578
+  size: 589820
+  timestamp: 1759314376324
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-quality-of-service-demo-py-0.36.2-np2py312h31f38b3_14.conda
+  sha256: e6367b67f9ef208fd398183a118f2e445105520af62d1ba1888d21aa80477f5c
+  md5: 31ff9cf6329cca5f97534bba6eadfafc
   depends:
   - python
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 34806
-  timestamp: 1759138290169
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-9.2.7-np126py312h3bd2861_10.conda
-  sha256: 9bf9e007a2f7986731e8cb6ce6359a9ae98ce58a1d966575d7899659e3ed1119
-  md5: 6abad32f74bfe8f8583c73cfdb82a909
+  size: 35175
+  timestamp: 1759314139515
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-10.1.1-np2py312h31f38b3_14.conda
+  sha256: 83c36157d0d7bcdec4fbf8915093eb3989b054823c4971ccae669292fa143ad0
+  md5: a57680fa1b91a95378d1467ce7d61ac6
   depends:
   - python
-  - ros-jazzy-libyaml-vendor
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rcl-logging-interface
-  - ros-jazzy-rcl-logging-spdlog
-  - ros-jazzy-rcl-yaml-param-parser
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-rmw-implementation
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-service-msgs
-  - ros-jazzy-tracetools
-  - ros-jazzy-type-description-interfaces
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-libyaml-vendor
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rcl-logging-interface
+  - ros-kilted-rcl-logging-spdlog
+  - ros-kilted-rcl-yaml-param-parser
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-rmw-implementation
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-service-msgs
+  - ros-kilted-tracetools
+  - ros-kilted-type-description-interfaces
+  - ros2-distro-mutex 0.12.* kilted_*
   - yaml
   - yaml-cpp
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - yaml >=0.2.5,<0.3.0a0
   - yaml-cpp >=0.8.0,<0.9.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 201210
-  timestamp: 1759137495192
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-action-9.2.7-np126py312h3bd2861_10.conda
-  sha256: a7c84e402761127b9f7036c6c73dbbf196d53d2544c9c665388cc150e05cba48
-  md5: b8a8b6dda0eec9080ba7bf2cbbdcd67a
+  size: 200523
+  timestamp: 1759313687753
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.1-np2py312h31f38b3_14.conda
+  sha256: 2a577115135723bc208a8a6ab5f42eaa2b9f9a2def00acfb8d1fe408a4fdcb96
+  md5: 40cc99fc1b0f083826f85c8b56ff0fe2
   depends:
   - python
-  - ros-jazzy-action-msgs
-  - ros-jazzy-rcl
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-c
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-action-msgs
+  - ros-kilted-rcl
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-c
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 83879
+  timestamp: 1759313860578
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.0-np2py312h31f38b3_14.conda
+  sha256: 62537f4346b424dabd9a4493c0a9fd2c2f12c33445ee60ceda521be7e28ecfe7
+  md5: 6c1497db693b7df6abdb4d2fd65fce1f
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 80470
-  timestamp: 1759137925701
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-interfaces-2.0.3-np126py312h3bd2861_10.conda
-  sha256: 1638a8038a7891a5800e17802654d5faf14ac071b2755141e7a82629cab0b4d3
-  md5: 10d8e200bbd2bd07e2bd8616397e3545
+  size: 579084
+  timestamp: 1759312384207
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-lifecycle-10.1.1-np2py312h31f38b3_14.conda
+  sha256: 90d6214636e0ab169dfbf6db4542ec437b049626273c0204aaa5de8bbd358c6e
+  md5: a0fec3f9a7eef2516125fbed5352f37a
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-lifecycle-msgs
+  - ros-kilted-rcl
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-tracetools
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 570206
-  timestamp: 1759136612244
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-lifecycle-9.2.7-np126py312h3bd2861_10.conda
-  sha256: 7ff773f141b7d07f9f97f4c9b4d61d4ceddc5bc5b1f127384a19464b4fdebf32
-  md5: f2bce5e8e6a2dd921b81e163413c1b60
+  size: 59315
+  timestamp: 1759313852541
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-interface-3.2.2-np2py312h31f38b3_14.conda
+  sha256: 2d1ab0d2c4cb7ae190c0652bfbca2ee5c5e6fd57ef1c87df386e214c9bcc62b3
+  md5: 401d49cbe96cb00c91b11c42739dee37
   depends:
   - python
-  - ros-jazzy-lifecycle-msgs
-  - ros-jazzy-rcl
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 57975
-  timestamp: 1759137917796
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-interface-3.1.1-np126py312h3bd2861_10.conda
-  sha256: 815ced2e31d60df46ab95a6ac1d3914203ea19acab7fc3d7f5b40bbb50b60853
-  md5: d823a66d091b680808641438ceca0078
+  size: 38576
+  timestamp: 1759313373145
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-spdlog-3.2.2-np2py312hb464df2_14.conda
+  sha256: 7f9d6cbb1459bf496c55af3f3e6ddf61469b14131d9a317685dc38481211cb1b
+  md5: 18beeac36e0c2dce0b76a1a79fdb537a
   depends:
   - python
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  license: BSD-3-Clause
-  size: 35352
-  timestamp: 1759135851282
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-spdlog-3.1.1-np126py312he340118_10.conda
-  sha256: 3422ebeec09a0d41ec7c85ccc4aaba86de3197b30c80d1703f6be697bcf4f6a1
-  md5: a021831db4f20a42022ef9923c79a26d
-  depends:
-  - python
-  - ros-jazzy-rcl-logging-interface
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-spdlog-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rcl-logging-interface
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-spdlog-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
   - spdlog
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - spdlog >=1.15.3,<1.16.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - spdlog >=1.15.3,<1.16.0a0
   license: BSD-3-Clause
-  size: 45954
-  timestamp: 1759135935520
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-yaml-param-parser-9.2.7-np126py312h3bd2861_10.conda
-  sha256: cc79978e35ed388c961f928df46a422cdaff5290416473950524f0bc07f20fcd
-  md5: 8236b5b6f305ab7fa5c7ecc3e8f3de3b
+  size: 49167
+  timestamp: 1759313585933
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-yaml-param-parser-10.1.1-np2py312h31f38b3_14.conda
+  sha256: 6770a250b9457aa76f75011009ce2c180600d3b0cf4aba0042294c51b5861645
+  md5: e4987834771034981b506dedcf83fd57
   depends:
   - python
-  - ros-jazzy-libyaml-vendor
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-libyaml-vendor
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - yaml
   - yaml-cpp
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - yaml >=0.2.5,<0.3.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - yaml-cpp >=0.8.0,<0.9.0a0
+  - yaml >=0.2.5,<0.3.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 51623
-  timestamp: 1759136002236
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-28.1.12-np126py312h3bd2861_10.conda
-  sha256: 5fac9cbad51d1f1886825b1c29e869fd1390e5e777651143da8075ed13f48000
-  md5: 0ec79e2a566db7f4d526eaf0436ab861
+  size: 54722
+  timestamp: 1759313385515
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-29.5.3-np2py312h31f38b3_14.conda
+  sha256: e9963197be0e90933e9f8943c1c749c18a128ddb2e6d5dffb5ec9186acae08ba
+  md5: acaf6b052abebb2a0eeecd40702c0a48
   depends:
   - python
-  - ros-jazzy-ament-index-cpp
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-libstatistics-collector
-  - ros-jazzy-rcl
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rcl-logging-interface
-  - ros-jazzy-rcl-yaml-param-parser
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosgraph-msgs
-  - ros-jazzy-rosidl-dynamic-typesupport
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros-jazzy-rosidl-typesupport-c
-  - ros-jazzy-rosidl-typesupport-cpp
-  - ros-jazzy-statistics-msgs
-  - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-libstatistics-collector
+  - ros-kilted-rcl
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rcl-logging-interface
+  - ros-kilted-rcl-yaml-param-parser
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosgraph-msgs
+  - ros-kilted-rosidl-dynamic-typesupport
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-runtime-cpp
+  - ros-kilted-rosidl-typesupport-c
+  - ros-kilted-rosidl-typesupport-cpp
+  - ros-kilted-statistics-msgs
+  - ros-kilted-tracetools
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 1095658
-  timestamp: 1759138036472
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-action-28.1.12-np126py312h3bd2861_10.conda
-  sha256: 0569eb337647a4fceb1b0649139d5a933b43f5c59c3c95087c2b5d9ae3fc439f
-  md5: fe6e6d7ee5a3fb0821e8da09455f33bd
+  size: 1084354
+  timestamp: 1759313921344
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-action-29.5.3-np2py312h31f38b3_14.conda
+  sha256: 6587a5d7c3e19afed6ebc63e2efbbdbdd9047104092eeead19b437b13c649dc2
+  md5: 80b1d3b8b3c48b712294fc0d108e130e
   depends:
   - python
-  - ros-jazzy-action-msgs
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-rcl
-  - ros-jazzy-rcl-action
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rcpputils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-c
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-action-msgs
+  - ros-kilted-rcl
+  - ros-kilted-rcl-action
+  - ros-kilted-rclcpp
+  - ros-kilted-rcpputils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-c
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 116482
-  timestamp: 1759138297286
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-components-28.1.12-np126py312h3bd2861_10.conda
-  sha256: 2d6952afbdaf759d4c5cc88d5e1a16a1051820b2e8b1b6f1a92d451d0603593b
-  md5: a6fb2bb240c4be2ca4b495d499f9b722
+  size: 153908
+  timestamp: 1759314150388
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-components-29.5.3-np2py312h31f38b3_14.conda
+  sha256: 5988f485bdddb92f67b37891ff4d30cfe230e2dccb443653b4ebcdde0aa3ef18
+  md5: 9f3b445afa6a1f868edc17e070d073d4
   depends:
   - python
-  - ros-jazzy-ament-index-cpp
-  - ros-jazzy-class-loader
-  - ros-jazzy-composition-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-class-loader
+  - ros-kilted-composition-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 140131
-  timestamp: 1759138254427
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-lifecycle-28.1.12-np126py312h3bd2861_10.conda
-  sha256: ca596229ef1e750e475caca605e978d705e736430f39bac4f79505d28ca0fc83
-  md5: 4b80b876d5cedcb4aa0b3005435284b7
+  size: 140534
+  timestamp: 1759314104972
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-lifecycle-29.5.3-np2py312h31f38b3_14.conda
+  sha256: bd3a378f85b0b95bd810e4ac3e1bcf789ca8ed312a0731f5a1182761d519dc89
+  md5: ac95792ea5b9776e9df4dc36eea95825
   depends:
   - python
-  - ros-jazzy-lifecycle-msgs
-  - ros-jazzy-rcl
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rcl-lifecycle
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-typesupport-cpp
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-lifecycle-msgs
+  - ros-kilted-rcl
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rcl-lifecycle
+  - ros-kilted-rclcpp
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-typesupport-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 130881
-  timestamp: 1759138283448
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclpy-7.1.5-np126py312h3bd2861_10.conda
-  sha256: 66e39e1a82e360d41aa447b9b62fba41cefb8fe3530ac8f27bc5d3b16f737bc7
-  md5: 7d9f1d33df970f0e0fcc450e4544b6dc
+  size: 131530
+  timestamp: 1759314132222
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.1-np2py312h31f38b3_14.conda
+  sha256: ca571ca329980fde35cc48dab9d30e8ea2d758245995c1daa4af469692be713f
+  md5: 04a74a899a0e943164e239b35082492f
   depends:
   - python
   - pyyaml
-  - ros-jazzy-action-msgs
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-lifecycle-msgs
-  - ros-jazzy-rcl
-  - ros-jazzy-rcl-action
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rcl-lifecycle
-  - ros-jazzy-rcl-logging-interface
-  - ros-jazzy-rcl-yaml-param-parser
-  - ros-jazzy-rmw
-  - ros-jazzy-rmw-implementation
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosgraph-msgs
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rpyutils
-  - ros-jazzy-unique-identifier-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-action-msgs
+  - ros-kilted-ament-index-python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-lifecycle-msgs
+  - ros-kilted-rcl
+  - ros-kilted-rcl-action
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rcl-lifecycle
+  - ros-kilted-rcl-logging-interface
+  - ros-kilted-rcl-yaml-param-parser
+  - ros-kilted-rmw
+  - ros-kilted-rmw-implementation
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosgraph-msgs
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rpyutils
+  - ros-kilted-service-msgs
+  - ros-kilted-type-description-interfaces
+  - ros-kilted-unique-identifier-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - typing_extensions
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 722454
-  timestamp: 1759138136299
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcpputils-2.11.2-np126py312h3bd2861_10.conda
-  sha256: 3592b3549328122ceac5d8d5c9a85e1032cbfae81c40342b5a8dc6d708535680
-  md5: ab6f98127dddc09649e150499d0d0f11
+  size: 743405
+  timestamp: 1759314016573
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h31f38b3_14.conda
+  sha256: dd78b1e8e2edb73838ca910260568a235f7b5d297b61042a21e9f22160c6df8f
+  md5: ba8be7471cd7ece4e51f84d451652843
   depends:
   - python
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 80389
-  timestamp: 1759135754694
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcutils-6.7.4-np126py312h3bd2861_10.conda
-  sha256: f477bc94ca5d7d7de15c9edcb74a435824ea5feff0824485d456702f1a82a221
-  md5: 9fba73b4a6fc4c75ec91b3d6df1e7eb2
+  size: 80812
+  timestamp: 1759311765109
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.8-np2py312h31f38b3_14.conda
+  sha256: a0825c0c3a2d134b9fdd5f30789c3955efd32a099ffd8c81119ed3697110701d
+  md5: fe73cb3f5d64e8506e5681c8b7536580
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 122119
-  timestamp: 1759135628086
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-resource-retriever-3.4.4-np126py312h3bd2861_10.conda
-  sha256: cce7c268b3e1b9b1767c5d6289eefc587a669680e2aa1c9e351d50534ef34bb6
-  md5: 2cfb053769857c61ef2033376b5492da
+  size: 124253
+  timestamp: 1759311585195
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-resource-retriever-3.7.0-np2py312h31f38b3_14.conda
+  sha256: cb913d25d246820476f2fe22b43339c64e8909d78cbb6cc1bb6f4f0d430deb63
+  md5: 976033a18fa9d61a5f1bd9ac358cdfa1
   depends:
   - python
-  - ros-jazzy-ament-index-cpp
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-libcurl-vendor
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-ament-index-python
+  - ros-kilted-libcurl-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 44775
-  timestamp: 1759135559085
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-7.3.2-np126py312h3bd2861_10.conda
-  sha256: 57f23ae2beb22304328e2cee8535e9d547190700e73fcd169e3538eba79c7947
-  md5: 630603ba196ed5efebd28d281bfa848d
+  size: 58503
+  timestamp: 1759313375957
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h31f38b3_14.conda
+  sha256: 513b37e999756faa84d0fba3dc9e0a1a86c3f1e2ac2866e3ddbc00e570cfdbd4
+  md5: 9051b564a101bce6d11208d01f373234
   depends:
   - python
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-dynamic-typesupport
-  - ros-jazzy-rosidl-runtime-c
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-dynamic-typesupport
+  - ros-kilted-rosidl-runtime-c
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 97009
-  timestamp: 1759135915627
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-0.22.1-np126py312h3bd2861_10.conda
-  sha256: 30af3dbc51c6a65ca48c5836f4dd3cb000126ee6d682a62cd3c4ced5ab767199
-  md5: 6dc89b6b65a0e4d1bb292baffd93ca02
+  size: 96430
+  timestamp: 1759311864690
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.0-np2py312h31f38b3_14.conda
+  sha256: 287c875e8adc3827ac2c8303773dd611cbf9e7be82db3fa1563b212094ab8abc
+  md5: a320e663a4022e1c56884783b571db1b
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-rmw-connextdds-common
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake
+  - ros-kilted-rmw-connextdds-common
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 31990
-  timestamp: 1759137073605
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-common-0.22.1-np126py312h3bd2861_10.conda
-  sha256: 7e6dbb64826667344f1425f3c79445a17f694610c61ac0f09a9cff6c45d20050
-  md5: 671ed12124c2f6fdaf172b8b9059c358
+  size: 30398
+  timestamp: 1759312710551
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.0-np2py312h31f38b3_14.conda
+  sha256: 3e64a034960941173386c1a30581f4ed17357e281a8da00437fdd95c518f71de
+  md5: 9d87ba1272063589a978fe7120ca2962
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-fastcdr
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-rmw-dds-common
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros-jazzy-rosidl-typesupport-fastrtps-c
-  - ros-jazzy-rosidl-typesupport-fastrtps-cpp
-  - ros-jazzy-rosidl-typesupport-introspection-c
-  - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros-jazzy-rti-connext-dds-cmake-module
-  - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake
+  - ros-kilted-fastcdr
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-rmw-dds-common
+  - ros-kilted-rmw-security-common
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-runtime-cpp
+  - ros-kilted-rosidl-typesupport-fastrtps-c
+  - ros-kilted-rosidl-typesupport-fastrtps-cpp
+  - ros-kilted-rosidl-typesupport-introspection-c
+  - ros-kilted-rosidl-typesupport-introspection-cpp
+  - ros-kilted-rti-connext-dds-cmake-module
+  - ros-kilted-tracetools
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 53892
-  timestamp: 1759136858268
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-cyclonedds-cpp-2.2.3-np126py312h3bd2861_10.conda
-  sha256: b1bb8703ddc30c4304d14188a0fa25ccfcfda60307b66f2ab9a848bdc114a43a
-  md5: 409eb17f609d8fa0fe481597b4fffe14
+  size: 53679
+  timestamp: 1759312552764
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h31f38b3_14.conda
+  sha256: 593009e8f88ce2e730160d7837d6207264bd0e4a44ba0797fd81905218b7a86a
+  md5: ae885c4c0d0e549b1b103b1a1a5a974d
   depends:
   - python
-  - ros-jazzy-cyclonedds
-  - ros-jazzy-iceoryx-binding-c
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-rmw-dds-common
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-typesupport-introspection-c
-  - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-cyclonedds
+  - ros-kilted-iceoryx-binding-c
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-rmw-dds-common
+  - ros-kilted-rmw-security-common
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-typesupport-introspection-c
+  - ros-kilted-rosidl-typesupport-introspection-cpp
+  - ros-kilted-tracetools
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 265844
-  timestamp: 1759136864665
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-dds-common-3.1.0-np126py312h3bd2861_10.conda
-  sha256: b89576829c4206f362fd56c8620271059d05f9abda5e071176716ca1bfe1d4dc
-  md5: f57fb5582e0b488e9d442b319bb07962
+  size: 258997
+  timestamp: 1759312558031
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-dds-common-4.0.0-np2py312h31f38b3_14.conda
+  sha256: 284e7a29adb251fa02f4ab75c69e7f4cf7ffd3413e9163e0a9c0bf82fbc541bd
+  md5: 9beeaa6581166b3743df7cbcde690848
   depends:
   - python
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-rmw-security-common
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 177140
-  timestamp: 1759136532747
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-cpp-8.4.3-np126py312h3bd2861_10.conda
-  sha256: bcd12c84589f18855a56ec09a37ed827f63699f526a1bccfb3926320ef9e0a7c
-  md5: 60b7ea0455cc4697ff70513a5eac6522
+  size: 165458
+  timestamp: 1759312301444
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h31f38b3_14.conda
+  sha256: 88e2c0c6f2af606971b1078ba8b88e46bbd032910e947c28ad7ded41f71cddaf
+  md5: 1a7f35022069045ece1a030ea277a136
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-fastcdr
-  - ros-jazzy-fastrtps
-  - ros-jazzy-fastrtps-cmake-module
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-rmw-dds-common
-  - ros-jazzy-rmw-fastrtps-shared-cpp
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-dynamic-typesupport
-  - ros-jazzy-rosidl-dynamic-typesupport-fastrtps
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros-jazzy-rosidl-typesupport-fastrtps-c
-  - ros-jazzy-rosidl-typesupport-fastrtps-cpp
-  - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake
+  - ros-kilted-fastcdr
+  - ros-kilted-fastdds
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-rmw-dds-common
+  - ros-kilted-rmw-fastrtps-shared-cpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-dynamic-typesupport
+  - ros-kilted-rosidl-dynamic-typesupport-fastrtps
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-runtime-cpp
+  - ros-kilted-rosidl-typesupport-fastrtps-c
+  - ros-kilted-rosidl-typesupport-fastrtps-cpp
+  - ros-kilted-tracetools
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 159786
-  timestamp: 1759137049673
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-dynamic-cpp-8.4.3-np126py312h3bd2861_10.conda
-  sha256: 645d73d3eee4fe4a779810e596b73d5ed7c9256dd0eee1ac80719375ec55dfb6
-  md5: 0a7d3993e3df733e51161bf02d7f2e0f
+  size: 150298
+  timestamp: 1759312685640
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h31f38b3_14.conda
+  sha256: ae8aebab52a57d95ecaf50dad04f656a69cbe2b257b62692c4e047588adef02a
+  md5: c9ed4e327f4e24e718c3ff58fb4196d6
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-fastcdr
-  - ros-jazzy-fastrtps
-  - ros-jazzy-fastrtps-cmake-module
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-rmw-dds-common
-  - ros-jazzy-rmw-fastrtps-shared-cpp
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-typesupport-introspection-c
-  - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake
+  - ros-kilted-fastcdr
+  - ros-kilted-fastdds
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-rmw-dds-common
+  - ros-kilted-rmw-fastrtps-shared-cpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-typesupport-introspection-c
+  - ros-kilted-rosidl-typesupport-introspection-cpp
+  - ros-kilted-tracetools
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 187065
-  timestamp: 1759137014712
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-shared-cpp-8.4.3-np126py312h3bd2861_10.conda
-  sha256: a8fe05f2e9d56b580827c8b7caba319e8d65131280f5df157455ae5be7d965f7
-  md5: 76d071067b8d9ddcdb46236d811dc3c5
+  size: 172028
+  timestamp: 1759312649991
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h31f38b3_14.conda
+  sha256: 061e0b2aab0e743bbc81c086fe2d1b23a49f4188d48ea430dd66aaa90bf48f2c
+  md5: d6324ad302f9083d056baff889e438e1
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-fastcdr
-  - ros-jazzy-fastrtps
-  - ros-jazzy-fastrtps-cmake-module
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-rmw-dds-common
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-dynamic-typesupport
-  - ros-jazzy-rosidl-typesupport-introspection-c
-  - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake
+  - ros-kilted-fastcdr
+  - ros-kilted-fastdds
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-rmw-dds-common
+  - ros-kilted-rmw-security-common
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-dynamic-typesupport
+  - ros-kilted-rosidl-typesupport-introspection-c
+  - ros-kilted-rosidl-typesupport-introspection-cpp
+  - ros-kilted-tracetools
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 231656
-  timestamp: 1759136812044
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-2.15.6-np126py312h3bd2861_10.conda
-  sha256: 620c35ce03b22195ff4500019d6e0e5fa550797f2aafdc9a16ceb9142315a091
-  md5: 1c3b731bd70dbca6143a26ecdc1de850
+  size: 230694
+  timestamp: 1759312507141
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-3.0.4-np2py312h31f38b3_14.conda
+  sha256: 21e344894056780e6b2237aebbfb9c909d56f4d05321d28ea9bf961eb09b5853
+  md5: 8190cd7bea816f8714fc2a520460b45d
   depends:
   - python
-  - ros-jazzy-ament-index-cpp
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw-connextdds
-  - ros-jazzy-rmw-cyclonedds-cpp
-  - ros-jazzy-rmw-fastrtps-cpp
-  - ros-jazzy-rmw-fastrtps-dynamic-cpp
-  - ros-jazzy-rmw-implementation-cmake
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw-connextdds
+  - ros-kilted-rmw-cyclonedds-cpp
+  - ros-kilted-rmw-fastrtps-cpp
+  - ros-kilted-rmw-fastrtps-dynamic-cpp
+  - ros-kilted-rmw-implementation-cmake
+  - ros-kilted-rmw-zenoh-cpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 54228
-  timestamp: 1759137231735
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-cmake-7.3.2-np126py312h3bd2861_10.conda
-  sha256: 3ef8f2185c5a7f0adb9ea8306a78cbd7f6aea4b150f1d57f03e21838f93e0711
-  md5: 797411e57cbedf5800826bc6d966f4b0
+  size: 53196
+  timestamp: 1759312817411
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h31f38b3_14.conda
+  sha256: dbdc95732a558080d36089212ab580b98c12ee463b9da2348dc3340a29255fe7
+  md5: 1fe0aab6f05d737a3257abe246940d9b
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 29235
-  timestamp: 1759135465529
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-robot-state-publisher-3.3.3-np126py312h3bd2861_10.conda
-  sha256: c8833ae7b3ec0fc4d31fb3a774c849c85012fafa9d711cd964311d7477008199
-  md5: 6c8fa7a2175dce9d6224d4025598a4f6
+  size: 29217
+  timestamp: 1759311542759
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-security-common-7.8.2-np2py312h31f38b3_14.conda
+  sha256: 4646949bf8b3d8aa84c6348e8895a572f6da12c3aa87f009a91281b34baf1105
+  md5: 1b8d1a2484a2afecf9c7eea2e58e55d3
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-kdl-parser
-  - ros-jazzy-orocos-kdl-vendor
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros-jazzy-tf2-ros
-  - ros-jazzy-urdf
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 270797
-  timestamp: 1759139223476
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-base-0.11.0-np126py312h3bd2861_10.conda
-  sha256: aa5ad123294f930216312ccfa204c1ff16455f12468eb896d7a02cc0a918dd99
-  md5: 4ca1982f542affa6b86dcd63e58e0637
+  size: 50388
+  timestamp: 1759311945513
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.3-np2py312h31f38b3_14.conda
+  sha256: a119e4335309a2cdf91d52a191d600a2dbeb2374e83e2e8743b46aa540eb4d06
+  md5: b354664703515a5bc0989bed94703bc4
   depends:
   - python
-  - ros-jazzy-geometry2
-  - ros-jazzy-kdl-parser
-  - ros-jazzy-robot-state-publisher
-  - ros-jazzy-ros-core
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2
-  - ros-jazzy-urdf
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 22217
-  timestamp: 1759142572440
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-core-0.11.0-np126py312h3bd2861_10.conda
-  sha256: 78e70094f96dbd1833c488ebea406a6ac885c3676c0e7dc0d2fb51c83eaa1c6b
-  md5: 5f9ef851bcbd220526d56aa3995d87f8
+  size: 30258
+  timestamp: 1759311952911
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.3-np2py312h31f38b3_14.conda
+  sha256: 4cb1ef0a4cb21cf3fec99783d1e9a5f166217bf339190a6367b5457b746c4226
+  md5: bd1dade22b03a76cacaa3f78917eca78
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ament-cmake-auto
-  - ros-jazzy-ament-cmake-gmock
-  - ros-jazzy-ament-cmake-gtest
-  - ros-jazzy-ament-cmake-pytest
-  - ros-jazzy-ament-cmake-ros
-  - ros-jazzy-ament-index-cpp
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-ament-lint-auto
-  - ros-jazzy-ament-lint-common
-  - ros-jazzy-class-loader
-  - ros-jazzy-common-interfaces
-  - ros-jazzy-launch
-  - ros-jazzy-launch-ros
-  - ros-jazzy-launch-testing
-  - ros-jazzy-launch-testing-ament-cmake
-  - ros-jazzy-launch-testing-ros
-  - ros-jazzy-launch-xml
-  - ros-jazzy-launch-yaml
-  - ros-jazzy-pluginlib
-  - ros-jazzy-rcl-lifecycle
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-action
-  - ros-jazzy-rclcpp-lifecycle
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-environment
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli-common-extensions
-  - ros-jazzy-ros2launch
-  - ros-jazzy-rosidl-default-generators
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-sros2
-  - ros-jazzy-sros2-cmake
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-rmw-test-fixture
+  - ros-kilted-rmw-zenoh-cpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-rpyutils
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 22935
-  timestamp: 1759141203305
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-environment-4.2.1-np126py312h3bd2861_10.conda
-  sha256: afbf2503171aafa5a5caeb707793ac49c6ec04b18bbfec0bf3be28f7e74cc58a
-  md5: 1a0a37bef17a78e62502248d0333bb6f
+  size: 47808
+  timestamp: 1759313019333
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-zenoh-cpp-0.6.4-np2py312hf7ffe29_14.conda
+  sha256: 37fe130529d1a53b0f7d99943752df9e7df15b6784dded7604d0bc8f2c3d96e2
+  md5: 386f4295bbd9c0bb6ea2f6a9a8760d2a
   depends:
   - python
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-fastcdr
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-rmw-test-fixture
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-typesupport-fastrtps-c
+  - ros-kilted-rosidl-typesupport-fastrtps-cpp
+  - ros-kilted-tracetools
+  - ros-kilted-zenoh-cpp-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libzenohc >=1.5.1,<1.5.2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 21196
-  timestamp: 1759133897929
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-workspace-1.0.3-np126py312h3bd2861_10.conda
-  sha256: a6cdeb4918d9886db96dd14a436c863426ac804c37520fba2270671c3d188ff6
-  md5: ac5ee1d92135d01d66cf9b10047fac93
+  size: 331870
+  timestamp: 1759312084081
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-robot-state-publisher-3.4.2-np2py312h31f38b3_14.conda
+  sha256: 5594d113f1d49db669935eabaf1b39e2b205965511ae205cd6296472bbd564a1
+  md5: 339a85dd6459469b4d3fcaec124705d1
   depends:
   - python
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-kdl-parser
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-tf2-ros
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 35302
-  timestamp: 1759133887784
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2action-0.32.6-np126py312h3bd2861_10.conda
-  sha256: 69bd4ce547a8e13565d157d693848e950779c8bc91d2a9dca6218d9c5864b6c8
-  md5: 4261dd0395dd7a2f118dc8263b0ee2cc
+  size: 266660
+  timestamp: 1759314983138
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-base-0.12.0-np2py312h31f38b3_14.conda
+  sha256: 49e9f7b673ec59e12ff97777bb02456e352b36301c540a0d6db7eeb8892e91a4
+  md5: 491e4330e88b55aa746aafb6e67ca330
   depends:
   - python
-  - ros-jazzy-action-msgs
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-rosidl-runtime-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-geometry2
+  - ros-kilted-kdl-parser
+  - ros-kilted-robot-state-publisher
+  - ros-kilted-ros-core
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 47450
-  timestamp: 1759138982145
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2bag-0.26.9-np126py312h3bd2861_10.conda
-  sha256: 031189bf0e87180d36d239508456b78abc4beb585c432e6eff4507fb420f2f1d
-  md5: 1eb92c6e97923aa31eb44c0c27f201d5
+  size: 22223
+  timestamp: 1759318789787
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h31f38b3_14.conda
+  sha256: 12f4c47e69c1a444e5428c797741d95b7836db1efc816f52bbad76e92e46c7b8
+  md5: f1cbe5f0ba7aba686ebf54905a190a24
+  depends:
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-ament-cmake-auto
+  - ros-kilted-ament-cmake-gmock
+  - ros-kilted-ament-cmake-gtest
+  - ros-kilted-ament-cmake-pytest
+  - ros-kilted-ament-cmake-ros
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-ament-index-python
+  - ros-kilted-ament-lint-auto
+  - ros-kilted-ament-lint-common
+  - ros-kilted-class-loader
+  - ros-kilted-common-interfaces
+  - ros-kilted-launch
+  - ros-kilted-launch-ros
+  - ros-kilted-launch-testing
+  - ros-kilted-launch-testing-ament-cmake
+  - ros-kilted-launch-testing-ros
+  - ros-kilted-launch-xml
+  - ros-kilted-launch-yaml
+  - ros-kilted-pluginlib
+  - ros-kilted-rcl-lifecycle
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rclpy
+  - ros-kilted-ros-environment
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli-common-extensions
+  - ros-kilted-ros2launch
+  - ros-kilted-rosidl-default-generators
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-sros2
+  - ros-kilted-sros2-cmake
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 22953
+  timestamp: 1759316704626
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h31f38b3_14.conda
+  sha256: 229e716a40732f72571bd2772e504ef7a352f7cadb492f4b6cb18a940dcbce11
+  md5: 34d4e4d796a38ed8e0763f5b2f922794
+  depends:
+  - python
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 21164
+  timestamp: 1759310064778
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h31f38b3_14.conda
+  sha256: 47409d511530e8a6da7d064b1f796ceafc7408c5ffff85af76fc72451674458e
+  md5: 8ab07224e54e0fe2607c0480902e6db3
+  depends:
+  - python
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 35292
+  timestamp: 1759310053349
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.1-np2py312h31f38b3_14.conda
+  sha256: b9067769f7253971b95093a0cfa2cdfbe145f59a27d3edc880b53983d416804b
+  md5: 7a1085b37fbcd5a322035bb488f56176
+  depends:
+  - python
+  - ros-kilted-action-msgs
+  - ros-kilted-ament-index-python
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-ros2topic
+  - ros-kilted-rosidl-runtime-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 57007
+  timestamp: 1759314977746
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2bag-0.32.0-np2py312h31f38b3_14.conda
+  sha256: fedd4885765c9977318ecd2a4021f038a3a031971ba4bbfc3046cbde638b8945
+  md5: feee1ae9c5ab92ed51fb01782bbbe27a
   depends:
   - python
   - pyyaml
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-rosbag2-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-rosbag2-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 70906
-  timestamp: 1759141884021
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-0.32.6-np126py312h3bd2861_10.conda
-  sha256: 5fa312f8c9a1e2c6fd110bd6496739e14d31ddb63891a491dd1f3f197efdb11e
-  md5: 263ff9103e8220ffb8aa8d453436150a
+  size: 71775
+  timestamp: 1759317840934
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.1-np2py312h31f38b3_14.conda
+  sha256: 113d6e800fbce2a01d27843624cec8c9f5b9a140258779b6f17303f6ba89273f
+  md5: fc58e3bd42180daa4bd9ef78600a1cee
   depends:
   - argcomplete
   - importlib-metadata
   - packaging
   - psutil
   - python
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 75553
-  timestamp: 1759138307590
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-common-extensions-0.3.0-np126py312h3bd2861_10.conda
-  sha256: c7ced26a3b147437d55a0658a011e4d0b55cdf4685a9972b0621704a62b67701
-  md5: fdaae7901a16ca8bcac95ecb94806390
+  size: 75047
+  timestamp: 1759314163918
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.0-np2py312h31f38b3_14.conda
+  sha256: e19b096ce2a91adca387a87b023ee7ed3739fdca69ed8c66b4bcdb9be6909c55
+  md5: c0b46f5d26a13ed98624a39139ecebb1
   depends:
   - python
-  - ros-jazzy-launch-xml
-  - ros-jazzy-launch-yaml
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2action
-  - ros-jazzy-ros2cli
-  - ros-jazzy-ros2component
-  - ros-jazzy-ros2doctor
-  - ros-jazzy-ros2interface
-  - ros-jazzy-ros2launch
-  - ros-jazzy-ros2lifecycle
-  - ros-jazzy-ros2multicast
-  - ros-jazzy-ros2node
-  - ros-jazzy-ros2param
-  - ros-jazzy-ros2pkg
-  - ros-jazzy-ros2run
-  - ros-jazzy-ros2service
-  - ros-jazzy-ros2topic
-  - ros-jazzy-sros2
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-launch-xml
+  - ros-kilted-launch-yaml
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2action
+  - ros-kilted-ros2cli
+  - ros-kilted-ros2component
+  - ros-kilted-ros2doctor
+  - ros-kilted-ros2interface
+  - ros-kilted-ros2launch
+  - ros-kilted-ros2lifecycle
+  - ros-kilted-ros2multicast
+  - ros-kilted-ros2node
+  - ros-kilted-ros2param
+  - ros-kilted-ros2pkg
+  - ros-kilted-ros2run
+  - ros-kilted-ros2service
+  - ros-kilted-ros2topic
+  - ros-kilted-sros2
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
   size: 26564
-  timestamp: 1759140701384
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2component-0.32.6-np126py312h3bd2861_10.conda
-  sha256: 8e6fc3722298550ecf7602023c23c3c2fb549a43e424ee435ec1ac923518a1f3
-  md5: 794c2fa5a9617428640998dd7b9bc9ca
+  timestamp: 1759316348639
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2component-0.38.1-np2py312h31f38b3_14.conda
+  sha256: 21cc4f6a2501c0d19a2a36462e06a386c66f84ca16389cebbbd9c59ea4e783ec
+  md5: a0741c4ed2864e8dfd8d7c3906e65ed8
   depends:
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-composition-interfaces
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-ros2node
-  - ros-jazzy-ros2param
-  - ros-jazzy-ros2pkg
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-composition-interfaces
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclcpp-components
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-ros2node
+  - ros-kilted-ros2param
+  - ros-kilted-ros2pkg
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 37994
-  timestamp: 1759139839233
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2doctor-0.32.6-np126py312h3bd2861_10.conda
-  sha256: b8ce58dc818079448f612ca99f0168c33c406e791646acecb5a2e57b5ca4dc42
-  md5: bd93d203c53714eae363299ce2a8b539
+  size: 37952
+  timestamp: 1759315508171
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2doctor-0.38.1-np2py312h31f38b3_14.conda
+  sha256: b84b542a3062b825049ec10788061efa9a427756aaed786e39c62a3efa5c855e
+  md5: f153114836d6bc9c4f4f97bd4208f68b
   depends:
   - catkin_pkg
   - importlib-metadata
   - psutil
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-environment
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-python
+  - ros-kilted-rclpy
+  - ros-kilted-ros-environment
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - rosdistro
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 67612
-  timestamp: 1759138976282
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2interface-0.32.6-np126py312h3bd2861_10.conda
-  sha256: a3619dae2e62c6c1df9e84be23b6d7dae06f9816ad291919c3afb3ba23a2bce0
-  md5: f3e395a0c311e823a5b1a7fd70266446
+  size: 65726
+  timestamp: 1759314660116
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2interface-0.38.1-np2py312h31f38b3_14.conda
+  sha256: 70454087bd839b5bb76494d8b2424ce11a58c0442e929da2a7a8dec1af6c32c6
+  md5: 6d80ae565cbcf8212599138fcd69ea4d
   depends:
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-rosidl-adapter
-  - ros-jazzy-rosidl-runtime-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-rosidl-adapter
+  - ros-kilted-rosidl-runtime-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 46463
-  timestamp: 1759138967397
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2launch-0.26.9-np126py312h3bd2861_10.conda
-  sha256: 03ed142e0566c1734476d32489f27d02eeb7d8c2fb7b3c71ec2a7ff29a0c5e83
-  md5: 4851cfbba36ed59860c1d2912c56cb22
+  size: 46185
+  timestamp: 1759314651668
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2launch-0.28.3-np2py312h31f38b3_14.conda
+  sha256: 902cdcd9d2536c48552ec343243f867d827a849520851728962f843e2f3d87ab
+  md5: 081b54814d43ed836aa18e521a7bf3ae
   depends:
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-launch
-  - ros-jazzy-launch-ros
-  - ros-jazzy-launch-xml
-  - ros-jazzy-launch-yaml
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-ros2pkg
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-python
+  - ros-kilted-launch
+  - ros-kilted-launch-ros
+  - ros-kilted-launch-xml
+  - ros-kilted-launch-yaml
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-ros2pkg
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 46350
-  timestamp: 1759139191502
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2lifecycle-0.32.6-np126py312h3bd2861_10.conda
-  sha256: f82a9520f6297cdd82ccebc7499dce40f8b4ada8e2baea839b7fd4fa7f6b7e82
-  md5: 3e77332f55a96ad68bba48a741c462c1
+  size: 33472
+  timestamp: 1759314971871
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2lifecycle-0.38.1-np2py312h31f38b3_14.conda
+  sha256: 76c32e4c7c15fd3ffb74541a91350c5857972cb8c960ec4e1e3a94337581cba0
+  md5: cb384b0e86e9b7df9bd65b2fc6a73033
   depends:
   - python
-  - ros-jazzy-lifecycle-msgs
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-ros2node
-  - ros-jazzy-ros2service
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-lifecycle-msgs
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-ros2node
+  - ros-kilted-ros2service
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 45119
-  timestamp: 1759139560053
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2multicast-0.32.6-np126py312h3bd2861_10.conda
-  sha256: 501d54829e5b27bc6e1c1cd54bcfbc68d0c629753e26e351ef6b1731ee75f464
-  md5: 847b702c252c8de5afcfead44a50b5cc
+  size: 44949
+  timestamp: 1759315260593
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2multicast-0.38.1-np2py312h31f38b3_14.conda
+  sha256: 92b2d24b542c1f1e91d0039f193dd6385d254418ef34e8021b96d2f0a1360bec
+  md5: dfd4a405be14a55530f3269a7150b827
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 25532
-  timestamp: 1759138522774
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2node-0.32.6-np126py312h3bd2861_10.conda
-  sha256: 4e80967fcf91b1144fad9009b8c78e970f3dc2eba2cba09f3eeff526886a032b
-  md5: b615d960528f5478fe13c2d3f5c3c8be
+  size: 25496
+  timestamp: 1759314326771
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2node-0.38.1-np2py312h31f38b3_14.conda
+  sha256: 4e2429e63fe383f3c2a6b489c81927eeaedc88eb99e1c185dc589e0a4dd689d3
+  md5: 79ca25201caf057d5ffb83905860a4e9
   depends:
   - python
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 42873
-  timestamp: 1759138962330
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2param-0.32.6-np126py312h3bd2861_10.conda
-  sha256: ba87d8d5b53fd2117d99a9213a1e5c6c308e78f3e6b91929fb0cfd6a54fc6a53
-  md5: 2d3ee0fed29c59c1dcb66badb2aa71a6
+  size: 42662
+  timestamp: 1759314630459
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2param-0.38.1-np2py312h31f38b3_14.conda
+  sha256: 940fcd981f3664f0953d330136cd9341f86196e6eb462d8874f3ae9313302467
+  md5: 5f5d200cc810e0b4813f65faad515d9d
   depends:
   - python
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-ros2node
-  - ros-jazzy-ros2service
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-ros2node
+  - ros-kilted-ros2service
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 50118
-  timestamp: 1759139545420
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2pkg-0.32.6-np126py312h3bd2861_10.conda
-  sha256: 57b716431a9d9a41e0e161204416abc4b55b11ad0553ea452072e0120e0fb165
-  md5: 7d9bb8d7ebd4f1c373b5ca3ec3c70fca
+  size: 49982
+  timestamp: 1759315237495
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2pkg-0.38.1-np2py312h31f38b3_14.conda
+  sha256: 5ec357ddfd8b5c0b360097a0526154dadbdb0b90ce4f5a63d4067c08ecf71806
+  md5: 6582440f68c484f54815384238327172
   depends:
   - catkin_pkg
   - empy
   - importlib_resources
   - python
-  - ros-jazzy-ament-copyright
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-copyright
+  - ros-kilted-ament-index-python
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 57895
-  timestamp: 1759138957095
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2run-0.32.6-np126py312h3bd2861_10.conda
-  sha256: 1bc47672bff0f4beadee0cc550efcecf714d2ce965344de46dee1f1690ee0be0
-  md5: 9a489d806586ac557367adfc5e2e1b32
+  size: 58004
+  timestamp: 1759314624633
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2run-0.38.1-np2py312h31f38b3_14.conda
+  sha256: d3c16426e2fcb7a75c10fd1b539b5eaaface2d78b3331c1b669916015fa9b414
+  md5: ae7447422ad7c7016e97895f5a53786d
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-ros2pkg
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-ros2pkg
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 24631
-  timestamp: 1759139218388
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2service-0.32.6-np126py312h3bd2861_10.conda
-  sha256: c1cb547993691cdd77831ec10dc9899986c442d99782feb2bd7843e327dd109b
-  md5: 9c507683ea88d0b5cf43614f7fa79ff9
+  size: 25061
+  timestamp: 1759314977818
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2service-0.38.1-np2py312h31f38b3_14.conda
+  sha256: 799248c7bb6e6a4a01855c8feff8e0103d4d11b6eeef7a32e396593e46b874f2
+  md5: 9182c929c71e57b052fe0679b632f765
   depends:
   - python
   - pyyaml
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-ros2topic
-  - ros-jazzy-rosidl-runtime-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-ros2topic
+  - ros-kilted-rosidl-runtime-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 51443
-  timestamp: 1759139206309
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2topic-0.32.6-np126py312h3bd2861_10.conda
-  sha256: 036443a8f78b1db89992892ff8dd6ae90de05efe78b27af1d270b54ccd6e331a
-  md5: 8caa80e20e89d4dfb2d7e4a82fb1aaed
+  size: 51476
+  timestamp: 1759314969338
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2topic-0.38.1-np2py312h31f38b3_14.conda
+  sha256: 9e0812a6c0569daae016b856a1ba877869d68ea5c069d51def954c9330bab3a7
+  md5: f39e593b86d0f66b93078e3b31330be1
   depends:
   - numpy
   - python
   - pyyaml
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-rosidl-runtime-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-rosidl-runtime-py
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 73969
-  timestamp: 1759138948583
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-0.26.9-np126py312h3bd2861_10.conda
-  sha256: 0627fc2b3ddd5e89afa5406cdd050331161c18de25f6ca5c3c6f0a19d1f81b58
-  md5: 61d3f9ffa8b512592a607c467e4f44de
+  size: 79016
+  timestamp: 1759314616037
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 80c6ebffd2824359548af80e60c406ac6f8c0cf154249e9bc717edf6c7b6c1fe
+  md5: 927bb921645b8e53447c79f7c56e6034
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2bag
-  - ros-jazzy-rosbag2-compression
-  - ros-jazzy-rosbag2-compression-zstd
-  - ros-jazzy-rosbag2-cpp
-  - ros-jazzy-rosbag2-py
-  - ros-jazzy-rosbag2-storage
-  - ros-jazzy-rosbag2-storage-default-plugins
-  - ros-jazzy-rosbag2-transport
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2bag
+  - ros-kilted-rosbag2-compression
+  - ros-kilted-rosbag2-compression-zstd
+  - ros-kilted-rosbag2-cpp
+  - ros-kilted-rosbag2-py
+  - ros-kilted-rosbag2-storage
+  - ros-kilted-rosbag2-storage-default-plugins
+  - ros-kilted-rosbag2-transport
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 35314
-  timestamp: 1759142416071
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-compression-0.26.9-np126py312h3bd2861_10.conda
-  sha256: ecf2fc6ccf7604f6f8692ad4f00acb37b565c77a3a47c2cc1baa40662cbcbdd2
-  md5: f7e0c70980bf5950eaa89cff49876e1b
+  size: 34558
+  timestamp: 1759318699263
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-0.32.0-np2py312h31f38b3_14.conda
+  sha256: c791e2c9eadd83bdd3d842b4cee2b7df73b74923b88a97e0aa4e513b3a2bd92c
+  md5: 4da9cf13d3a3b36627b9045404411c31
   depends:
   - python
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2-cpp
-  - ros-jazzy-rosbag2-storage
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2-cpp
+  - ros-kilted-rosbag2-storage
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 205064
-  timestamp: 1759140551619
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-compression-zstd-0.26.9-np126py312h3bd2861_10.conda
-  sha256: 335930026aab021d50caccfebf981dbb29e1beace22b4cb0857bd9a07814c338
-  md5: 1c01047f7c75297c42e0dd2a2a875d85
+  size: 202401
+  timestamp: 1759316355006
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-zstd-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 794c5469c16129e44382d983489dada706a0177938df1eaf125bddd382690d20
+  md5: 387abfe7574efa1197a1c34c3323c5c6
   depends:
   - python
-  - ros-jazzy-pluginlib
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2-compression
-  - ros-jazzy-zstd-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-pluginlib
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2-compression
+  - ros-kilted-zstd-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 69920
-  timestamp: 1759140855189
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-cpp-0.26.9-np126py312h3bd2861_10.conda
-  sha256: ae4a5746142620fdf531fbb67c4ce4141f079060c3aee9f7e705806c660c40c8
-  md5: 31d81a4eb3feb7f95561f1d7461dd40a
+  size: 69523
+  timestamp: 1759316677405
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-cpp-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 2fdf677975f712b103e29976d2298043ab6a5011d9e7ad949e6675ba367177fe
+  md5: b4b5c8f5eda3865ffde921df49e5afa6
   depends:
   - python
-  - ros-jazzy-ament-index-cpp
-  - ros-jazzy-pluginlib
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-rmw-implementation
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2-storage
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros-jazzy-rosidl-typesupport-cpp
-  - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-rmw-implementation
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2-storage
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-runtime-cpp
+  - ros-kilted-rosidl-typesupport-cpp
+  - ros-kilted-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 349336
-  timestamp: 1759139610816
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-interfaces-0.26.9-np126py312h3bd2861_10.conda
-  sha256: a3b838ecb210795db8d5ce070dd2799c01200906bbb0751e915acb907291770a
-  md5: c5a4ea1feb07626b8e435569954328de
+  size: 352644
+  timestamp: 1759315519657
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-interfaces-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 7a0cf48c240f7e21788c5789e7df4f0ba85a0a1768f6b36b730c4348873b017f
+  md5: 7aa34cba2e71c64376bb9b69b81d185a
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 460923
-  timestamp: 1759136590937
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-py-0.26.9-np126py312h3bd2861_10.conda
-  sha256: e4598a1b71e133259aa9fa2b35c329f42bc089cd1383f0ae29c12f43e6e80204
-  md5: c16cb92f05bfe086187f8d1a14225d4e
+  size: 459395
+  timestamp: 1759312369402
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-py-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 690099fa284f10d831d31191d6d5b40fc73e01b4971ab045c7ae5de85d255918
+  md5: cf14df7f82014de184e6f1e07d836d09
   depends:
   - python
-  - ros-jazzy-pybind11-vendor
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2-compression
-  - ros-jazzy-rosbag2-cpp
-  - ros-jazzy-rosbag2-storage
-  - ros-jazzy-rosbag2-transport
-  - ros-jazzy-rpyutils
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-pybind11-vendor
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2-compression
+  - ros-kilted-rosbag2-cpp
+  - ros-kilted-rosbag2-storage
+  - ros-kilted-rosbag2-transport
+  - ros-kilted-rpyutils
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 791611
-  timestamp: 1759141642047
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-storage-0.26.9-np126py312h3bd2861_10.conda
-  sha256: d98ed3067864b772119d28e4facc094bb5a9c17813785d14a2353bb25b91d19d
-  md5: a8505a8aec773203f7a486d56c91a46a
+  size: 763819
+  timestamp: 1759317475644
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 53c8973d054dc8dbf433b07f26a28e2b10da2e76608029cc40acff60bfa3bd92
+  md5: 813a0956bdef0c27fcd704f9c31e7e5c
   depends:
   - python
-  - ros-jazzy-pluginlib
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-yaml-cpp-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-yaml-cpp-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 277994
-  timestamp: 1759138506727
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-storage-default-plugins-0.26.9-np126py312h3bd2861_10.conda
-  sha256: 8b5053c566e58889e24dd6d4fc4cdb4f2fe92156d8b1165e76bc143b0bc91ff1
-  md5: 0857d7d55c39c1df2a338cc1850d8c25
+  size: 271942
+  timestamp: 1759314602993
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-default-plugins-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 1027ce367f2687979daf4941c8fc06b022864a60b9ce92e99869f72055d7f265
+  md5: 684de0773cc7e95647bd12dbd0679441
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2-storage-mcap
-  - ros-jazzy-rosbag2-storage-sqlite3
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2-storage-mcap
+  - ros-kilted-rosbag2-storage-sqlite3
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 22192
-  timestamp: 1759139382680
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-storage-mcap-0.26.9-np126py312h3bd2861_10.conda
-  sha256: e85804264c328c43fd03be899f0eaf66dd70a0255af933a3fe8b2684720d1049
-  md5: d5201d71de1b13f54e3697acff610d52
+  size: 22225
+  timestamp: 1759315246230
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-mcap-0.32.0-np2py312h31f38b3_14.conda
+  sha256: f103085dfd5d7d1ba06f6ad1875a07bb1e86bba94346bef77a11e8abea4e12dd
+  md5: 243fc8c34c83cb204a2a4beb220f9450
   depends:
   - python
-  - ros-jazzy-ament-index-cpp
-  - ros-jazzy-mcap-vendor
-  - ros-jazzy-pluginlib
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2-storage
-  - ros-jazzy-yaml-cpp-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-mcap-vendor
+  - ros-kilted-pluginlib
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2-storage
+  - ros-kilted-yaml-cpp-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 197357
-  timestamp: 1759139095894
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-storage-sqlite3-0.26.9-np126py312h3bd2861_10.conda
-  sha256: b3260513e37b9d015c4621baf345bb9e3095e4ae324549b61474febb77fca90c
-  md5: b94f7f2296bb80fb1782a4b08afcefed
+  size: 195060
+  timestamp: 1759314934071
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-sqlite3-0.32.0-np2py312h31f38b3_14.conda
+  sha256: f86846999d2fd0658521de8d2c43fad6dddfa64018f3fbc15b8c6f5c1104c915
+  md5: b7be939b470f3f544982a7802b5e93cc
   depends:
   - python
-  - ros-jazzy-pluginlib
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2-storage
-  - ros-jazzy-sqlite3-vendor
-  - ros-jazzy-yaml-cpp-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-pluginlib
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2-storage
+  - ros-kilted-sqlite3-vendor
+  - ros-kilted-yaml-cpp-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 244169
-  timestamp: 1759139078134
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosbag2-transport-0.26.9-np126py312h3bd2861_10.conda
-  sha256: c9bd082669afde256f245bada988bc6a46f56ee60e64a3dc0279098a062d73cf
-  md5: bc8786f0649a8a0daec24436a8cc6093
+  size: 243879
+  timestamp: 1759315008540
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-transport-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 97e35d6690b7970e25dc7e0b1bf570dd43f871e5d375a0ba8ad99b64f7492b0b
+  md5: 430ed91fc598b4bc48311bdee40a0017
   depends:
   - python
-  - ros-jazzy-keyboard-handler
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2-compression
-  - ros-jazzy-rosbag2-cpp
-  - ros-jazzy-rosbag2-interfaces
-  - ros-jazzy-rosbag2-storage
-  - ros-jazzy-yaml-cpp-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-keyboard-handler
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-rclcpp-components
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2-compression
+  - ros-kilted-rosbag2-cpp
+  - ros-kilted-rosbag2-interfaces
+  - ros-kilted-rosbag2-storage
+  - ros-kilted-yaml-cpp-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 526480
-  timestamp: 1759141121630
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosgraph-msgs-2.0.3-np126py312h3bd2861_10.conda
-  sha256: 4b4ee7e4040cc05e7edc39eb1b1cee5b81336fda96ceffd0be1755b7a9ce5b41
-  md5: bae2502ca3142a4fb27825194ba6ea09
+  size: 556911
+  timestamp: 1759317082932
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosgraph-msgs-2.3.0-np2py312h31f38b3_14.conda
+  sha256: 5d5b2d9e1740d779334e7e171ad7321b7add88b70e5ec55e2d2eeb197262f417
+  md5: bfe1c4aff98b1815d0a8b17a5954b646
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 72341
-  timestamp: 1759136567175
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-adapter-4.6.6-np126py312h3bd2861_10.conda
-  sha256: d4e44209fc8e8cf5f6796d129ee59d5a09f8c2e6a992f5a8b79a12c91c57715c
-  md5: 65e07ac650b8a5b65fa3d534f07bb2e0
+  size: 69954
+  timestamp: 1759312334166
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-adapter-4.9.5-np2py312h31f38b3_14.conda
+  sha256: 0c83bdafdebe4a83563b9d5d49c1001b53e40746bf4daf5367562bc2ca24bcd6
+  md5: 61eaebbf670e7074d1a3171094996380
   depends:
   - empy
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 63288
-  timestamp: 1759135143582
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cli-4.6.6-np126py312h3bd2861_10.conda
-  sha256: 2d0cf10e2fcf9455c393bb83b51d4c89576dfdebec3d82453e1da5621d2258e2
-  md5: 5c0702b63578a68dc61e488c7ac6859f
+  size: 67544
+  timestamp: 1759311189658
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cli-4.9.5-np2py312h31f38b3_14.conda
+  sha256: 38d61db007c8327ee95b5241b5fe74f7d0a2c965c23fc812349b6693b9df0355
+  md5: 12fce500177e1e29d403f9a59bee7a49
   depends:
   - argcomplete
   - importlib-metadata
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 42559
-  timestamp: 1759134512964
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cmake-4.6.6-np126py312h3bd2861_10.conda
-  sha256: 99fbda6a89be497eb3e54b67fc6f9be2efb7cf721b1bf5d9c85799f29145f40b
-  md5: 654b00ca14494136e3454d97ff072ddc
+  size: 46182
+  timestamp: 1759310688725
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cmake-4.9.5-np2py312h31f38b3_14.conda
+  sha256: a12d7b8d12d0057310f9d021c69d5afdb23472873d557e5c5661d3361aba71de
+  md5: 55a2d21b0706f6f074e19be62290188c
   depends:
   - empy
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-pycommon
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-pycommon
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 35018
-  timestamp: 1759135749979
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-generators-0.2.0-np126py312h3bd2861_10.conda
-  sha256: d911d18c36fe0820c24c841361febac70a066284281a725c70cbf54f5338b499
-  md5: 0ad733400e3d217ccaa1b71bcd2558da
+  size: 34996
+  timestamp: 1759311796824
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-generators-0.3.1-np2py312h31f38b3_14.conda
+  sha256: 67e22fc5b90f053bff2ec7e2f0dbb3618473cd901d14566e5f49b349273492c4
+  md5: 456ad38f45d89837355516ca1e7bcf29
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cmake
-  - ros-jazzy-rosidl-generator-c
-  - ros-jazzy-rosidl-generator-cpp
-  - ros-jazzy-rosidl-generator-py
-  - ros-jazzy-rosidl-generator-type-description
-  - ros-jazzy-rosidl-typesupport-c
-  - ros-jazzy-rosidl-typesupport-cpp
-  - ros-jazzy-rosidl-typesupport-fastrtps-c
-  - ros-jazzy-rosidl-typesupport-fastrtps-cpp
-  - ros-jazzy-rosidl-typesupport-introspection-c
-  - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cmake
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-generator-cpp
+  - ros-kilted-rosidl-generator-py
+  - ros-kilted-rosidl-generator-type-description
+  - ros-kilted-rosidl-typesupport-c
+  - ros-kilted-rosidl-typesupport-cpp
+  - ros-kilted-rosidl-typesupport-fastrtps-c
+  - ros-kilted-rosidl-typesupport-fastrtps-cpp
+  - ros-kilted-rosidl-typesupport-introspection-c
+  - ros-kilted-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 32136
-  timestamp: 1759136331062
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-runtime-0.2.0-np126py312h3bd2861_10.conda
-  sha256: 9efabedab52314ae05188b49254b682280de9385575708957322ab4a120f073a
-  md5: ffa316df1ea2920a88724d0fbb9aa52a
+  size: 30529
+  timestamp: 1759312154247
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-runtime-0.3.1-np2py312h31f38b3_14.conda
+  sha256: 9ce6c7c140431faa6aac10616e0a1a640ce1a74e06f92f0d3547750339aae89b
+  md5: f0ab7d0c82c0b589a2a68ae2d7a5e1fa
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-generator-py
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros-jazzy-rosidl-typesupport-c
-  - ros-jazzy-rosidl-typesupport-cpp
-  - ros-jazzy-rosidl-typesupport-fastrtps-c
-  - ros-jazzy-rosidl-typesupport-fastrtps-cpp
-  - ros-jazzy-rosidl-typesupport-introspection-c
-  - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-generator-py
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-runtime-cpp
+  - ros-kilted-rosidl-typesupport-c
+  - ros-kilted-rosidl-typesupport-cpp
+  - ros-kilted-rosidl-typesupport-fastrtps-c
+  - ros-kilted-rosidl-typesupport-fastrtps-cpp
+  - ros-kilted-rosidl-typesupport-introspection-c
+  - ros-kilted-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 31161
-  timestamp: 1759136319716
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-generators-1.6.0-np126py312h3bd2861_10.conda
-  sha256: a707114fd8b64ea02a81423a611e25e9e6e531b897a6dc60734bb1a162d3454b
-  md5: a670201c019c39ef93155a4234af1c9e
+  size: 29555
+  timestamp: 1759312142546
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-generators-1.7.1-np2py312h31f38b3_14.conda
+  sha256: 09eb66284a8e75e176ca6dda64c3045294227ba670e96b012dcec93728528f9d
+  md5: 33cc8799ecf250bf13eefb0d95fd2e70
   depends:
   - python
-  - ros-jazzy-action-msgs
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-core-generators
-  - ros-jazzy-service-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-action-msgs
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-core-generators
+  - ros-kilted-service-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 32409
-  timestamp: 1759136496815
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-runtime-1.6.0-np126py312h3bd2861_10.conda
-  sha256: 23b17a498e31ec797ead5204d4b3bd1dab9b23bb86dcc2f96c87896a2e1e0b58
-  md5: a1c88648a1ee798ae6ba8a3cdd8fecf4
+  size: 30711
+  timestamp: 1759312282465
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-runtime-1.7.1-np2py312h31f38b3_14.conda
+  sha256: b62910346237ccec34c378d6da9343c77a361f610500f38dee59321bed5c13a8
+  md5: 6cee4bcbd1d2f7f846a137e2d50b5873
   depends:
   - python
-  - ros-jazzy-action-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-core-runtime
-  - ros-jazzy-service-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-action-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-core-runtime
+  - ros-kilted-service-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 31814
-  timestamp: 1759136484793
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-0.1.2-np126py312h3bd2861_10.conda
-  sha256: ba35997f90df5939af3b9c32a5bbfd4e144c1a0fa2edba0c93f3f1d08ac1b245
-  md5: 0409589abcc712e53499a63270c64b2b
+  size: 30142
+  timestamp: 1759312270762
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h31f38b3_14.conda
+  sha256: 8dd0efee75e70518f3b5c0f966facfa1eaffceaaf024ad9676bd1a0968e6eb49
+  md5: c6def2250d3023afd1499afd5c9414b4
   depends:
   - python
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-c
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-c
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 62858
-  timestamp: 1759135845185
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-fastrtps-0.1.0-np126py312h3bd2861_10.conda
-  sha256: 30eefec9684ce8bc9761984cab745ebe8f8ab2786af5e559c3144e8290d1a0ef
-  md5: 6d3ac5d660f36ce2d5a505547f8f0ae2
+  size: 60759
+  timestamp: 1759311815446
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.1-np2py312h31f38b3_14.conda
+  sha256: 7826e59c075ccbecd495a3ec4887fbdce110876b315027b50c52f61cb413b119
+  md5: 29b4e77f22add686f679e4a184092dad
   depends:
   - python
-  - ros-jazzy-fastcdr
-  - ros-jazzy-fastrtps
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-dynamic-typesupport
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-fastcdr
+  - ros-kilted-fastdds
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-dynamic-typesupport
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 86349
-  timestamp: 1759135926381
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-c-4.6.6-np126py312h3bd2861_10.conda
-  sha256: 35d42979abd9bcd8ee251889e97744ae111fb5a3626b98b76f7d58b329b521da
-  md5: 720f8420b90a66e5a25c4cd5d8325bb2
+  size: 82157
+  timestamp: 1759311870504
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-c-4.9.5-np2py312h31f38b3_14.conda
+  sha256: 150d840cb43a46e3bf217ef957620ae6917a31dcdfb8db6e594e5d5854287cf9
+  md5: 5e7182bdc7f89ca1bef2f5f4d559b07d
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros-jazzy-rosidl-cmake
-  - ros-jazzy-rosidl-generator-type-description
-  - ros-jazzy-rosidl-parser
-  - ros-jazzy-rosidl-pycommon
-  - ros-jazzy-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-index-python
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros-kilted-rosidl-cmake
+  - ros-kilted-rosidl-generator-type-description
+  - ros-kilted-rosidl-parser
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 53004
-  timestamp: 1759135839591
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-cpp-4.6.6-np126py312h3bd2861_10.conda
-  sha256: e62600644173e5d1c5c6ebe8472f9d8abe366f0cfc2e8918e2f76ef0143a3ebd
-  md5: 88adcc872b754780da08c6b69849e254
+  size: 51753
+  timestamp: 1759311851950
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-cpp-4.9.5-np2py312h31f38b3_14.conda
+  sha256: 30d2398b7081c4e16da7294b2728e11a983efad06afebf0e1b9f6a4fd78c0de3
+  md5: e60f2e4555f4fe702c64b758b04cb243
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros-jazzy-rosidl-cmake
-  - ros-jazzy-rosidl-generator-c
-  - ros-jazzy-rosidl-generator-type-description
-  - ros-jazzy-rosidl-parser
-  - ros-jazzy-rosidl-pycommon
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-index-python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros-kilted-rosidl-cmake
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-generator-type-description
+  - ros-kilted-rosidl-parser
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 49898
-  timestamp: 1759135902089
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-py-0.22.1-np126py312h3bd2861_10.conda
-  sha256: 775e66067ffaa69912fe55fdf494503c81ecdbb1b651e9f15737ab63540cff4b
-  md5: 0cb58a98294d974d0cb6b1a58e6e0ce1
+  size: 49944
+  timestamp: 1759311925512
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-py-0.24.1-np2py312h31f38b3_14.conda
+  sha256: 2a993c8ef46feab1f4bbb5e299e0843f426bbb77caf92d2ba4db15279f865c65
+  md5: e70445c927f8695457647fa43136883c
   depends:
   - numpy
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ament-cmake-cppcheck
-  - ros-jazzy-ament-cmake-cpplint
-  - ros-jazzy-ament-cmake-flake8
-  - ros-jazzy-ament-cmake-pep257
-  - ros-jazzy-ament-cmake-uncrustify
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-python-cmake-module
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros-jazzy-rosidl-generator-c
-  - ros-jazzy-rosidl-parser
-  - ros-jazzy-rosidl-pycommon
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-typesupport-c
-  - ros-jazzy-rosidl-typesupport-interface
-  - ros-jazzy-rpyutils
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake
+  - ros-kilted-ament-cmake-cppcheck
+  - ros-kilted-ament-cmake-cpplint
+  - ros-kilted-ament-cmake-flake8
+  - ros-kilted-ament-cmake-pep257
+  - ros-kilted-ament-cmake-uncrustify
+  - ros-kilted-ament-index-python
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-parser
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-typesupport-c
+  - ros-kilted-rosidl-typesupport-interface
+  - ros-kilted-rpyutils
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 59990
-  timestamp: 1759136277836
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-type-description-4.6.6-np126py312h3bd2861_10.conda
-  sha256: 1d01791814ce42808f232d8d7857ab94f21d23084580ac2d84834426dd365ec2
-  md5: 159c33cc74b36a7ebfe6e49a416b5d6e
+  size: 59345
+  timestamp: 1759312118277
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-type-description-4.9.5-np2py312h31f38b3_14.conda
+  sha256: 5e06d1b8eabafaf01012559097681f360e301833e00062b5c3b90080e9278a1a
+  md5: a73ff94312a1b4d8ffedd1aab2243328
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros-jazzy-rosidl-parser
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-index-python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros-kilted-rosidl-parser
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 48511
-  timestamp: 1759135649822
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-parser-4.6.6-np126py312h3bd2861_10.conda
-  sha256: 9cda9c91fe734345c9f83e22b24da0045eccf150a7840892d834d5c8c5c42563
-  md5: 288b24a8d8cb17b4a3e0b2d9c2dcb35f
+  size: 45865
+  timestamp: 1759311760230
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-parser-4.9.5-np2py312h31f38b3_14.conda
+  sha256: 43cca8a840ec804c5daec247a373ea6c72085c4eeeef2ab7790c2b238ab61bfa
+  md5: 3f406585a95ff5bf76b9d20a17a3a99d
   depends:
   - lark-parser
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-adapter
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-adapter
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 60062
-  timestamp: 1759135545410
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-pycommon-4.6.6-np126py312h3bd2861_10.conda
-  sha256: d1a68a4629d184f840098436e13e276c5b39e964f76374a584168e23d4ce82ce
-  md5: a83a0fedc51d37628dc4230dd37af24c
+  size: 65692
+  timestamp: 1759311571028
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-pycommon-4.9.5-np2py312h31f38b3_14.conda
+  sha256: b517edd258b624483e131c3ab6fd7bc769cc7008bf38f0f6e4b8a17022c295b5
+  md5: bd37bc80a1952f39dec3d0010eeefb09
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-parser
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-parser
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 25122
-  timestamp: 1759135643674
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-c-4.6.6-np126py312h3bd2861_10.conda
-  sha256: a6becfeb81b3f1b1eb63ca9bf15b255a03c2319a978e1ea450751ceff0f01070
-  md5: dca4734bd880fb4dd628ab01d02a8924
+  size: 26656
+  timestamp: 1759311741952
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-c-4.9.5-np2py312h31f38b3_14.conda
+  sha256: ac9cda7c0bb20febbf53f9b1c8403b9a2e566a192dcfa2a844c362263a6ec499
+  md5: b32db92511c76411e52397aa850027ac
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 83310
-  timestamp: 1759135737006
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-cpp-4.6.6-np126py312h3bd2861_10.conda
-  sha256: 1a6c8a7ce90474afb3089c2902243b43793c27349a8efbbb4be600a9182b8773
-  md5: c82c6d7a2ccb6c100a78b450171435d2
+  size: 82232
+  timestamp: 1759311753527
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-cpp-4.9.5-np2py312h31f38b3_14.conda
+  sha256: 0d687e8bf58dcb0312489b0e90087a6eeeea4b6d4e69863c01bcf1bfab5fc734
+  md5: 45c65a09b707c7b9989440868b27dd2b
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-c
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-c
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 40765
-  timestamp: 1759135826231
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-py-0.13.1-np126py312h3bd2861_10.conda
-  sha256: 1f5f15b6e9aeda80b12430b17ebfb56cba1e3f23a15dd389638eca535f3eda22
-  md5: cc871aee15e43c56ef46160cf9486b27
+  size: 40757
+  timestamp: 1759311809820
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h31f38b3_14.conda
+  sha256: 33402febf6de03991b93d418e6f7bc403832c305b4d78fb7244bbff886e2a8a5
+  md5: 4b3f31d0de081b6bda135a41b93508e5
   depends:
   - numpy
   - python
   - pyyaml
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-parser
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-parser
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 47292
-  timestamp: 1759136811336
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-c-3.2.2-np126py312h3bd2861_10.conda
-  sha256: 48d323f3ee531a77655bb0aed03ef9ae0a7c8b94af626cb7a3ce1eb9405fabe3
-  md5: 529f9ffa0a73fcf8c41f1964d16e5022
+  size: 46384
+  timestamp: 1759312507444
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h31f38b3_14.conda
+  sha256: 9759a256878307744906f3399ec505dc3997f242ee11a533812910a0c383be4e
+  md5: 1743ce563643ccfd55689513cbf02a3f
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros-jazzy-rosidl-generator-c
-  - ros-jazzy-rosidl-pycommon
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-typesupport-fastrtps-c
-  - ros-jazzy-rosidl-typesupport-interface
-  - ros-jazzy-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-index-python
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-typesupport-fastrtps-c
+  - ros-kilted-rosidl-typesupport-interface
+  - ros-kilted-rosidl-typesupport-introspection-c
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 50864
-  timestamp: 1759136231797
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-cpp-3.2.2-np126py312h3bd2861_10.conda
-  sha256: 6443733659f9f5d6e4514b075f06663af3cdf7300d2016d17c81c594159d4e0e
-  md5: e03c02f670e399757b56a524e89a4090
+  size: 50295
+  timestamp: 1759312068254
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h31f38b3_14.conda
+  sha256: 9009aa9865364caf6ef6ffae113f5388e5fdbcf9de25ce7852c277d05ac545b4
+  md5: b47eaf214b3ad9bd2a5ba83b653084fa
   depends:
   - python
-  - ros-jazzy-ament-cmake-core
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-rcpputils
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros-jazzy-rosidl-generator-c
-  - ros-jazzy-rosidl-generator-type-description
-  - ros-jazzy-rosidl-pycommon
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros-jazzy-rosidl-typesupport-c
-  - ros-jazzy-rosidl-typesupport-fastrtps-cpp
-  - ros-jazzy-rosidl-typesupport-interface
-  - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-index-python
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-generator-type-description
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-runtime-cpp
+  - ros-kilted-rosidl-typesupport-c
+  - ros-kilted-rosidl-typesupport-fastrtps-cpp
+  - ros-kilted-rosidl-typesupport-interface
+  - ros-kilted-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 50085
-  timestamp: 1759136271816
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-c-3.6.2-np126py312h3bd2861_10.conda
-  sha256: 9bee9940d28266a5542570de567e631365e5c98801f91c414d4a828edd2183db
-  md5: 47b54ef7ab0a20ae0b52b5bea6427c60
+  size: 49411
+  timestamp: 1759312112524
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.1-np2py312h31f38b3_14.conda
+  sha256: 44c5e23028e1c70c771bd1ca74f3056b864db681d14a4fa68e6da837b3380baf
+  md5: 71bc651578e4d2d57ffd3095c82ac224
   depends:
   - python
-  - ros-jazzy-ament-cmake-ros
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-fastcdr
-  - ros-jazzy-fastrtps-cmake-module
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros-jazzy-rosidl-generator-c
-  - ros-jazzy-rosidl-pycommon
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros-jazzy-rosidl-typesupport-fastrtps-cpp
-  - ros-jazzy-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake-ros-core
+  - ros-kilted-ament-index-python
+  - ros-kilted-fastcdr
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-runtime-cpp
+  - ros-kilted-rosidl-typesupport-fastrtps-cpp
+  - ros-kilted-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 51692
-  timestamp: 1759136159703
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-cpp-3.6.2-np126py312h3bd2861_10.conda
-  sha256: 98b40c4a00ece5b171619985d8ee1feff9669f3538c2192f19fe1560b37d8a35
-  md5: fafacfc793c18e2fc40e6d5b347d73bc
+  size: 51119
+  timestamp: 1759312041834
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.1-np2py312h31f38b3_14.conda
+  sha256: 8a8ba77bde6059afbfb87c9678f587c9cad7f04d9eb6f1426c2247a13288e6cf
+  md5: 0a3400e7ed374883d96ecbdb81ceae64
   depends:
   - python
-  - ros-jazzy-ament-cmake-ros
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-fastcdr
-  - ros-jazzy-fastrtps-cmake-module
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros-jazzy-rosidl-generator-c
-  - ros-jazzy-rosidl-generator-cpp
-  - ros-jazzy-rosidl-pycommon
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros-jazzy-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-cmake-ros-core
+  - ros-kilted-ament-index-python
+  - ros-kilted-fastcdr
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-generator-cpp
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-runtime-cpp
+  - ros-kilted-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 53698
-  timestamp: 1759135981264
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-interface-4.6.6-np126py312h3bd2861_10.conda
-  sha256: 77fb97f9d5367b0ea2aadde2a4f004532bb56248a8f5b2ec7e5bcf24bf2ddd61
-  md5: 248b1c0c3fb1761ea4e17f6d0303b8f8
+  size: 53096
+  timestamp: 1759311999036
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-interface-4.9.5-np2py312h31f38b3_14.conda
+  sha256: 3b3f57645000981297601f39055a19c7435298785d327d088d9908f1217f41c3
+  md5: d4da90f5206cfccc880b41edd12f9675
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 29117
-  timestamp: 1759135163731
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-c-4.6.6-np126py312h3bd2861_10.conda
-  sha256: 6f30e4ae7a3c8c68ae98fb734e5b7366cb76de492d1e9af69b699bee3b1fdd1c
-  md5: 2ecb6407e4c9b99625e7b9134597ba46
+  size: 29104
+  timestamp: 1759311219318
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.5-np2py312h31f38b3_14.conda
+  sha256: b23a92c31665576f21e30e74f5cdb71ca3fe2875654bc5ee9f775f8b937940cd
+  md5: 1c86d6841bbf2196d546267d62fb221a
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros-jazzy-rosidl-cmake
-  - ros-jazzy-rosidl-generator-c
-  - ros-jazzy-rosidl-parser
-  - ros-jazzy-rosidl-pycommon
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake
+  - ros-kilted-ament-index-python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros-kilted-rosidl-cmake
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-parser
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 48037
-  timestamp: 1759135921391
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-cpp-4.6.6-np126py312h3bd2861_10.conda
-  sha256: 5fabcdd7b3ad4b763ab731ebc56d25507597a172542f4a5e052b788ce2fc671b
-  md5: c530712c799ea65fa4e9fbdbdd8b295a
+  size: 46605
+  timestamp: 1759311939839
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.5-np2py312h31f38b3_14.conda
+  sha256: d3508457eb30a994959f7b76d9c9e8f45a4247f55728e3ac39377b498a113db1
+  md5: 980e7f5acae739bf1ecb34b87fc0423b
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-cli
-  - ros-jazzy-rosidl-cmake
-  - ros-jazzy-rosidl-generator-c
-  - ros-jazzy-rosidl-generator-cpp
-  - ros-jazzy-rosidl-parser
-  - ros-jazzy-rosidl-pycommon
-  - ros-jazzy-rosidl-runtime-c
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros-jazzy-rosidl-typesupport-interface
-  - ros-jazzy-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake
+  - ros-kilted-ament-index-python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-cli
+  - ros-kilted-rosidl-cmake
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-generator-cpp
+  - ros-kilted-rosidl-parser
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-runtime-c
+  - ros-kilted-rosidl-runtime-cpp
+  - ros-kilted-rosidl-typesupport-interface
+  - ros-kilted-rosidl-typesupport-introspection-c
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 48259
-  timestamp: 1759135994674
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rpyutils-0.4.2-np126py312h3bd2861_10.conda
-  sha256: feaa9fd7b874f60bb8705f284266e7a5ecd46685743fece17ebd97b15b970ecd
-  md5: e784214b5b2c6ce6c362ba9cc3ce66f1
+  size: 46903
+  timestamp: 1759312011070
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h31f38b3_14.conda
+  sha256: 9aa080af0bf516503f496f1b53b2ef1329390af0f55f57928798d436519fdbef
+  md5: 4274ab7f3f4c54f42b4ecefdba8e62f4
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 26130
-  timestamp: 1759134487455
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-action-2.2.0-np126py312h3bd2861_10.conda
-  sha256: f2e794c5f82ed270f334523c4b4ed3a06aa06cb7bb142d4c76d63aa07eeb7a55
-  md5: 286dc7a6b02e8361b58dd68a91feb152
+  size: 27149
+  timestamp: 1759310655737
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-action-2.3.0-np2py312h31f38b3_14.conda
+  sha256: 77f7a83188c306421b5f3b048bf8d2a39e82bd0affbe98c4edb5e34da712ea18
+  md5: c5fb0f1bcf30f12d432f34106e49d668
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros-jazzy-rqt-msg
-  - ros-jazzy-rqt-py-common
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros-kilted-rqt-msg
+  - ros-kilted-rqt-py-common
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 20418
-  timestamp: 1759139523194
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-bag-1.5.5-np126py312h3bd2861_10.conda
-  sha256: b68e5320ae912b45f8a602530ee80d4be3ea967d55b26dd7c150130e88690baa
-  md5: d07828b1dae08ce7f85de8b3a5a6a6ce
+  size: 20406
+  timestamp: 1759315229183
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-bag-2.0.2-np2py312h31f38b3_14.conda
+  sha256: 2f08a4e6ad30982eeb188e198416c4140bc61777a227a663c2a3492ee6ca4f7e
+  md5: d70c540e1e1d1a649aff4408ce5d4ad9
   depends:
   - python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2-py
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - pyyaml
+  - ros-kilted-ament-index-python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-python-qt-binding
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2-py
+  - ros-kilted-rosidl-runtime-py
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 136415
-  timestamp: 1759141892478
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-bag-plugins-1.5.5-np126py312h3bd2861_10.conda
-  sha256: 6de02226a3b072cb110ce147d57458e791aeacd699dbfb896680304871e3e9fb
-  md5: fe773d3b2d3d9bfc151c2c3e02afb475
+  size: 135417
+  timestamp: 1759317596261
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-bag-plugins-2.0.2-np2py312h31f38b3_14.conda
+  sha256: 10f14221cd23ef2cc9cc74365f52ca5d5e8bd7a75bfd56d8cfaf46b268fe06fe
+  md5: 7c5bfb9d19b10124fec7106754c2dd9d
   depends:
-  - numpy
   - pillow
   - pycairo
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosbag2
-  - ros-jazzy-rqt-bag
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros-jazzy-rqt-plot
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosbag2
+  - ros-kilted-rqt-bag
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros-kilted-rqt-plot
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 51186
-  timestamp: 1759142829809
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-common-plugins-1.2.0-np126py312h3bd2861_10.conda
-  sha256: 44e169c813d97b9594318fdd8ed56d2fcc17287c6eeb01d22fae927926f35de0
-  md5: 10a9f85c93d6809249f94009904eea58
+  size: 50481
+  timestamp: 1759318768823
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-common-plugins-1.2.0-np2py312h31f38b3_14.conda
+  sha256: 5ba3ba8fdaa2bedaa9303f2b148f3eb21c486d94643ced8be87618dde86a399f
+  md5: 85ac88961498425f76c3bf3efd86411d
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-action
-  - ros-jazzy-rqt-bag
-  - ros-jazzy-rqt-bag-plugins
-  - ros-jazzy-rqt-console
-  - ros-jazzy-rqt-graph
-  - ros-jazzy-rqt-image-view
-  - ros-jazzy-rqt-msg
-  - ros-jazzy-rqt-plot
-  - ros-jazzy-rqt-publisher
-  - ros-jazzy-rqt-py-common
-  - ros-jazzy-rqt-py-console
-  - ros-jazzy-rqt-reconfigure
-  - ros-jazzy-rqt-service-caller
-  - ros-jazzy-rqt-shell
-  - ros-jazzy-rqt-srv
-  - ros-jazzy-rqt-topic
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-action
+  - ros-kilted-rqt-bag
+  - ros-kilted-rqt-bag-plugins
+  - ros-kilted-rqt-console
+  - ros-kilted-rqt-graph
+  - ros-kilted-rqt-image-view
+  - ros-kilted-rqt-msg
+  - ros-kilted-rqt-plot
+  - ros-kilted-rqt-publisher
+  - ros-kilted-rqt-py-common
+  - ros-kilted-rqt-py-console
+  - ros-kilted-rqt-reconfigure
+  - ros-kilted-rqt-service-caller
+  - ros-kilted-rqt-shell
+  - ros-kilted-rqt-srv
+  - ros-kilted-rqt-topic
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 22889
-  timestamp: 1759143187107
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-console-2.2.1-np126py312h3bd2861_10.conda
-  sha256: 2ce066b5dfabe6b699ce1848c560b15a9efbfa5cbe1e967a27d2da11324e35c9
-  md5: 6c3dabb49227ad09b1cc90f148689149
+  size: 22907
+  timestamp: 1759319381420
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-console-2.3.1-np2py312h31f38b3_14.conda
+  sha256: 9731791c629f6505575354c5672a5026e948689f14be83436db7cb6e8768940b
+  md5: f5358cbd03a761d3eb8d9bfa91c07493
   depends:
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros-jazzy-rqt-py-common
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros-kilted-rqt-py-common
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 83329
-  timestamp: 1759138934134
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-graph-1.5.5-np126py312h3bd2861_10.conda
-  sha256: 143e92304e358383fd7a5a747be4ebb2e1a967dd4e39bbe168f3c807d054c3c8
-  md5: a5a5bf5907c7931787e22a1521320ada
+  size: 85353
+  timestamp: 1759314690519
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-graph-1.7.1-np2py312h31f38b3_14.conda
+  sha256: f9a35f5c95ac359a436f4d974acf8b45b168725c578a0b477d2732e6dc7b6b21
+  md5: 6a20b76160cbd2960362748433d39cfb
   depends:
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-qt-dotgraph
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-qt-dotgraph
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 69553
-  timestamp: 1759138933496
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-gui-1.6.0-np126py312h3bd2861_10.conda
-  sha256: b5337dfe3eceb0b3ddf5ae4096412fda405a86266c1a4bffce4583c7ce36c870
-  md5: 0e03ec507463a98d53756c3b612bc4b1
+  size: 70262
+  timestamp: 1759314620866
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-gui-1.9.0-np2py312h31f38b3_14.conda
+  sha256: c7b28f990eb6955c0395f7d510d3ac51f312d638d7d63a7b6e3cfee0d980dcd6
+  md5: 9dfc5c264665a9ce7c851b92f4281ce3
   depends:
   - catkin_pkg
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-qt-gui
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-qt-gui
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 126702
-  timestamp: 1759138254521
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-gui-cpp-1.6.0-np126py312h3bd2861_10.conda
-  sha256: 35220ae9ccf0e154391db3eecc52124cc0a3f570c617c7f35d018480f17a17c4
-  md5: a3ea672c84ebd68536968487d7364940
+  size: 125012
+  timestamp: 1759314138682
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-gui-cpp-1.9.0-np2py312h31f38b3_14.conda
+  sha256: e3572fe6b07a5f9170cf7922ac58573ad267b8f283cf42f3e85304ffa161c3b9
+  md5: 93172a04973cdf9a56757c736ef6b925
   depends:
   - python
-  - ros-jazzy-pluginlib
-  - ros-jazzy-qt-gui-cpp
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-pluginlib
+  - ros-kilted-qt-gui-cpp
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - libgl >=1.7.0,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - libopengl >=1.7.0,<2.0a0
   - xorg-libxext >=1.3.6,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
   - qt-main >=5.15.15,<5.16.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 187130
-  timestamp: 1759138282403
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-gui-py-1.6.0-np126py312h3bd2861_10.conda
-  sha256: d859156792ef19102cfa102d361d76e8650f1f85b65f818067979aff52680ea3
-  md5: ae38bf329c387b61adb6e34d26bcd2f8
+  size: 184336
+  timestamp: 1759314218965
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-gui-py-1.9.0-np2py312h31f38b3_14.conda
+  sha256: c30f44dde0f4b6f47d753091771883524a05dce21a53d889603a81dec02c0578
+  md5: 4017f4952f67c444de4459e85bedc254
   depends:
   - python
-  - ros-jazzy-qt-gui
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-gui
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-python-qt-binding
+  - ros-kilted-qt-gui
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-gui
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 49844
-  timestamp: 1759138489245
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-image-view-1.3.0-np126py312h3bd2861_10.conda
-  sha256: cb4e28e96d92a2c2a3faa5537ee8ed2338503d27023dee0d2bf1f17e706f8f0d
-  md5: 88aa588fa8ff7535738200a8d260fae7
+  size: 23124
+  timestamp: 1759314322615
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-image-view-1.3.3-np2py312h31f38b3_14.conda
+  sha256: 8edaf2539d4a085e4d952bd8da4bd1a75e1421db17aa9c82dcd92742e6ea2f77
+  md5: 954ab59483c9e2e4bcc935b9a5e2f313
   depends:
   - python
-  - ros-jazzy-cv-bridge
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-image-transport
-  - ros-jazzy-qt-gui-cpp
-  - ros-jazzy-rclcpp
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-cpp
-  - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-cv-bridge
+  - ros-kilted-geometry-msgs
+  - ros-kilted-image-transport
+  - ros-kilted-qt-gui-cpp
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-cpp
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - libopengl >=1.7.0,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - libgl >=1.7.0,<2.0a0
   - python_abi 3.12.* *_cp312
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 295056
-  timestamp: 1759139216127
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-msg-1.5.1-np126py312h3bd2861_10.conda
-  sha256: e5816d23f0b2a183a3db963e2326104836bcae06ee617d9a9099fb7783ecb2cb
-  md5: 8a547f7b06e91cffc57e7083d5cac4aa
+  size: 295660
+  timestamp: 1759314949758
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-msg-1.6.0-np2py312h31f38b3_14.conda
+  sha256: 9fa86ed997f7010e0b797311ad0e26587c5444c84d5acbf486b5f20b471cb713
+  md5: 97dc5915f4a41e64930973e3b863eebb
   depends:
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-py
-  - ros-jazzy-rqt-console
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros-jazzy-rqt-py-common
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-py
+  - ros-kilted-rqt-console
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros-kilted-rqt-py-common
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 30408
-  timestamp: 1759139191523
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-plot-1.4.4-np126py312h3bd2861_10.conda
-  sha256: c530b7d9c6db353c94bcb79bae24c09a1c8290bffdde64d6567a1f44161b18a5
-  md5: 71e6d19ece274ab633e708741c89738e
+  size: 30385
+  timestamp: 1759314957737
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-plot-1.6.3-np2py312h31f38b3_14.conda
+  sha256: 54adfb2691b9b33b1f03150bb9ab5f3fc8054b8e711fdf39f78e1426019b48c6
+  md5: e5863a15f41a360af75a8d7118826c4c
   depends:
-  - catkin_pkg
   - matplotlib-base
   - numpy
   - python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-qt-gui-py-common
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-py
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros-jazzy-rqt-py-common
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-qt-gui-py-common
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-parser
+  - ros-kilted-rosidl-runtime-py
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros-kilted-rqt-py-common
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 77281
-  timestamp: 1759139034195
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-publisher-1.7.2-np126py312h3bd2861_10.conda
-  sha256: 4538c74a6269766c485fb2f0d8726ed26494a6844e506ff695761688a947f65f
-  md5: 4e439a21d1de19deadb517e832555c91
+  size: 68122
+  timestamp: 1759314604032
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-publisher-1.9.0-np2py312h31f38b3_14.conda
+  sha256: e5bb39e5001a56fe992071570597e57241a49987a7eec58fc7d7c186e1f40324
+  md5: 73cb1fc1798ec7dfda9c342030bdc84d
   depends:
   - numpy
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-qt-gui-py-common
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-py
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros-jazzy-rqt-py-common
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-qt-gui-py-common
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-py
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros-kilted-rqt-py-common
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 42733
-  timestamp: 1759138965274
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-py-common-1.6.0-np126py312h3bd2861_10.conda
-  sha256: 31d88da85c8fdc30f1af5abce79e16981260d6bc13b3a9073312b2dd84d7252d
-  md5: 871534225380fba0b744c0885a5fc340
+  size: 44902
+  timestamp: 1759314616534
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-py-common-1.9.0-np2py312h31f38b3_14.conda
+  sha256: f15e4ed55def6f03137e57a24485e81cc89fb119b0b4ad7ee291cd9b3a43287c
+  md5: 41918057dead45486b0f220b7ad31933
   depends:
   - python
   - qt-main
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-qt-gui
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-python-qt-binding
+  - ros-kilted-qt-gui
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - qt-main >=5.15.15,<5.16.0a0
-  - libopengl >=1.7.0,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - python_abi 3.12.* *_cp312
-  - xorg-libxext >=1.3.6,<2.0a0
   - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.23,<3
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 88049
-  timestamp: 1759138273780
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-py-console-1.2.2-np126py312h3bd2861_10.conda
-  sha256: 7e21bd267b3393c1abdef55d028850d8ca54083b1f51425083cc0752c11db304
-  md5: 764881b84f0b45a52a0b0e57f63a7230
+  size: 89062
+  timestamp: 1759314104538
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-py-console-1.4.0-np2py312h31f38b3_14.conda
+  sha256: e1bbaec43b6022a0f8fdf85f3597aeed711622e334ce04b16d01afb2cd29ce3a
+  md5: 3ffca9ccf0841e4cb483bf05a194a5cb
   depends:
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-qt-gui
-  - ros-jazzy-qt-gui-py-common
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-qt-gui
+  - ros-kilted-qt-gui-py-common
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 25434
-  timestamp: 1759138961219
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-reconfigure-1.6.2-np126py312h3bd2861_10.conda
-  sha256: 78e437fa957443f9f8ab4a5e4f48553541ab721c74bed3441698501ae2779bcb
-  md5: 84b1c2774cf8be08d71cdd00be6ecee4
+  size: 27499
+  timestamp: 1759314611673
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-reconfigure-1.7.0-np2py312h31f38b3_14.conda
+  sha256: ad54afbcef7896ab02dbca9c701f35d5766718a2aec2912514cf7255ff2a91cd
+  md5: b1003ed32512f6f09829a6ce03f48062
   depends:
   - python
   - pyyaml
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-qt-gui-py-common
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-console
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros-jazzy-rqt-py-common
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-qt-gui-py-common
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-console
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros-kilted-rqt-py-common
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 78372
-  timestamp: 1759139262667
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-service-caller-1.2.1-np126py312h3bd2861_10.conda
-  sha256: a3533460101e124892dbd9a21e2f5816d0407a931c9ec627d2cc699138d98caf
-  md5: 58a40d8c9ef9ab26d3a669f8012047d3
+  size: 78341
+  timestamp: 1759314945159
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-service-caller-1.4.0-np2py312h31f38b3_14.conda
+  sha256: 9ef252c6ebd9bb39c95ab20609f6178993e8830e3fde74585aee02aae51e8413
+  md5: a2d35b4502ff9d858d397de24da63291
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros-jazzy-rqt-py-common
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-index-python
+  - ros-kilted-python-qt-binding
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros-kilted-rqt-py-common
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 32123
-  timestamp: 1759138957166
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-shell-1.2.2-np126py312h3bd2861_10.conda
-  sha256: f6bab953ff3a3e4c1430337edf3b98d449f27c3eea01d2face576e8ebcf3552a
-  md5: 2635bd35c4057cc2ae42a21408493e9d
-  depends:
-  - catkin_pkg
-  - python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-qt-gui
-  - ros-jazzy-qt-gui-py-common
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  license: BSD-3-Clause
-  size: 29351
-  timestamp: 1759138953056
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-srv-1.2.2-np126py312h3bd2861_10.conda
-  sha256: db7884882489d5371bfba6fe8ce849beed963fbb3a1e3cda3f1684d4b6871fcf
-  md5: 7ca8f79685538bf170ba19822f01155a
+  size: 34222
+  timestamp: 1759314602323
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-shell-1.3.1-np2py312h31f38b3_14.conda
+  sha256: b3c6d588f13ae879c06f93571550ded567d5966e3552721a18df4a2ed08baf47
+  md5: 1c2e53a414aa38ca96d29ee06476c3a7
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros-jazzy-rqt-msg
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-python-qt-binding
+  - ros-kilted-qt-gui
+  - ros-kilted-qt-gui-py-common
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 21381
-  timestamp: 1759139519091
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rqt-topic-1.7.3-np126py312h3bd2861_10.conda
-  sha256: 2c035e52a5f7642228d359562147369e06a1983e9916187e09c090287f9aa05b
-  md5: 807391be62dce610b9c586ab1dce63ee
+  size: 31254
+  timestamp: 1759314663503
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-srv-1.3.0-np2py312h31f38b3_14.conda
+  sha256: 3fad48812647ed25ae419a6c880024bc6092c3e62bb80bf3d0453ff2c3dc1fc9
+  md5: ced91e5a948af782d6cd084321afd613
   depends:
   - python
-  - ros-jazzy-python-qt-binding
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2topic
-  - ros-jazzy-rqt-gui
-  - ros-jazzy-rqt-gui-py
-  - ros-jazzy-rqt-py-common
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros-kilted-rqt-msg
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 38628
-  timestamp: 1759139211889
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rti-connext-dds-cmake-module-0.22.1-np126py312h3bd2861_10.conda
-  sha256: 939f02511575d68e5e213faf011a2cc83bdde7d158a931259334470a0959a0d2
-  md5: a814fd56f1d32c08c552c78599d04971
+  size: 21355
+  timestamp: 1759315224930
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rqt-topic-1.8.1-np2py312h31f38b3_14.conda
+  sha256: af62669ac4dc512e4127d6a7f288285b5139ec8246a3b9061ed7b38b0592cb5e
+  md5: fcfd8b3636dc1514300c52c973d311d8
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-python-qt-binding
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2topic
+  - ros-kilted-rqt-gui
+  - ros-kilted-rqt-gui-py
+  - ros-kilted-rqt-py-common
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 31364
-  timestamp: 1759135460323
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rttest-0.17.1-np126py312h3bd2861_10.conda
-  sha256: 43f469cbbeaa1ecea1b9a2bc84741e71bc14f61c34808370b21f06e736576efe
-  md5: dfe3e5c9690bcd2dfb0b813e9368bc6b
+  size: 38630
+  timestamp: 1759314935589
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.0-np2py312h31f38b3_14.conda
+  sha256: 30f4bd38ace26022eaa24d6d3276ed5bca644c9fcf63ffa57c5f349ac1134dc9
+  md5: ae11d140e3ed3205234f3ea03a3fde76
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 53911
-  timestamp: 1759135169976
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-assimp-vendor-14.1.15-np126py312h3bd2861_10.conda
-  sha256: d51251931f0b4be140cc862490d07674c71e43bec253e7cfb48016814410a0a1
-  md5: 768c532c8973aafe963b0bf155d07743
+  size: 31413
+  timestamp: 1759311531229
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rttest-0.18.3-np2py312h31f38b3_14.conda
+  sha256: 5066f44d7658e2023554ce1a87484806e3bf3db870fa4ab0f9b45a2da8e837d1
+  md5: 83de59877587284a0036241d248307ea
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 54033
+  timestamp: 1759311228122
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-assimp-vendor-15.0.6-np2py312h31f38b3_14.conda
+  sha256: 47146c977fc2b4b16ce6b0779b4f3d70d0fbbc05f3fca43bbac2c57c470a3ebe
+  md5: 02cc8fb336c7296bd685043dbcaa6ed3
   depends:
   - assimp
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   - assimp >=5.4.3,<5.4.4.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 24810
-  timestamp: 1759135089466
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-common-14.1.15-np126py312h3bd2861_10.conda
-  sha256: 4148f838974e0dccafb38827221f6ee150f5ad146f4fcb7632d2c3a045583f26
-  md5: a2a69da9f9be2fe1158df1260b211c19
+  size: 24820
+  timestamp: 1759311129264
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-common-15.0.6-np2py312h31f38b3_14.conda
+  sha256: cfb01e6a8e598fdd7bb4fd93318b7328ee4657c292b37825544e33bfbd953e11
+  md5: 7de2562aea6079920595f195d28f7df9
   depends:
   - python
   - qt-main
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-message-filters
-  - ros-jazzy-pluginlib
-  - ros-jazzy-rclcpp
-  - ros-jazzy-resource-retriever
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rviz-ogre-vendor
-  - ros-jazzy-rviz-rendering
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros-jazzy-std-srvs
-  - ros-jazzy-tf2
-  - ros-jazzy-tf2-ros
-  - ros-jazzy-tinyxml2-vendor
-  - ros-jazzy-urdf
-  - ros-jazzy-yaml-cpp-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-geometry-msgs
+  - ros-kilted-message-filters
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-resource-retriever
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-ogre-vendor
+  - ros-kilted-rviz-rendering
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-std-srvs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdf
+  - ros-kilted-yaml-cpp-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - qt-main >=5.15.15,<5.16.0a0
   - libopengl >=1.7.0,<2.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
   - libgl >=1.7.0,<2.0a0
   - xorg-libxext >=1.3.6,<2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 889510
-  timestamp: 1759139178899
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-default-plugins-14.1.15-np126py312h3bd2861_10.conda
-  sha256: b9c6fcede16d94a7d2daf109fab9597d8efbc87ac3daa1574ba0b690bdfca137
-  md5: c87ef245ad83fbf05cd57eb4ccfb9ccd
+  size: 872672
+  timestamp: 1759314972201
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-default-plugins-15.0.6-np2py312h31f38b3_14.conda
+  sha256: 2e26e5f02f1fd4dee20dda6cbd0a16bacce86b49a129e52ec6edbbe3fc63d373
+  md5: 81ffd58d4751369add24162530d24e36
   depends:
   - python
   - qt-main
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-gz-math-vendor
-  - ros-jazzy-image-transport
-  - ros-jazzy-interactive-markers
-  - ros-jazzy-laser-geometry
-  - ros-jazzy-map-msgs
-  - ros-jazzy-nav-msgs
-  - ros-jazzy-pluginlib
-  - ros-jazzy-point-cloud-transport
-  - ros-jazzy-rclcpp
-  - ros-jazzy-resource-retriever
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rviz-common
-  - ros-jazzy-rviz-ogre-vendor
-  - ros-jazzy-rviz-rendering
-  - ros-jazzy-tf2
-  - ros-jazzy-tf2-geometry-msgs
-  - ros-jazzy-tf2-ros
-  - ros-jazzy-urdf
-  - ros-jazzy-visualization-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-geometry-msgs
+  - ros-kilted-gz-math-vendor
+  - ros-kilted-image-transport
+  - ros-kilted-interactive-markers
+  - ros-kilted-laser-geometry
+  - ros-kilted-map-msgs
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-point-cloud-transport
+  - ros-kilted-rclcpp
+  - ros-kilted-resource-retriever
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-common
+  - ros-kilted-rviz-ogre-vendor
+  - ros-kilted-rviz-rendering
+  - ros-kilted-rviz-resource-interfaces
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-ros
+  - ros-kilted-urdf
+  - ros-kilted-visualization-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - libgl >=1.7.0,<2.0a0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
   - python_abi 3.12.* *_cp312
   - libopengl >=1.7.0,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 2285873
-  timestamp: 1759140028444
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-ogre-vendor-14.1.15-np126py312h39124df_10.conda
-  sha256: 4081bce459c4d31b506dc3314b9d9032320ddc8c3ffa7c8b625ff6bf5a14a55a
-  md5: 9ffd6fc4b4c271d5578b29c8f4725748
+  size: 2304032
+  timestamp: 1759315782395
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-ogre-vendor-15.0.6-np2py312hb5dd976_14.conda
+  sha256: 921c0df5f205784677e944a508ad324616c58abb46eede1af1c6cbab03083b30
+  md5: b7b4de657b5f9937e26c5a30e1567928
   depends:
   - assimp
   - freetype
   - glew
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxaw
   - xorg-libxrandr
   - xorg-xorgproto
   - xorg-libx11
   - xorg-libxext
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - assimp >=5.4.3,<5.4.4.0a0
-  - numpy >=1.26.4,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - zziplib >=0.13.69,<0.14.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - pugixml >=1.15,<1.16.0a0
   - xorg-libxrandr >=1.5.4,<2.0a0
-  - freeimage >=3.18.0,<3.19.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - libglu >=9.0.3,<9.1.0a0
-  - glew >=2.1.0,<2.2.0a0
   - libfreetype >=2.14.1
   - libfreetype6 >=2.14.1
-  - pugixml >=1.15,<1.16.0a0
-  - libopengl >=1.7.0,<2.0a0
+  - glew >=2.1.0,<2.2.0a0
   - python_abi 3.12.* *_cp312
-  - libgl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.23,<3
+  - freeimage >=3.18.0,<3.19.0a0
+  - zziplib >=0.13.69,<0.14.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
   license: BSD-3-Clause
-  size: 5377597
-  timestamp: 1759134848838
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-rendering-14.1.15-np126py312h3bd2861_10.conda
-  sha256: 1d5e4748a83e5515a66f00e8a13626df0c016c1ed2a576dabec66e8005c83609
-  md5: 7b499dabea440a986f2b3d4638b48947
+  size: 5287574
+  timestamp: 1759310893597
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-rendering-15.0.6-np2py312h31f38b3_14.conda
+  sha256: 641e0cf15e4e5f26b47f3333e92b4e45dbc0d559616cb096cdff139a11f4e9e8
+  md5: f4f5fabb4c53a021add6677d34e34523
   depends:
   - eigen
   - python
   - qt-main
-  - ros-jazzy-ament-index-cpp
-  - ros-jazzy-eigen3-cmake-module
-  - ros-jazzy-resource-retriever
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rviz-assimp-vendor
-  - ros-jazzy-rviz-ogre-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-eigen3-cmake-module
+  - ros-kilted-resource-retriever
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-assimp-vendor
+  - ros-kilted-rviz-ogre-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
   - libopengl >=1.7.0,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - python_abi 3.12.* *_cp312
   - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.23,<3
+  - xorg-libxext >=1.3.6,<2.0a0
   - libgl >=1.7.0,<2.0a0
   - glew >=2.1.0,<2.2.0a0
-  - numpy >=1.26.4,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - xorg-libx11 >=1.8.12,<2.0a0
   license: BSD-3-Clause
-  size: 937128
-  timestamp: 1759135657587
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz2-14.1.15-np126py312h3bd2861_10.conda
-  sha256: a166b0b2289c9de429818b58f5cc9b0ea35e3c057a1a4c3eb0cf360677f3ab84
-  md5: 57345cdcf4230d648e45206218ec3667
+  size: 940718
+  timestamp: 1759313609249
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-resource-interfaces-15.0.6-np2py312h31f38b3_14.conda
+  sha256: 2189c4771d5bfc0f0f2908dd0b34ab6638e22e422e2d821d5641c7bb916fedb6
+  md5: bd6a0d08f7f22c5dd98e6f1f3d486137
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rviz-common
-  - ros-jazzy-rviz-default-plugins
-  - ros-jazzy-rviz-ogre-vendor
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 126450
+  timestamp: 1759312300235
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz2-15.0.6-np2py312h31f38b3_14.conda
+  sha256: 10102f02227a8518fda2c9e0849375986fff03f6b675eecdb1db54b5cc9291d4
+  md5: 39aac8a66fcee137a7a04560388b510c
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-common
+  - ros-kilted-rviz-default-plugins
+  - ros-kilted-rviz-ogre-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
-  - libopengl >=1.7.0,<2.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - libgl >=1.7.0,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - xorg-libxext >=1.3.6,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
   license: BSD-3-Clause
-  size: 76045
-  timestamp: 1759140831984
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdl2-vendor-3.3.0-np126py312h3bd2861_10.conda
-  sha256: 88e8acd0939d054908173adf8acd84deb728c37b6639f9d7056dbe9ce485b83d
-  md5: 74fe5dbdd0766d608c1d3f931b5d61f7
+  size: 77948
+  timestamp: 1759316283890
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdl2-vendor-3.3.0-np2py312h31f38b3_14.conda
+  sha256: 9103e4e2ec138eecd67f6d370a16ecbb412a909278236ebc88e12e8131053860
+  md5: 60908b4eb726b66eacc4d0634842057d
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - sdl2
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - sdl2 >=2.32.56,<3.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 28358
-  timestamp: 1759134486840
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: 65926e9bd0725c11a170d9263502cd08dbd75f67c69d3ab9b15f8edf0aca0692
-  md5: 477cf9584895a578c653b40c0df1da4e
+  size: 28378
+  timestamp: 1759310590309
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: 3421ea3741f3933c695e450e6e98c75f43dbecff9991312addcb0d63765ed559
+  md5: 64380666a25f8ff034fcb5f8552b66ab
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 546202
-  timestamp: 1759137085566
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-py-5.3.6-np126py312h3bd2861_10.conda
-  sha256: 620c211b274a399b29d8f4e3c9d2cfe74e54ac72d617c49ba3e854663634beda
-  md5: 2aa778ab9342a18b183ecadeda6792e5
+  size: 549435
+  timestamp: 1759312716758
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-py-5.5.0-np2py312h31f38b3_14.conda
+  sha256: 0e60856e1945275334f50c24708ac78cfde76c94c6e1850172e04df5e5845ab9
+  md5: 277ccf11f40147a85c6b7024f3a42b3e
   depends:
   - numpy
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 30492
-  timestamp: 1759137231637
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-service-msgs-2.0.3-np126py312h3bd2861_10.conda
-  sha256: 58f5a585a42773ac153529a7a23b63bfbf5a4c5fa1299c6bb9af671847582934
-  md5: a0c36bf475e340a819d8b781bd798058
+  size: 30746
+  timestamp: 1759312875115
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.0-np2py312h31f38b3_14.conda
+  sha256: 819e548ec1d453053ce9a11f89309ca1e9c344719753856c579cca9c4b5ca444
+  md5: 92fcab071a437f8800a55948469178dc
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-core-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-core-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 80559
-  timestamp: 1759136384945
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-shape-msgs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: c5d5df98bb2eccca01963ae67a4d0b13ec5ad125029dac7e57df7d1bae28e539
-  md5: b58fd8c09ca808f2de434fba37f849b1
+  size: 77918
+  timestamp: 1759312192999
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: be8cc4c23d58640c6c1e731b171f26d48dca6d1dabd44a9db977080f372225a2
+  md5: 4006a5794abaf1517704a671ce6a2111
   depends:
   - python
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 128005
-  timestamp: 1759137079790
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-spdlog-vendor-1.6.1-np126py312he340118_10.conda
-  sha256: 25c91dfa53a354e9d604895e8f2ac86555d980ce9d06944782bfc156a1dcf86b
-  md5: 8ea8282ec14e7532dd2ce77cb1baa09a
+  size: 125842
+  timestamp: 1759312692090
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312hb464df2_14.conda
+  sha256: 5ff496fdb467c065b315674ed386857e13040cf96c236be701c850b40ab40aac
+  md5: 2a5e907b29ef8ef3178a78be2b90d614
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - spdlog
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   - spdlog >=1.15.3,<1.16.0a0
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 26975
-  timestamp: 1759135131375
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sqlite3-vendor-0.26.9-np126py312h3bd2861_10.conda
-  sha256: fbeb3324aefa915593780edf0c437d1ae663317b86d221ee15a43b42d9fb16e0
-  md5: 76572b5246c086603b24f59a4be3a1ff
+  size: 27014
+  timestamp: 1759311547281
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sqlite3-vendor-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 899035fa6dde178f5f23a33a2f236f0ed270d1065d2fdfaee3fa80bb5746485a
+  md5: 2743e777029f92523f38030b9045b81f
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - sqlite
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   - libsqlite >=3.50.4,<4.0a0
   license: BSD-3-Clause
-  size: 24382
-  timestamp: 1759134522950
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-0.13.4-np126py312h3bd2861_10.conda
-  sha256: 7358133b6b370224a6b04b3ed395e40ed24c903f65b4aeb9135ad26fb45bf82f
-  md5: 9518dff7ffd2c7ff47af86fa4c82f68a
+  size: 24340
+  timestamp: 1759310581538
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-0.15.2-np2py312h31f38b3_14.conda
+  sha256: 4e7d5312e533a3a63bda10b1a22d745d84c15c42b0ff071b540bb461b70d4b3e
+  md5: 3ec489c240f3277b620cdabf46d3feee
   depends:
   - argcomplete
   - cryptography
   - importlib_resources
   - lxml
   - python
-  - ros-jazzy-ament-index-python
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-python
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 75538
-  timestamp: 1759139553332
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-cmake-0.13.4-np126py312h3bd2861_10.conda
-  sha256: 28ab21ac18bcd822e55bbf323b826b0998bb6bf1ad4e66f8d087e3de10c25270
-  md5: 6b44db4840c291a2557554dcb340f9e0
+  size: 74898
+  timestamp: 1759315253196
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-cmake-0.15.2-np2py312h31f38b3_14.conda
+  sha256: 8d73aa17e1c15db87dd123eaa146dc74d5ea9137fed537703cc2fc252357b74a
+  md5: 4231a3901a57c56d6c42ca023c3b504e
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-ros2cli
-  - ros-jazzy-sros2
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2cli
+  - ros-kilted-sros2
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 39480
-  timestamp: 1759139957743
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-statistics-msgs-2.0.3-np126py312h3bd2861_10.conda
-  sha256: 1e8c8cacbcc7e014ed82ebefc92994463abd2a0a587c83d0d53a4910ff584b6d
-  md5: dd7d893a87be62eb00829bd413032131
+  size: 37153
+  timestamp: 1759315514232
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.0-np2py312h31f38b3_14.conda
+  sha256: 73469bed51f011822c68d58025810d62eb8a3afc0763a2e214e08277cc7cffa0
+  md5: 77efe8be05f46be950b62ad2ff355fe4
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 108933
-  timestamp: 1759136704465
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-msgs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: 5ed0fcfa1f107eb1cc0073a83975c9273b170bc673ab38b62803433953e102ba
-  md5: 1c35c3356534e65a425ca49fcd8365e7
+  size: 108110
+  timestamp: 1759312469834
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: c4cc5571e723c9bb593ca51c543f5fc0da903633f25402f3e5f7992fcbf28da3
+  md5: bef1e68d09246813560469e7c2cc5b3b
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 339951
-  timestamp: 1759136657294
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-srvs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: d7760b7fdb8b9344b5b310481e824e317e550a56ded359b05ab6da2806227c0b
-  md5: 48ccd18c4e5f25b1b50b200fa687bf9f
+  size: 339331
+  timestamp: 1759312428997
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: 584d8788cacd1c72a004fe8c257755be20b2f51262b6fa576685435dc2117eaa
+  md5: 01e14a02e9fc3724dcb03e7126f029e0
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 168725
-  timestamp: 1759136576806
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-stereo-msgs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: 58b940930d7eb8e1d8e9dd4623848b2865b1795916919c6c5a993c79cef71e5c
-  md5: 76f33262a398c8320890860d3e39416a
+  size: 168130
+  timestamp: 1759312342620
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: 5518360853b03fef83ced1de2de11ea16f5d962970cbcfd7af7ecbca73c95040
+  md5: fa2ce7ae65bd4be6346053632750aa33
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 83543
-  timestamp: 1759137382359
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tango-icons-vendor-0.3.0-np126py312h3bd2861_10.conda
-  sha256: fa722bfb7beef9c0a695dfb950a82f504f87babe12905e604f62b9a680811005
-  md5: f287ae107ff25ff18f5fcb8b968c6885
+  size: 81006
+  timestamp: 1759312984261
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tango-icons-vendor-0.4.0-np2py312h31f38b3_14.conda
+  sha256: 29f111f3d41610eac254f57c1849c1434ed00ea468a54d9ae7682f051dd25675
+  md5: 018d8ea0f5422702b765bba4eaccf68f
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 26272
-  timestamp: 1759135165169
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-teleop-twist-joy-2.6.5-np126py312h3bd2861_10.conda
-  sha256: 69b8f774d543d5f7581c796ece7cdf848ee5121993bed91ccb8feed8658cace5
-  md5: 50ebee9a66553e7058d8f5110abbd9b6
+  size: 26216
+  timestamp: 1759311225487
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-teleop-twist-joy-2.6.5-np2py312h31f38b3_14.conda
+  sha256: 04d4492bac3a40b063cd47aaf5f1dece13e7dfb45fc3f85554a95934d3f84248
+  md5: e5ae406efcd5cac336c3850247c8b0fd
   depends:
   - python
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-joy
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-geometry-msgs
+  - ros-kilted-joy
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 221803
-  timestamp: 1759138982345
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-teleop-twist-keyboard-2.4.1-np126py312h3bd2861_10.conda
-  sha256: 38aa3d7ddbc93b97aa247f1589eccb63ebbb83759d1fae507979a27f14e3fda4
-  md5: 83bc205faee9646f89104839f24352eb
+  size: 221948
+  timestamp: 1759314627320
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-teleop-twist-keyboard-2.4.1-np2py312h31f38b3_14.conda
+  sha256: f97b9d37b16d52a141c754d20c38c3c110137daa5ac5ba8b687447d90605e4c8
+  md5: f6442af4e57033b4b4cd740654d5ae9d
   depends:
   - python
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 24077
-  timestamp: 1759138325262
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-0.36.14-np126py312h3bd2861_10.conda
-  sha256: 3e0e8bc92bf1fa2cf9d165b7fc12df751d9ddeaa0f32677576269da9ed7941eb
-  md5: 023d8670910a31fb8952ed211d1edaa9
+  size: 24067
+  timestamp: 1759314105787
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-0.41.2-np2py312h31f38b3_14.conda
+  sha256: 0e82022c58250244fead9fdee101c20ec87cfaeb459a4a532f20a8ae9d878d3b
+  md5: f0bcbace2c659dd37e7de38ed29988fe
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-rcutils
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 135313
-  timestamp: 1759137051595
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-bullet-0.36.14-np126py312h3bd2861_10.conda
-  sha256: 76c891cf32f746179de831f0fdb54195d441335fe03fe22b0c938a98d87c572a
-  md5: 235c13736d054c2347651dc17ec843bd
+  size: 135241
+  timestamp: 1759313405626
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-bullet-0.41.2-np2py312h31f38b3_14.conda
+  sha256: 78b52964e35f89acf18b6d10ec41d7d57ead1f08ae04e798b80beb0ff1b3ab9d
+  md5: 7500d06adcc51fd1b5a0795711396404
   depends:
   - bullet
   - python
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tf2
-  - ros-jazzy-tf2-ros
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 44369
-  timestamp: 1759139173611
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-eigen-0.36.14-np126py312h3bd2861_10.conda
-  sha256: b42f3a2b125b4a3e0140e01bc3df5359ac705f4f34ce96b87cb75963856a55f6
-  md5: e11c0996f2e94d4aa9b5675aa7c46343
+  size: 43718
+  timestamp: 1759314939610
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-0.41.2-np2py312h31f38b3_14.conda
+  sha256: f47907a22233c1431544a989313a5e573da5f3040db2e623d37c2cdd55e14fda
+  md5: 32305e97b6809bdae24378d3850bf323
   depends:
   - eigen
   - python
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tf2
-  - ros-jazzy-tf2-ros
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 45726
-  timestamp: 1759139209962
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-eigen-kdl-0.36.14-np126py312h3bd2861_10.conda
-  sha256: afb712a0f20dc0a4243f2dcd92e328c08891642cf622b8dff5029d9ee86db00a
-  md5: 90cbb5675ddac6725557265f1584aec7
+  size: 45055
+  timestamp: 1759314966081
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-kdl-0.41.2-np2py312h31f38b3_14.conda
+  sha256: de899e1a275ae37d2b3bf859eef7bf7a4252e2aa6a7ed2cef8a9becf68ee3d63
+  md5: 139cb945ea545055078493aca62fabcf
   depends:
   - eigen
   - python
-  - ros-jazzy-orocos-kdl-vendor
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tf2
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 41287
-  timestamp: 1759137269359
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-geometry-msgs-0.36.14-np126py312h3bd2861_10.conda
-  sha256: 675b3240a29cb38be97b6369f8c8b93581b355a942666b75e2b27f74ec1accd2
-  md5: eed7a734010d4d468415fe2bd03312c8
+  size: 39859
+  timestamp: 1759313647577
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-geometry-msgs-0.41.2-np2py312h31f38b3_14.conda
+  sha256: dd9ce78181cd57a880d7df0334fb0c329e06a7681dd3e10a0161859271367f23
+  md5: bbd1c26df93c03d93937e42b5370cc2c
   depends:
   - numpy
   - python
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-orocos-kdl-vendor
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tf2
-  - ros-jazzy-tf2-ros
-  - ros-jazzy-tf2-ros-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-geometry-msgs
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros-kilted-tf2-ros-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 57650
-  timestamp: 1759139173325
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-kdl-0.36.14-np126py312h3bd2861_10.conda
-  sha256: 058712bc28454547f8c2fbdb2b35c9ab9a2beb9dfe75b6297653c5871faa71c2
-  md5: a848b4fc65282fe6f55578e58c489c96
+  size: 57642
+  timestamp: 1759314958338
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-kdl-0.41.2-np2py312h31f38b3_14.conda
+  sha256: da44bfad8f60c26756a57d137221c9574def10fe05c032fde5f9ad0a49eab5dc
+  md5: 7dec5dd5543200e5e6fc62fef685c785
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-orocos-kdl-vendor
-  - ros-jazzy-python-orocos-kdl-vendor
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tf2
-  - ros-jazzy-tf2-ros
-  - ros-jazzy-tf2-ros-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-python-orocos-kdl-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros-kilted-tf2-ros-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 47225
-  timestamp: 1759139203220
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-msgs-0.36.14-np126py312h3bd2861_10.conda
-  sha256: 4abd8e41ad7f82e89f8857eede0e00135986f2c262fc886a22469dc782f4109a
-  md5: a11bc4a57bc7cb43d5a144b8aba6b18b
+  size: 46569
+  timestamp: 1759314940647
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.2-np2py312h31f38b3_14.conda
+  sha256: cafa456644eb71935ad3c2f1918ec747ad13ad9e58b7d9f418bddd65182ee607
+  md5: ce51ccce8f106e349e665cc2f98ddab4
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 256026
-  timestamp: 1759137020823
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-py-0.36.14-np126py312h3bd2861_10.conda
-  sha256: 332d1062f7645bf195c14a9712a7aede4cdf79b23ea734483f28ebcf8390d9a4
-  md5: c4d17504df0d4cfc2546f0c94b85ffd8
+  size: 258479
+  timestamp: 1759312673587
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.2-np2py312h31f38b3_14.conda
+  sha256: 36221497e622a668ec22e541613b69bf21a8e557206a0a56730441920c285531
+  md5: d155c3e828d8a5fbf338acae195989f1
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rpyutils
-  - ros-jazzy-tf2
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rpyutils
+  - ros-kilted-tf2
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 58858
-  timestamp: 1759138282022
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-0.36.14-np126py312h3bd2861_10.conda
-  sha256: 5abb275a02ee9dbaa3ea35cdf79040c9c080a5af961eff471ad2ceb53c8ebf21
-  md5: 17efb45a654c668411f121bd2b1d01cd
+  size: 55612
+  timestamp: 1759314129362
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.2-np2py312h31f38b3_14.conda
+  sha256: 8413ab802da172deffffb361f2c15a80693ef0cf24030ec6ad1f6db99f438d01
+  md5: b99fc62a76f4a868e15b13183255ae04
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-message-filters
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-action
-  - ros-jazzy-rclcpp-components
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tf2
-  - ros-jazzy-tf2-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-message-filters
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 466480
-  timestamp: 1759138967417
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-py-0.36.14-np126py312h3bd2861_10.conda
-  sha256: 4b74718a81327f22c9f5ccd7e701122354150efef92630e3cfe40206fc25c7ba
-  md5: b480decf703ef801b0c591ebd08c5624
+  size: 467964
+  timestamp: 1759314636321
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.2-np2py312h31f38b3_14.conda
+  sha256: df6143fa14de312f8480c8476afad4c935cdad58aa9e74cb8d0cd113807d2db7
+  md5: eab06e6404bbf90827d57edd1a77fcbc
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros-jazzy-tf2-msgs
-  - ros-jazzy-tf2-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-tf2-msgs
+  - ros-kilted-tf2-py
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 48787
-  timestamp: 1759138495464
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-sensor-msgs-0.36.14-np126py312h3bd2861_10.conda
-  sha256: a1b64da83229c31844b62593daa15f181f5e1e63d5dfd6067c581ea596c18f61
-  md5: 9b191e4d7d70b792d28be7d04d266d42
+  size: 48731
+  timestamp: 1759314332236
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-sensor-msgs-0.41.2-np2py312h31f38b3_14.conda
+  sha256: 9619aab5ae6a300278c3e3cc48abe9a771316c20b67d7227f6887aecb4eccd7a
+  md5: 777910072ea90ff4ff648ccc9604d79a
   depends:
   - eigen
   - numpy
   - python
-  - ros-jazzy-eigen3-cmake-module
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-sensor-msgs-py
-  - ros-jazzy-std-msgs
-  - ros-jazzy-tf2
-  - ros-jazzy-tf2-ros
-  - ros-jazzy-tf2-ros-py
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-eigen3-cmake-module
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-sensor-msgs-py
+  - ros-kilted-std-msgs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros-kilted-tf2-ros-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 49843
-  timestamp: 1759139390039
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-tools-0.36.14-np126py312h3bd2861_10.conda
-  sha256: 2bc39da305fccacaa4ec7d83bc5b6c9ee8a7b20c6ece56eba6c12a727d569c95
-  md5: 3c56b870db4cdcebed6ff6769c588514
+  size: 49820
+  timestamp: 1759315162025
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-tools-0.41.2-np2py312h31f38b3_14.conda
+  sha256: aaedfe2798826f522618f6110a5368a3f6956a5fd4ba919caeecc274d6abe07e
+  md5: e02b0dfe41e6b61a4afbd5c7e482c654
   depends:
   - graphviz
   - python
   - pyyaml
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tf2-msgs
-  - ros-jazzy-tf2-py
-  - ros-jazzy-tf2-ros-py
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2-msgs
+  - ros-kilted-tf2-py
+  - ros-kilted-tf2-ros-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 24008
-  timestamp: 1759139016782
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tinyxml2-vendor-0.9.1-np126py312h3bd2861_10.conda
-  sha256: 1826bf7e955fec0c5d74f28e58851fae90d56ed47b1e58ad84f6e0cc567b9ad7
-  md5: 3e859a033dd175dddd2864a10824f247
+  size: 24510
+  timestamp: 1759314709470
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.0-np2py312h31f38b3_14.conda
+  sha256: 664a4d0e41a758f6f193de8e9512ca143e7c36e4e7f5a9f5c179393e8baf9a9f
+  md5: d3d4fd3b0961da8dcfefb10e491be400
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - tinyxml2
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - tinyxml2 >=11.0.0,<11.1.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 24332
-  timestamp: 1759134515660
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tlsf-0.9.0-np126py312h3bd2861_10.conda
-  sha256: bc0bc093a129c741fcba2cc3dfd93ce73d221b8cf91c8db4b1bec456e098774a
-  md5: 7d0b957bc23d73c4a52bdf473e22d036
+  size: 24357
+  timestamp: 1759310551172
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tlsf-0.10.1-np2py312h31f38b3_14.conda
+  sha256: ffe73cc55ecf02072534c13ac9e37ddd0015325d59ef6f4407f3d0e76a601b4b
+  md5: 3dea2803e92958e66e305d4c74a48e09
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 32866
-  timestamp: 1759135164380
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tlsf-cpp-0.17.1-np126py312h3bd2861_10.conda
-  sha256: 31e57a0cfe8e2dd0739457d6742ba6460c851b5e20b10d6380835971bba5d0db
-  md5: 5828d1b5cb97433c92ee519d36eba18d
+  size: 32882
+  timestamp: 1759311223133
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tlsf-cpp-0.18.3-np2py312h31f38b3_14.conda
+  sha256: d4dcc148df052ae9ebac24770bd27b011ea1df02290a0a6c24537bd0b6947539
+  md5: 0080f12a63984a5b8ff0bdf4f1fe6223
   depends:
   - python
-  - ros-jazzy-ament-cmake
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rmw
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros-jazzy-tlsf
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ament-cmake
+  - ros-kilted-rclcpp
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros-kilted-tlsf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 186047
-  timestamp: 1759138281588
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-topic-monitor-0.33.7-np126py312h3bd2861_10.conda
-  sha256: 0cbcac924387a6fa2e248962ce23e0e0e23ce25e57adfcba632c54cae30e4b91
-  md5: ebea8f4e5cfc1719fba66a5f263873a2
+  size: 184559
+  timestamp: 1759314118930
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-topic-monitor-0.36.2-np2py312h31f38b3_14.conda
+  sha256: 64cac2e4152c0249dbe3b1209237cb06da644653ba3d8d83e13640d9a1cc6f0c
+  md5: 99333adc44f2e25036956bbea1a70858
   depends:
   - python
-  - ros-jazzy-launch
-  - ros-jazzy-launch-ros
-  - ros-jazzy-rclpy
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-launch
+  - ros-kilted-launch-ros
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 49500
-  timestamp: 1759138607334
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tracetools-8.2.4-np126py312h3bd2861_10.conda
-  sha256: f25d0f1a214c27118745c3ca772ffa64631489be4e9868c9daaf300ca11b26af
-  md5: af1df22dc8dd175c42fe14c84fcfb71b
+  size: 49466
+  timestamp: 1759314360658
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h31f38b3_14.conda
+  sha256: d5566180b6d0b80437f921482c1326cc19a1317177b1e4401d33eea055ca9517
+  md5: 61a009492f44fa9c8c53ee58e30abe07
   depends:
   - lttng-ust
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
   - lttng-ust >=2.13.9,<2.14.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 72568
-  timestamp: 1759135552746
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-trajectory-msgs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: 3a559f36ac25265d42db4abfefcdcfe7e399480e24a8a07c9cef158173e4a5a9
-  md5: 31563caf1d5993faea662a9bbef47c2b
+  size: 75909
+  timestamp: 1759311594080
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: 73258522ce780eb8bddb61655fceebbc1711b19ec9cbe5df38bdcc797898df95
+  md5: 73b5b71f22bcd8994eb80e74edda69d2
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 150323
-  timestamp: 1759137139092
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-turtlesim-1.8.3-np126py312h3bd2861_10.conda
-  sha256: acf6aa9edf37ac21aba2a60eb67c03a6ecdaf988a63552ec84a67a148aa82815
-  md5: 0f9340ea3165d99c230a18e9cdbf5561
+  size: 148617
+  timestamp: 1759312768675
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-turtlesim-1.9.3-np2py312h31f38b3_14.conda
+  sha256: 3146db12749291de12a0cfe6f6cb30cdf30daba678628b322b218e4a5b388f48
+  md5: b8a53cdf42d5bd1feb8dfd3ed8f19669
   depends:
   - python
   - qt-main
-  - ros-jazzy-ament-index-cpp
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-rcl-interfaces
-  - ros-jazzy-rclcpp
-  - ros-jazzy-rclcpp-action
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-std-msgs
-  - ros-jazzy-std-srvs
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros-kilted-std-srvs
+  - ros-kilted-turtlesim-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
   - xorg-libx11
   - xorg-libxext
-  - libgcc >=14
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
   - libgl >=1.7.0,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - libopengl >=1.7.0,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - qt-main >=5.15.15,<5.16.0a0
-  license: BSD-3-Clause
-  size: 905827
-  timestamp: 1759138544824
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-type-description-interfaces-2.0.3-np126py312h3bd2861_10.conda
-  sha256: 14368876873331ac7451cbf86be9ca2e19266d359bf583112b65bf3d5f06f776
-  md5: 148ab2d471c3f2c05ece1bef1a74aa33
-  depends:
-  - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-core-runtime
-  - ros-jazzy-service-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
   license: BSD-3-Clause
-  size: 232014
-  timestamp: 1759136425687
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-uncrustify-vendor-3.0.1-np126py312h3bd2861_10.conda
-  sha256: 8bfec2c28f1d91dae66dc2e340919df515cf24aa9f2b2c10436cb5e7f87a7e2c
-  md5: 9f7999ca0a848afcf154526c50fd1730
+  size: 578321
+  timestamp: 1759314311477
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-turtlesim-msgs-1.9.3-np2py312h31f38b3_14.conda
+  sha256: df71ca41d87a943adf4e058be2cb8ed999503c83ea4e530e2b3ca9a04be6a52d
+  md5: 0d663c27fbe4d2201e8405fda3d85d39
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 354681
+  timestamp: 1759312382218
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.0-np2py312h31f38b3_14.conda
+  sha256: 5d110f81291d7d35c9f49a4cd12ba8c0a98346dd11f9b7e7cf9fe5cabe02efb7
+  md5: b3170b9c4d7f084ada2f5c0b4feacd89
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-core-runtime
+  - ros-kilted-service-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 235660
+  timestamp: 1759312231654
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h31f38b3_14.conda
+  sha256: 0eb93b4dd346539ec669030a396229e6c54a2cf425cc0df233ac95b26b2d75ab
+  md5: 3c659b1d43a36fd36507d5a91abb4031
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - uncrustify
-  - libgcc >=14
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - uncrustify >=0.81.0,<0.82.0a0
-  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 22961
-  timestamp: 1759134500513
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-unique-identifier-msgs-2.5.0-np126py312h3bd2861_10.conda
-  sha256: 268d05a4cfdffd530dae91976a9ef5c4b627c0aa98d3d98b112d51ef6e7ee9c1
-  md5: 5ec0687171c636826444b41d9f2d1dc5
+  size: 22903
+  timestamp: 1759310568987
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h31f38b3_14.conda
+  sha256: 86244b9c4c68bb7fa8ef438be36e41ba46865ce5cb71f602b1c42044d1006a6a
+  md5: f52e20f5a1ee97432ae0196447e68a0e
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-core-runtime
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-core-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 74184
-  timestamp: 1759136346004
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-2.10.0-np126py312h3bd2861_10.conda
-  sha256: 6f82c0ad060265a4e44d5eb636b8249cc336cf93bbf66b6a8c6ff4649cec889a
-  md5: 03ddeb2220090ded429a18fcb63b2eb5
+  size: 72223
+  timestamp: 1759312168628
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-2.12.2-np2py312h31f38b3_14.conda
+  sha256: e01ea4a3b15d6047d768a0d425c63a8397c074f65ddaf1aed2ef4ed87bdb4ded
+  md5: 10fc4a3b24552f0106e23a0379b8e932
   depends:
   - python
-  - ros-jazzy-pluginlib
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tinyxml2-vendor
-  - ros-jazzy-urdf-parser-plugin
-  - ros-jazzy-urdfdom
-  - ros-jazzy-urdfdom-headers
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libgcc >=14
+  - ros-kilted-pluginlib
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdf-parser-plugin
+  - ros-kilted-urdfdom
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
   license: BSD-3-Clause
-  size: 155698
-  timestamp: 1759136011042
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-parser-plugin-2.10.0-np126py312h3bd2861_10.conda
-  sha256: daf76d316eab5af498999c6e3b59d84957540176ac8d6f8b663888f05f82a2d6
-  md5: 1e6605f33ce8f839c4b38d5fc95d7b6f
+  size: 157992
+  timestamp: 1759313704911
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-parser-plugin-2.12.2-np2py312h31f38b3_14.conda
+  sha256: 9f1f097b7f40d5721b63bf43603a3458305207c8a0d8d27bde54298ea6301e83
+  md5: 6dc2127774486b4d274b079d80921037
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-urdfdom-headers
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 31820
-  timestamp: 1759135533626
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-4.0.1-py312h24bf083_10.conda
-  sha256: a0a91bcf54de765bca95a7d49265bf33fb4cae66843004bcd9427ce396b7df78
-  md5: 4c5c0f01d6ed4f67279203376113bda8
+  size: 35339
+  timestamp: 1759313400256
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-4.0.1-py312h24bf083_14.conda
+  sha256: 41d74d8a275f9900b0467527640675e31e7acc7f0f0f7372611ca07d735e7dd0
+  md5: 9e10c205e7b8be8f7170244d9765c842
   depends:
   - console_bridge
   - python
-  - ros-jazzy-console-bridge-vendor
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-tinyxml2-vendor
-  - ros-jazzy-urdfdom-headers
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-console-bridge-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
   - tinyxml2
   - urdfdom >=4.0.1,<4.1.0a0
   - tinyxml2 >=11.0.0,<11.1.0a0
   - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 8062
-  timestamp: 1759135655375
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-headers-1.1.2-py312h24bf083_10.conda
-  sha256: a8600df10433692cd78648cbc25505084e97a78e54c9ab41df5ff267adde73a8
-  md5: 205a659da7d45091f845eb916bfbf7f1
+  size: 8043
+  timestamp: 1759311771528
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-headers-1.1.2-py312h24bf083_14.conda
+  sha256: 7ad307e8e5f93ade280789cebd98e4d7b7f9743ed546baa55b081f183125ff7d
+  md5: a54e127dab8ede674732ec3865adeca0
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - urdfdom_headers >=1.1.2,<1.2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
   license: BSD-3-Clause
-  size: 7285
-  timestamp: 1759133953538
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-visualization-msgs-5.3.6-np126py312h3bd2861_10.conda
-  sha256: 824e0c796d3702e4fc0d08910d34139896c85aa990f29fa9faf7c02a6aa93e6e
-  md5: 48cc837470469c7e55f8e6dc2ef870db
+  size: 7188
+  timestamp: 1759310088496
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.0-np2py312h31f38b3_14.conda
+  sha256: 3fbe5c4c8cd0aacf5179d030aab6ddcd849823d8730e482457fce0f1bce235c6
+  md5: c000d1bb682daff341c9366522ce0b77
   depends:
   - python
-  - ros-jazzy-builtin-interfaces
-  - ros-jazzy-geometry-msgs
-  - ros-jazzy-ros-workspace
-  - ros-jazzy-rosidl-default-runtime
-  - ros-jazzy-sensor-msgs
-  - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.11.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 369545
-  timestamp: 1759137347430
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-yaml-cpp-vendor-9.0.1-np126py312h3bd2861_10.conda
-  sha256: 2c627b005682990b8593beeea79f9c153e10a73108e99a52587d68c857703029
-  md5: f57f937864c0d1b09520f0d520539c4c
+  size: 376425
+  timestamp: 1759312951613
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h31f38b3_14.conda
+  sha256: 8b1e129142a71b6443e221e39a04faee2c26668e380c98e7da1321d8c970fe30
+  md5: 025b593a3d6ce1aaec4f1101dd93bcd7
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - yaml-cpp
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.26.4,<2.0a0
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
   - yaml-cpp >=0.8.0,<0.9.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 22923
-  timestamp: 1759134507745
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-zstd-vendor-0.26.9-np126py312h3bd2861_10.conda
-  sha256: 534eca1c6ec10b467ac3899eda5d0180e9acb57b9b6fe31e262d17ff781a8f84
-  md5: ba56b7898804a84306bc8d11ebd8d891
+  size: 22965
+  timestamp: 1759310581082
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zenoh-cpp-vendor-0.6.4-np2py312hf7ffe29_14.conda
+  sha256: b1e69c552768b4e202672b0263a94831c0a62589e9ab0c445db06eae44d899c3
+  md5: 1c6688b6fb616f18386ab55218df67e6
   depends:
   - python
-  - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.11.* jazzy_*
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libzenohc >=1.5.1,<1.5.2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: BSD-3-Clause
+  size: 25381
+  timestamp: 1759310563327
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-vendor-0.32.0-np2py312h31f38b3_14.conda
+  sha256: 3878487f828b0048aea76926396d3916e26302782a44a298190b2e1b72c9d1c9
+  md5: 55c4cc860e07ccb0fb02023b44ecbe53
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
   - zstd
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   - zstd >=1.5.7,<1.6.0a0
-  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
   license: BSD-3-Clause
-  size: 23744
-  timestamp: 1759134513579
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros2-distro-mutex-0.11.0-jazzy_10.conda
-  sha256: 7fcc5b58a9c7dda98bd4f13cfd5aa9d548d0564064d1375e153ab329ea04a7e8
-  md5: 0f3a0a48488540478bc8bdb536522b59
+  size: 23808
+  timestamp: 1759310593907
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros2-distro-mutex-0.12.0-kilted_14.conda
+  sha256: 56d6559c480829189182818499a65eb453ef59e9d969f2f051471ef2e0afb92e
+  md5: 13e5de7533aa2a21a835572178dedacd
   constrains:
   - libboost 1.86.*
   - libboost-devel 1.86.*
   - pcl 1.15.0.*
   - gazebo 11.*
-  - libprotobuf 5.29.3.*
+  - libprotobuf 6.31.1.*
   - libxml2 2.13.*
   - vtk 9.4.2.*
   license: BSD-3-Clause
-  size: 2353
-  timestamp: 1759133819339
-- conda: https://conda.anaconda.org/conda-forge/noarch/rosdep-0.26.0-pyhd8ed1ab_0.conda
-  sha256: c6f50c74e9b9620e55adcbb3c7bf8b6c91e04dce439681e8678b4dd028b200e9
-  md5: a4d0ef4688b3b621b7bb8e05667c0fbd
+  size: 2352
+  timestamp: 1759309976763
+- conda: https://conda.anaconda.org/conda-forge/noarch/rosdep-0.26.0-pyhd8ed1ab_1.conda
+  sha256: 73eebdcdebc4f78053dcfcd7366a3a07ad7e6c259125c1f22e411816a1fff89f
+  md5: 75e3cb8cf6a5a8283ae55b5a2209c746
   depends:
   - catkin_pkg >=0.4.0
-  - python >=3.9
+  - python >=3.10
   - pyyaml >=3.1
   - rosdistro >=0.8.3
   - rospkg >=1.3.0
@@ -14455,8 +15885,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/rosdep?source=hash-mapping
-  size: 69689
-  timestamp: 1751054686691
+  size: 69513
+  timestamp: 1761976348362
 - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
   sha256: bff3b2fe7afe35125669ffcb7d6153db78070a753e1e4ac3b3d8d198eb6d6982
   md5: b7ed380a9088b543e06a4f73985ed03a
@@ -14472,20 +15902,19 @@ packages:
   - pkg:pypi/rosdistro?source=hash-mapping
   size: 47691
   timestamp: 1747826651335
-- conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.0-pyhd8ed1ab_0.conda
-  sha256: 236e8b53b0fab599d63f346b0e84fbe9bd8d160e0dd1e591e39f23ff6924941e
-  md5: 80daa4ba1f1944b8ac1f90a66fc9ef27
+- conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
+  sha256: 4d930bee9f6a6d0fb7e5c9bb644b2b168787e907014deb49a3e00c0552934447
+  md5: d530f2ffe740578a5ece44b1004067cc
   depends:
   - catkin_pkg
   - distro
-  - python >=3.9
+  - python >=3.10
   - pyyaml
   license: BSD-3-Clause
-  license_family: BSD
   purls:
   - pkg:pypi/rospkg?source=hash-mapping
-  size: 31293
-  timestamp: 1737835793379
+  size: 31852
+  timestamp: 1766125246079
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.1-ha3a3aed_0.conda
   noarch: python
   sha256: fab29f194ae2facb591126acd35bcb22cc00283608c6214d555362623df7560f
@@ -14502,11 +15931,27 @@ packages:
   - pkg:pypi/ruff?source=hash-mapping
   size: 10982968
   timestamp: 1760643965238
-- pypi: git+https://github.com/scipy/scipy.git?rev=4cb83b6#4cb83b62d4bf1d27f63a57988a0fcd2aa15d6640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.10-h4196e79_0.conda
+  noarch: python
+  sha256: 997b45ce89554f677e4a30cd1d64565949be9d25c806727c3d844fee0d55d7d2
+  md5: ddecdee0806589993d96a950ad51b927
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  purls:
+  - pkg:pypi/ruff?source=compressed-mapping
+  size: 11472103
+  timestamp: 1766094973645
+- pypi: https://files.pythonhosted.org/packages/a9/0e/45af88dc9d4ebd36ce6c2778e67a6124bcbf0565ddc7751279fe0af5b2bd/scipy-1.17.0rc1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: scipy
-  version: 1.17.0.dev0
+  version: 1.17.0rc1
+  sha256: 701dd63a9543d6b80df947eeb3ef9fc3ec082862fb310b252e0501992feea1b0
   requires_dist:
-  - numpy>=1.26.4
+  - numpy>=1.26.4,<2.7
   - pytest>=8.0.0 ; extra == 'test'
   - pytest-cov ; extra == 'test'
   - pytest-timeout ; extra == 'test'
@@ -14536,6 +15981,51 @@ packages:
   - jupyterlite-pyodide-kernel ; extra == 'doc'
   - linkify-it-py ; extra == 'doc'
   - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.10.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/d7/52/871177befb910285db87fb23a93cb39d30e1fd38e6a6a0c6c63b872d41d6/scipy-1.17.0rc1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: scipy
+  version: 1.17.0rc1
+  sha256: c9a5c868b652220db2cda67fd11f86e64a1f6910b91359db5152c495b3ef89b2
+  requires_dist:
+  - numpy>=1.26.4,<2.7
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
   - spin ; extra == 'dev'
   - mypy==1.10.0 ; extra == 'dev'
   - typing-extensions ; extra == 'dev'
@@ -14666,6 +16156,11 @@ packages:
   - pkg:pypi/setuptools?source=hash-mapping
   size: 748788
   timestamp: 1748804951958
+- pypi: https://files.pythonhosted.org/packages/20/05/ed9b2571bbf38f1a2425391f18e3ac11cb1e91482c22d644a1640dea9da7/simplejson-3.20.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: simplejson
+  version: 3.20.2
+  sha256: 979ce23ea663895ae39106946ef3d78527822d918a136dbc77b9e2b7f006237e
+  requires_python: '>=2.5,!=3.0.*,!=3.1.*,!=3.2.*'
 - pypi: https://files.pythonhosted.org/packages/43/f1/b392952200f3393bb06fbc4dd975fc63a6843261705839355560b7264eb2/simplejson-3.20.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: simplejson
   version: 3.20.2
@@ -14707,19 +16202,19 @@ packages:
   version: 5.0.2
   sha256: b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e
   requires_python: '>=3.7'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_0.conda
-  sha256: 8b8acbde6814d1643da509e11afeb6bb30eb1e3004cf04a7c9ae43e9b097f063
-  md5: 3d8da0248bdae970b4ade636a104b7f5
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+  sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
+  md5: 98b6c9dc80eb87b2519b97bcf7e578dd
   depends:
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 45805
-  timestamp: 1753083455352
+  size: 45829
+  timestamp: 1762948049098
 - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
   sha256: 17007a4cfbc564dc3e7310dcbe4932c6ecb21593d4fec3c68610720f19e73fb2
   md5: 755cf22df8693aa0d1aec1c123fa5863
@@ -14744,32 +16239,32 @@ packages:
   purls: []
   size: 195618
   timestamp: 1751348678073
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.4-hbc0de68_0.conda
-  sha256: ea12e0714d70a536abe5968df612c57a966aa93c5a152cc4a1974046248d72a4
-  md5: 8376bd3854542be0c8c7cd07525d31c6
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.51.1-hbc0de68_0.conda
+  sha256: f74f6e1302086d84cb62b2bca74950763378054008c77b0a62ac637bcf25b3c1
+  md5: 968f50847d17c74a428fc47a2c70fd6f
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libsqlite 3.50.4 h0c1763c_0
+  - libsqlite 3.51.1 h0c1763c_0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
   license: blessing
   purls: []
-  size: 166233
-  timestamp: 1753948493149
-- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-3.0.2-h5888daf_0.conda
-  sha256: fb4b97a3fd259eff4849b2cfe5678ced0c5792b697eb1f7bcd93a4230e90e80e
-  md5: 0096882bd623e6cc09e8bf920fc8fb47
+  size: 183775
+  timestamp: 1764359463938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-3.1.2-hecca717_0.conda
+  sha256: 34e2e9c505cd25dba0a9311eb332381b15147cf599d972322a7c197aedfc8ce2
+  md5: 9859766c658e78fec9afa4a54891d920
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
+  - libgcc >=14
+  - libstdcxx >=14
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 2750235
-  timestamp: 1742907589246
+  size: 2741200
+  timestamp: 1756086702093
 - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
   name: sympy
   version: 1.14.0
@@ -14791,9 +16286,21 @@ packages:
   purls: []
   size: 24210909
   timestamp: 1752669140965
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.2.0-hb60516a_1.conda
-  sha256: 105a12b00e407aaaf04d811d3e737d470fd9e9328bc9a6a57f0f3fea5a486e84
-  md5: 29ed2be4b47b5aa1b07689e12407fbfd
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+  sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
+  md5: 13dc3adbc692664cd3beabd216434749
+  depends:
+  - __glibc >=2.28
+  - kernel-headers_linux-64 4.18.0 he073ed8_9
+  - tzdata
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 24008591
+  timestamp: 1765578833462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
+  sha256: 2e3238234ae094d5a5f7c559410ea8875351b6bac0d9d0e576bf64b732b8029e
+  md5: e3259be3341da4bc06c5b7a78c8bf1bd
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -14802,19 +16309,19 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 183204
-  timestamp: 1755775909376
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-devel-2022.2.0-h74b38a2_1.conda
-  sha256: 975eef4b3678fa0553e5326e35e7fc65bc49c4051677c282301be43d1c83258c
-  md5: 7add6fd0b1f39c7edbfff8704b34b6b6
+  size: 181262
+  timestamp: 1762509955687
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-devel-2022.3.0-h74b38a2_1.conda
+  sha256: 3c1bf7722f5c82459d3580c8e14eed19b08a83188d1c17aad9cb1e34d5f57339
+  md5: 11d050030e91674285a5daa2e17b1126
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - tbb 2022.2.0 hb60516a_1
+  - tbb 2022.3.0 h8d10470_1
   purls: []
-  size: 1091675
-  timestamp: 1755775925902
+  size: 1115083
+  timestamp: 1762509972811
 - pypi: https://files.pythonhosted.org/packages/68/d6/d95cde18ca2475bf317051b2be168cc963c5cfcd67e9c59786326ccdca53/tensorstore-0.1.78-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: tensorstore
   version: 0.1.78
@@ -14823,6 +16330,14 @@ packages:
   - numpy>=1.22.0
   - ml-dtypes>=0.5.0
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/48/85/55addd16896343ea2731388028945576060139dda3c68a15d6b00158ef6f/tensorstore-0.1.80-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: tensorstore
+  version: 0.1.80
+  sha256: bc28a58c580253a526a4b6d239d18181ef96f1e285a502dbb03ff15eeec07a5b
+  requires_dist:
+  - numpy>=1.22.0
+  - ml-dtypes>=0.5.0
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl
   name: termcolor
   version: 3.1.0
@@ -14831,6 +16346,14 @@ packages:
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/f9/d5/141f53d7c1eb2a80e6d3e9a390228c3222c27705cbe7f048d3623053f3ca/termcolor-3.2.0-py3-none-any.whl
+  name: termcolor
+  version: 3.2.0
+  sha256: a10343879eba4da819353c55cb8049b0933890c2ebf9ad5d3ecd2bb32ea96ea6
+  requires_dist:
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_2.conda
   sha256: 4770807cc5a217638c9aea3f05ea55718a82c50f32462df196b5472aff02787f
   md5: 23b4ba5619c4752976eb7ba1f5acb7e8
@@ -14854,6 +16377,20 @@ packages:
   purls: []
   size: 131351
   timestamp: 1742246125630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
+  sha256: 1544760538a40bcd8ace2b1d8ebe3eb5807ac268641f8acdc18c69c5ebfeaf64
+  md5: 86bc20552bf46075e3d92b67f089172d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3284905
+  timestamp: 1763054914403
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
   sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
   md5: a0116df4f4ed05c303811a837d5b39d8
@@ -14871,17 +16408,18 @@ packages:
   version: 0.10.2
   sha256: 806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b
   requires_python: '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*'
-- conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
-  sha256: 34f3a83384ac3ac30aefd1309e69498d8a4aa0bf2d1f21c645f79b180e378938
-  md5: b0dd904de08b7db706167240bf37b164
+- conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
+  sha256: fd30e43699cb22ab32ff3134d3acf12d6010b5bbaa63293c37076b50009b91f8
+  md5: d0fc809fa4c4d85e959ce4ab6e1de800
   depends:
-  - python >=3.9
+  - python >=3.10
+  - python
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/toml?source=hash-mapping
-  size: 22132
-  timestamp: 1734091907682
+  size: 24017
+  timestamp: 1764486833072
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
   sha256: cb77c660b646c00a48ef942a9e1721ee46e90230c7c570cdeb5a893b5cce9bff
   md5: d2732eb636c264dc9aa4cbee404b1a53
@@ -14941,6 +16479,13 @@ packages:
   - pkg:pypi/tqdm?source=hash-mapping
   size: 89498
   timestamp: 1735661472632
+- pypi: https://files.pythonhosted.org/packages/61/7a/f38385f1b2d5f54221baf1db3d6371dc6eef8041d95abff39576c694e9d9/transforms3d-0.4.2-py3-none-any.whl
+  name: transforms3d
+  version: 0.4.2
+  sha256: 1c70399d9e9473ecc23311fd947f727f7c69ed0b063244828c383aa1aefa5941
+  requires_dist:
+  - numpy>=1.15
+  requires_python: '>=3.6'
 - pypi: https://files.pythonhosted.org/packages/43/2b/36e984399089c026a6499ac8f7401d38487cf0183839a4aa78140d373771/treescope-0.1.10-py3-none-any.whl
   name: treescope
   version: 0.1.10
@@ -15028,6 +16573,54 @@ packages:
   - openctm ; extra == 'deprecated'
   - trimesh[deprecated,easy,recommend,test,test-more] ; extra == 'all'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/d5/0c/f08f0d16b4f97ec2ea6d542b9a70472a344384382fa3543a12ec417cc063/trimesh-4.10.1-py3-none-any.whl
+  name: trimesh
+  version: 4.10.1
+  sha256: 4e81fae696683dfe912ef54ce124869487d35d267b87e10fe07fc05ab62aaadb
+  requires_dist:
+  - numpy>=1.20
+  - colorlog ; extra == 'easy'
+  - manifold3d>=2.3.0 ; python_full_version < '3.14' and extra == 'easy'
+  - charset-normalizer ; extra == 'easy'
+  - lxml ; extra == 'easy'
+  - jsonschema ; extra == 'easy'
+  - networkx ; extra == 'easy'
+  - svg-path ; extra == 'easy'
+  - pycollada<=0.9.0 ; python_full_version < '3.9' and extra == 'easy'
+  - pycollada ; python_full_version >= '3.9' and extra == 'easy'
+  - shapely ; extra == 'easy'
+  - xxhash ; extra == 'easy'
+  - rtree ; extra == 'easy'
+  - httpx ; extra == 'easy'
+  - scipy ; extra == 'easy'
+  - embreex ; platform_machine == 'x86_64' and extra == 'easy'
+  - pillow ; extra == 'easy'
+  - vhacdx ; python_full_version >= '3.9' and extra == 'easy'
+  - mapbox-earcut>=1.0.2 ; python_full_version >= '3.9' and extra == 'easy'
+  - sympy ; extra == 'recommend'
+  - pyglet<2 ; extra == 'recommend'
+  - scikit-image ; extra == 'recommend'
+  - fast-simplification ; extra == 'recommend'
+  - python-fcl ; extra == 'recommend'
+  - cascadio ; extra == 'recommend'
+  - manifold3d>=2.3.0 ; python_full_version >= '3.14' and extra == 'recommend'
+  - pytest-cov ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pyinstrument ; extra == 'test'
+  - ruff ; extra == 'test'
+  - coveralls ; extra == 'test-more'
+  - ezdxf ; extra == 'test-more'
+  - meshio ; extra == 'test-more'
+  - xatlas ; extra == 'test-more'
+  - pytest-beartype ; python_full_version >= '3.10' and extra == 'test-more'
+  - matplotlib ; extra == 'test-more'
+  - pymeshlab ; python_full_version < '3.14' and extra == 'test-more'
+  - triangle ; python_full_version < '3.14' and extra == 'test-more'
+  - ipython ; extra == 'test-more'
+  - marimo ; extra == 'test-more'
+  - openctm ; extra == 'deprecated'
+  - trimesh[deprecated,easy,recommend,test,test-more] ; extra == 'all'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: triton
   version: 3.4.0
@@ -15075,6 +16668,13 @@ packages:
   purls: []
   size: 122968
   timestamp: 1742727099393
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-h8577fbf_0.conda
+  sha256: 50fad5db6734d1bb73df1cf5db73215e326413d4b2137933f70708aa1840e25b
+  md5: 338201218b54cadff2e774ac27733990
+  license: LicenseRef-Public-Domain
+  purls: []
+  size: 119204
+  timestamp: 1765745742795
 - conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.81.0-h5888daf_0.conda
   sha256: f0b3ad46b173de03c45134b16d7be0b5bdaff344cccb6a4d205850809c1a4dca
   md5: c2310445798370fe622fc6b03d79a3a4
@@ -15087,9 +16687,9 @@ packages:
   purls: []
   size: 650318
   timestamp: 1747514389910
-- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py312h4c3975b_1.conda
-  sha256: cbf7d13819cf526a094f0cfe2da7f7ba22c4fbae4d231c9004520fbbf93f7027
-  md5: 4da303c1e91703d178817252615ca0a7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.0-py312h4c3975b_1.conda
+  sha256: 3c812c634e78cec74e224cc6adf33aed533d9fe1ee1eff7f692e1f338efb8c5b
+  md5: a0b8efbe73c90f810a171a6c746be087
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -15099,8 +16699,8 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/unicodedata2?source=hash-mapping
-  size: 404974
-  timestamp: 1756494558558
+  size: 408399
+  timestamp: 1763054875733
 - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-hae71d53_3.conda
   sha256: 70b1e7322bf6306de6186e91fb87c15f7ba5c1aeb6d0fd31780e088c42025fc4
   md5: a7830d1b7ade9d3f8c35191084fe7022
@@ -15150,6 +16750,44 @@ packages:
   purls: []
   size: 14169
   timestamp: 1758003868824
+- pypi: https://files.pythonhosted.org/packages/ac/a4/dc6f335e54877f5d26ad4e4aac8f49b2d6e7719dee3e08f363d882c8aba4/vispy-0.15.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: vispy
+  version: 0.15.2
+  sha256: e9d38228cedd23876cb2359ff568d523a97284d225259d450d5e5e2129e98eb1
+  requires_dist:
+  - numpy
+  - freetype-py
+  - hsluv
+  - kiwisolver
+  - packaging
+  - ipython ; extra == 'ipython-static'
+  - pyglet>=1.2 ; extra == 'pyglet'
+  - pyqt5 ; extra == 'pyqt5'
+  - pyqt6 ; extra == 'pyqt6'
+  - pyside ; extra == 'pyside'
+  - pyside2 ; extra == 'pyside2'
+  - pyside6 ; extra == 'pyside6'
+  - glfw ; extra == 'glfw'
+  - pysdl2 ; extra == 'sdl2'
+  - wxpython ; extra == 'wx'
+  - pyopengltk ; extra == 'tk'
+  - pydata-sphinx-theme ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - sphinxcontrib-apidoc ; extra == 'doc'
+  - sphinx-gallery ; extra == 'doc'
+  - myst-parser ; extra == 'doc'
+  - pillow ; extra == 'doc'
+  - pytest ; extra == 'doc'
+  - pyopengl ; extra == 'doc'
+  - meshio ; extra == 'io'
+  - pillow ; extra == 'io'
+  - pytest ; extra == 'test'
+  - pytest-sugar ; extra == 'test'
+  - meshio ; extra == 'test'
+  - pillow ; extra == 'test'
+  - sphinx-gallery ; extra == 'test'
+  - imageio ; extra == 'test'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-9.4.2-hf9009d3_4.conda
   sha256: cfad04c182bceefa91b4ed77fe723d9920d0f2571d6d315594b7e9f87052a2a9
   md5: 1fe792b86976782b3a91469a6a873dff
@@ -15323,28 +16961,54 @@ packages:
   - pillow ; extra == 'extras'
   - pyglet ; extra == 'extras'
   requires_python: '>=3.8'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-h3e06ad9_0.conda
-  sha256: ba673427dcd480cfa9bbc262fd04a9b1ad2ed59a159bd8f7e750d4c52282f34c
-  md5: 0f2ca7906bf166247d1d760c3422cb8a
+- pypi: https://files.pythonhosted.org/packages/ea/85/22c1e2ed47daec6dd40eaf0b11c6b86ad483636b8038453a87d1031f8a36/warp_lang-1.10.1-py3-none-manylinux_2_28_x86_64.whl
+  name: warp-lang
+  version: 1.10.1
+  sha256: 2884b642f16b07b930b3605193c1b97d183eef80c5b0083d3a17473aee92138e
+  requires_dist:
+  - numpy
+  - nvidia-sphinx-theme ; python_full_version >= '3.9' and extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - pre-commit ; extra == 'docs'
+  - myst-parser ; extra == 'docs'
+  - usd-core>=25.5 ; python_full_version < '3.14' and platform_machine != 'aarch64' and extra == 'benchmark'
+  - usd-exchange>=2.1.0a3 ; python_full_version >= '3.10' and platform_machine == 'aarch64' and extra == 'benchmark'
+  - blosc>=1.11.1 ; extra == 'examples'
+  - matplotlib>=3.7.5 ; extra == 'examples'
+  - pillow>=10.4.0 ; extra == 'examples'
+  - psutil>=7.1.0 ; extra == 'examples'
+  - pyglet>=2.1.9 ; extra == 'examples'
+  - usd-core>=25.5 ; python_full_version < '3.14' and platform_machine != 'aarch64' and extra == 'examples'
+  - usd-exchange>=2.1.0a3 ; python_full_version >= '3.10' and platform_machine == 'aarch64' and extra == 'examples'
+  - warp-lang[examples] ; extra == 'torch-cu12'
+  - torch>=2.7.0 ; python_full_version >= '3.9' and extra == 'torch-cu12'
+  - warp-lang[examples] ; extra == 'dev'
+  - warp-lang[docs] ; extra == 'dev'
+  - nvtx ; extra == 'dev'
+  - coverage[toml] ; extra == 'dev'
+  requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
+  sha256: 3aa04ae8e9521d9b56b562376d944c3e52b69f9d2a0667f77b8953464822e125
+  md5: 035da2e4f5770f036ff704fa17aace24
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libexpat >=2.7.0,<3.0a0
-  - libffi >=3.4.6,<3.5.0a0
-  - libgcc >=13
-  - libstdcxx >=13
+  - libexpat >=2.7.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - libstdcxx >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 330474
-  timestamp: 1751817998141
-- conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.45-hd8ed1ab_0.conda
-  sha256: 37b0e03a943c048e143f624c51b329778f36923052092fd938827f8c19a4941d
-  md5: 6db9be3b67190229479780eeeee1b35b
+  size: 329779
+  timestamp: 1761174273487
+- conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
+  sha256: 9ab2c12053ea8984228dd573114ffc6d63df42c501d59fda3bf3aeb1eaa1d23e
+  md5: 7da1571f560d4ba3343f7f4c48a79c76
   license: MIT
   license_family: MIT
   purls: []
-  size: 138011
-  timestamp: 1749836220507
+  size: 140476
+  timestamp: 1765821981856
 - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
   sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
   md5: 2841eb5bfc75ce15e9a0054b98dcd64d
@@ -15427,21 +17091,21 @@ packages:
   purls: []
   size: 20772
   timestamp: 1750436796633
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
-  sha256: c7b35db96f6e32a9e5346f97adc968ef2f33948e3d7084295baebc0e33abdd5b
-  md5: eb44b3b6deb1cab08d72cb61686fe64c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+  sha256: c2be9cae786fdb2df7c2387d2db31b285cf90ab3bfabda8fa75a596c3d20fc67
+  md5: 4d1fc190b99912ed557a8236e958c559
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   - libxcb >=1.13
-  - libxcb >=1.16,<2.0.0a0
+  - libxcb >=1.17.0,<2.0a0
   - xcb-util-image >=0.4.0,<0.5.0a0
   - xcb-util-renderutil >=0.3.10,<0.4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 20296
-  timestamp: 1726125844850
+  size: 20829
+  timestamp: 1763366954390
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
   sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
   md5: a0901183f08b6c7107aab109733a3c91
@@ -15535,17 +17199,17 @@ packages:
   purls: []
   size: 835896
   timestamp: 1741901112627
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
-  sha256: ed10c9283974d311855ae08a16dfd7e56241fac632aec3b92e3cfe73cff31038
-  md5: f6ebe2cb3f82ba6c057dde5d9debe4f7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+  sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
+  md5: b2895afaf55bf96a8c8282a2e47a5de0
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 14780
-  timestamp: 1734229004433
+  size: 15321
+  timestamp: 1762976464266
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
   sha256: 105ff923b60286188978d7b3aa159b555e2baf4c736801f62602d4127159f06d
   md5: 7c0a9bf62d573409d12ad14b362a96e5
@@ -15603,17 +17267,17 @@ packages:
   purls: []
   size: 13217
   timestamp: 1727891438799
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
-  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
-  md5: 8035c64cb77ed555e3f150b7b3972480
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+  sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
+  md5: 1dafce8548e38671bea82e3f5c6ce22f
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 19901
-  timestamp: 1727794976192
+  size: 20591
+  timestamp: 1762976546182
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
   sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
   md5: febbab7d15033c913d53c7a2c102309d
@@ -15788,17 +17452,17 @@ packages:
   purls: []
   size: 17819
   timestamp: 1734214575628
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
-  sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
-  md5: 7c21106b851ec72c037b162c216d8f05
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
+  sha256: 7a8c64938428c2bfd016359f9cb3c44f94acc256c6167dbdade9f2a1f5ca7a36
+  md5: aa8d21be4b461ce612d8f5fb791decae
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 565425
-  timestamp: 1726846388217
+  size: 570010
+  timestamp: 1766154256151
 - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
   sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
   md5: a77f85f77be52ff59391544bfe73390a
@@ -15823,13 +17487,13 @@ packages:
   purls: []
   size: 223526
   timestamp: 1745307989800
-- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.20.1-py312h178313f_0.conda
-  sha256: f5c2c572423fac9ea74512f96a7c002c81fd2eb260608cfa1edfaeda4d81582e
-  md5: 3b3fa80c71d6a8d0380e9e790f5a4a8a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.22.0-py312h8a5da7c_0.conda
+  sha256: 6e3f2db09387fc982b5400b842745084825cd2d4621e8278e4af8fb0dc2b55d8
+  md5: 6a3fd177315aaafd4366930d440e4430
   depends:
   - __glibc >=2.17,<3.0.a0
   - idna >=2.0
-  - libgcc >=13
+  - libgcc >=14
   - multidict >=4.0
   - propcache >=0.2.1
   - python >=3.12,<3.13.0a0
@@ -15838,8 +17502,19 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/yarl?source=hash-mapping
-  size: 149496
-  timestamp: 1749555225039
+  size: 151549
+  timestamp: 1761337128623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zenoh-rust-abi-1.5.1.1.85.0-h8619998_0.conda
+  sha256: fd9a51a818c9e3f6208d7bdfc64b0393e49ff7a7ad0c102f188bd9d8a4b4d4c8
+  md5: 5484736d4ddd49de688e3cd7a9262238
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 OR EPL-2.0
+  purls: []
+  size: 46881
+  timestamp: 1757026026903
 - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
   name: zipp
   version: 3.23.0
@@ -15864,17 +17539,18 @@ packages:
   - pytest-enabler>=2.2 ; extra == 'enabler'
   - pytest-mypy ; extra == 'type'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
-  sha256: 7560d21e1b021fd40b65bfb72f67945a3fcb83d78ad7ccf37b8b3165ec3b68ad
-  md5: df5e78d904988eb55042c0c97446079f
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+  sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
+  md5: 30cd29cb87d819caead4d55184c1d115
   depends:
-  - python >=3.9
+  - python >=3.10
+  - python
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/zipp?source=hash-mapping
-  size: 22963
-  timestamp: 1749421737203
+  - pkg:pypi/zipp?source=compressed-mapping
+  size: 24194
+  timestamp: 1764460141901
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
   sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
   md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
@@ -15887,6 +17563,18 @@ packages:
   purls: []
   size: 92286
   timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.2-hceb46e0_1.conda
+  sha256: f2b6a175677701a0b6ce556b3bd362dc94a4e36ffcd10e3860e52ca036b4ad96
+  md5: 40feea2979654ed579f1cda7c63ccb94
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 122303
+  timestamp: 1766076745735
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py313h54dd161_0.conda
   sha256: 9d79d176afe50361cc3fd4366bedff20852dbea1e5b03f358b55f12aca22d60d
   md5: 1fe43bd1fc86e22ad3eb0edec637f8a2
@@ -15904,6 +17592,17 @@ packages:
   - pkg:pypi/zstandard?source=hash-mapping
   size: 471152
   timestamp: 1757930114245
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 601375
+  timestamp: 1764777111296
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
   sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
   md5: 6432cb5d4ac0046c3ac0a8a0f95842f9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ lsy_drone_racing = ["envs/assets/*.xml"]
 [tool.pytest.ini_options]
 markers = ["unit", "integration"]
 
+[tool.ruff.lint.isort]  # Prevent ruff from reporting conflicting settings with isort
+split-on-trailing-comma = false
+
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ indent-width = 4
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "D", "TCH", "ANN"]
+select = ["E", "F", "I", "D", "TCH", "ANN"]
 ignore = ["ANN401"]
 fixable = ["ALL"]
 unfixable = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ sim = [
     "gymnasium[array-api] >= 1.2.0",
     "ml-collections >= 1.0",
     "packaging >= 24.0",
-    "drone-models @ git+https://github.com/utiasDSL/drone-models.git@adr_ws25",
-    "drone-controllers @ git+https://github.com/utiasDSL/drone-controllers.git@adr_ws25",
-    "crazyflow @ git+https://github.com/utiasDSL/crazyflow.git@adr_ws25",
+    "drone-models",
+    "drone-controllers",
+    "crazyflow @ git+https://github.com/utiasDSL/crazyflow.git@0.1.0b0",
     "jax >= 0.7",
     "warp-lang",
 ]
@@ -41,7 +41,7 @@ gpu = ["jax[cuda12]"]
 # option[deploy]: deploy to real drones
 deploy = [
     "cfclient",
-    "drone-estimators @ git+https://github.com/utiasDSL/drone-estimators.git@adr_ws25",
+    "drone-estimators",
 ]
 # option[rl]: train rl policy
 rl = ["torch == 2.8.0", "wandb"]
@@ -120,16 +120,24 @@ platforms = ["linux-64"]
 [tool.pixi.pypi-dependencies]
 lsy_drone_racing = { path = ".", editable = true }
 
-# feature[jazzy]
-[tool.pixi.feature.jazzy]
-channels = ["https://prefix.dev/robostack-jazzy"]
+# feature[kilted]
+[tool.pixi.feature.kilted]
+channels = ["https://prefix.dev/robostack-kilted"]
 
-[tool.pixi.feature.jazzy.dependencies]
-ros-jazzy-desktop = "*"
-colcon-common-extensions = "*"
+[tool.pixi.feature.kilted.dependencies]
+# Build tools
+compilers = "*"
+cmake = "*"
+pkg-config = "*"
+make = "*"
+ninja = "*"
+# ROS specific tools
 rosdep = "*"
+colcon-common-extensions = "*"
+# Kilted specific tools
+ros-kilted-desktop = "*"
 
-[tool.pixi.feature.jazzy.activation]
+[tool.pixi.feature.kilted.activation]
 scripts = ["tools/setup_mocap.sh"]
 
 [tool.pixi.activation]
@@ -156,9 +164,7 @@ pytest = "*"
 # environments
 [tool.pixi.environments]
 default = { features = ["sim"], solve-group = "default" }
-deploy = { features = [
-    "jazzy",
-] } # for deploy we must install everything else with pip
+deploy = { features = ["sim", "gpu", "kilted", "deploy"] }
 gpu = { features = ["sim", "gpu"], solve-group = "default" }
 online-submission = { features = [
     "sim",
@@ -168,13 +174,6 @@ tests = { features = ["sim", "rl", "tests"], solve-group = "default" }
 gpu-tests = { features = ["sim", "gpu", "tests"], solve-group = "default" }
 
 [tool.pixi.dependencies]
-# TODO: Remove compilers once scipy 1.17 is released and drone-models have been updated.
-# gcc = ">=15.1.0,<15.2"
-# cxx-compiler = ">=1.0.0,<2"
-# gfortran = ">=15.1.0,<15.2"
-# pkg-config = "*"
-# ninja = "*"
-# rosbags = ">=0.10.9,<0.11"
 openblas = ">=0.3.30,<0.4"
 ruff = "*"
 python = ">=3.11.12,<3.14"

--- a/scripts/check_track.py
+++ b/scripts/check_track.py
@@ -9,6 +9,7 @@ from scipy.spatial.transform import Rotation as R
 
 from lsy_drone_racing.utils import load_config
 from lsy_drone_racing.utils.checks import check_race_track
+from lsy_drone_racing.utils.ros import track_poses
 
 logger = logging.getLogger("rosout." + __name__)
 
@@ -21,10 +22,22 @@ def main(config: str = "level2.toml"):
     """
     rclpy.init()
     config = load_config(Path(__file__).resolve().parents[1] / "config" / config)
-    gates_pos = [g["pos"] for g in config.env.track.gates]
-    gates_quat = [R.from_euler("xyz", g["rpy"]).as_quat() for g in config.env.track.gates]
-    obstacle_pos = [o["pos"] for o in config.env.track.obstacles]
-    check_race_track(gates_pos, gates_quat, obstacle_pos, rng_config=config.env.randomizations)
+    nominal_gates_pos = [g["pos"] for g in config.env.track.gates]
+    nominal_gates_quat = [R.from_euler("xyz", g["rpy"]).as_quat() for g in config.env.track.gates]
+    nominal_obstacles_pos = [o["pos"] for o in config.env.track.obstacles]
+    n_gates = len(nominal_gates_pos)
+    n_obstacles = len(nominal_obstacles_pos)
+    gates_pos, gates_quat, obstacles_pos = track_poses(n_gates=n_gates, n_obstacles=n_obstacles)
+    check_race_track(
+        gates_pos=gates_pos,
+        nominal_gates_pos=nominal_gates_pos,
+        gates_quat=gates_quat,
+        nominal_gates_quat=nominal_gates_quat,
+        obstacles_pos=obstacles_pos,
+        nominal_obstacles_pos=nominal_obstacles_pos,
+        rng_config=config.env.randomizations,
+    )
+
     logger.info("Race track check passed")
 
 

--- a/scripts/save_track_as_config.py
+++ b/scripts/save_track_as_config.py
@@ -1,0 +1,75 @@
+"""Script for generating .toml configuration files from a real race track."""
+
+import logging
+from pathlib import Path
+
+import fire
+import rclpy
+import toml
+from ml_collections import ConfigDict
+from scipy.spatial.transform import Rotation as R
+
+from lsy_drone_racing.utils import load_config
+from lsy_drone_racing.utils.ros import drone_poses, track_poses
+
+logger = logging.getLogger("rosout." + __name__)
+
+
+def update_level_config(
+    config: ConfigDict, gates: ConfigDict, obstacles: ConfigDict, drones: ConfigDict
+) -> ConfigDict:
+    """Update the level config with the real track objects poses.
+
+    Args:
+        config: A ConfigDict storing the original level configuration.
+        gates: A ConfigDict storing the updated gate positions and orientations.
+        obstacles: A ConfigDict storing the updated obstacle positions.
+        drones: A ConfigDict storing the updated drone starting positions and orientations.
+
+    Returns:
+        A ConfigDict object, with updated starting pose of gates, obstacles and drones
+    """
+    # We store the real-world track layout, so randomization must be disabled
+    config.env.track.randomize = False
+    # Overwrite the original positions and orientations with the measured ones
+    for i in range(gates.pos.shape[0]):
+        config.env.track.gates[i]["pos"] = gates.pos[i].tolist()
+        config.env.track.gates[i]["rpy"] = R.from_quat(gates.quat[i]).as_euler("xyz").tolist()
+    for i in range(obstacles.pos.shape[0]):
+        config.env.track.obstacles[i]["pos"] = obstacles.pos[i].tolist()
+    for i in range(drones.pos.shape[0]):
+        config.env.track.drones[i]["pos"] = drones.pos[i].tolist()
+        config.env.track.drones[i]["rpy"] = R.from_quat(drones.quat[i]).as_euler("xyz").tolist()
+    return config
+
+
+def main(config: str = "level2.toml", save_config_to: str = "real_track.toml"):
+    """Check if the real race track conforms to the race configuration.
+
+    Args:
+        config: Path to the race configuration. Assumes the file is in `config/`.
+        save_config_to: Path to save the track configuration if the check passes.
+    """
+    rclpy.init()
+    config = load_config(Path(__file__).resolve().parents[1] / "config" / config)
+    n_gates = len(config.env.track.gates)
+    n_obstacles = len(config.env.track.obstacles)
+    drone_names = [f"cf{drone['id']}" for drone in config.deploy.drones]
+    gates, obstacles, drones = dict(), dict(), dict()
+    gates["pos"], gates["quat"], obstacles["pos"] = track_poses(
+        n_gates=n_gates, n_obstacles=n_obstacles
+    )
+    drones["pos"], drones["quat"] = drone_poses(drone_names=drone_names)
+    config_output = update_level_config(
+        config, gates=ConfigDict(gates), obstacles=ConfigDict(obstacles), drones=ConfigDict(drones)
+    )
+    output_path = Path(__file__).parents[1] / "config" / save_config_to
+    if not output_path.suffix == ".toml":
+        raise ValueError(f"Configuration file has to be a TOML file: {output_path}")
+    with open(output_path, "w") as f:
+        toml.dump(config_output.to_dict(), f)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    fire.Fire(main)


### PR DESCRIPTION
1. Support level 3 deployment & refactor code.
2. Upgrade to latest drone-models, drone-controllers, drone-estimators and ros2-kilted.
3. Update docs.