### PR TITLE
Fix bug: Takeoff pos randomization is overridden by complete track randomization.

### DIFF
--- a/lsy_drone_racing/control/attitude_rl.py
+++ b/lsy_drone_racing/control/attitude_rl.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
+from drone_controllers.mellinger.params import ForceTorqueParams
 from drone_models.core import load_params
 from scipy.interpolate import CubicSpline
 
@@ -42,8 +43,9 @@ class AttitudeRL(Controller):
 
         drone_params = load_params(config.sim.physics, config.sim.drone_model)
         self.drone_mass = drone_params["mass"]  # alternatively from sim.drone_mass
-        self.thrust_min = drone_params["thrust_min"] * 4  # min total thrust
-        self.thrust_max = drone_params["thrust_max"] * 4  # max total thrust
+        params = ForceTorqueParams.load(config.sim.drone_model)
+        self.thrust_min = params.thrust_min * 4  # min total thrust
+        self.thrust_max = params.thrust_max * 4  # max total thrust
 
         # Set num of stacked obs
         self.n_obs = 2

--- a/lsy_drone_racing/control/attitude_rl.py
+++ b/lsy_drone_racing/control/attitude_rl.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-from drone_controllers.mellinger.params import ForceTorqueParams
 from drone_models.core import load_params
 from scipy.interpolate import CubicSpline
 
@@ -43,9 +42,8 @@ class AttitudeRL(Controller):
 
         drone_params = load_params(config.sim.physics, config.sim.drone_model)
         self.drone_mass = drone_params["mass"]  # alternatively from sim.drone_mass
-        params = ForceTorqueParams.load(config.sim.drone_model)
-        self.thrust_min = params.thrust_min * 4  # min total thrust
-        self.thrust_max = params.thrust_max * 4  # max total thrust
+        self.thrust_min = drone_params["thrust_min"] * 4  # min total thrust
+        self.thrust_max = drone_params["thrust_max"] * 4  # max total thrust
 
         # Set num of stacked obs
         self.n_obs = 2

--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -32,6 +32,7 @@ import mujoco
 import numpy as np
 from crazyflow.sim import Sim
 from crazyflow.sim.sim import use_box_collision
+from crazyflow.utils import leaf_replace
 from drone_controllers.mellinger.params import ForceTorqueParams
 from flax.struct import dataclass
 from gymnasium import spaces
@@ -347,9 +348,6 @@ class RaceCoreEnv:
         if seed is not None:
             self.sim.seed(seed)
             self._np_random = np.random.default_rng(seed)  # Also update gymnasium's rng
-        # Randomization of the drone is compiled into the sim reset pipeline, so we don't need to
-        # explicitly do it here
-        self.sim.reset(mask=mask)
         key, subkey, subkey2 = jax.random.split(self.sim.data.core.rng_key, 3)
         # Generate random track
         track = generate_random_track(self.track, subkey2) if self.track.randomize else self.track
@@ -359,11 +357,11 @@ class RaceCoreEnv:
 
         @jax.jit
         def update_sim_data(
-            data: SimData, mjx_data: Data, key: jax.random.PRNGKey
+            data: SimData, mjx_data: Data, mask: Array, key: jax.random.PRNGKey
         ) -> tuple[SimData, Data]:
-            # Randomized drone pos
+            # Write randomized takeoff pos to default data
             pos = data.states.pos.at[...].set(self.drone["pos"])
-            data = data.replace(states=data.states.replace(pos=pos))
+            data = data.replace(states=leaf_replace(data.states, mask, pos=pos))
 
             mjx_data = self.randomize_track(
                 mjx_data,
@@ -375,7 +373,13 @@ class RaceCoreEnv:
             )
             return data, mjx_data
 
-        self.sim.data, self.sim.mjx_data = update_sim_data(self.sim.data, self.sim.mjx_data, subkey)
+        self.sim.default_data, self.sim.mjx_data = update_sim_data(
+            self.sim.default_data, self.sim.mjx_data, mask, subkey
+        )
+
+        # Randomization of the drone is compiled into the sim reset pipeline, so we don't need to
+        # explicitly do it here
+        self.sim.reset(mask=mask)
 
         # Reset the environment data
         self.data = self._reset_env_data(

--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -781,7 +781,7 @@ def build_track_randomization_fn(
         nominal_mocap_pos = nominal_mocap_pos.at[:, obstacle_mocap_ids].set(nominal_obstacle_pos)
         nominal_mocap_quat = data.mocap_quat.at[:, gate_mocap_ids].set(gate_quat)
         data = leaf_replace(data, mask, mocap_pos=nominal_mocap_pos, mocap_quat=nominal_mocap_quat)
-        
+
         keys = jax.random.split(key, len(randomization_fns))
         for key, randomize_fn in zip(keys, randomization_fns, strict=True):
             data = randomize_fn(data, mask, key)

--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -777,11 +777,11 @@ def build_track_randomization_fn(
         gate_quat = jp.roll(nominal_gate_quat, 1, axis=-1)  # Convert from scipy to MuJoCo order
 
         # Reset to default track positions first
-        data = data.replace(mocap_pos=data.mocap_pos.at[:, gate_mocap_ids].set(nominal_gate_pos))
-        data = data.replace(mocap_quat=data.mocap_quat.at[:, gate_mocap_ids].set(gate_quat))
-        data = data.replace(
-            mocap_pos=data.mocap_pos.at[:, obstacle_mocap_ids].set(nominal_obstacle_pos)
-        )
+        nominal_mocap_pos = data.mocap_pos.at[:, gate_mocap_ids].set(nominal_gate_pos)
+        nominal_mocap_pos = nominal_mocap_pos.at[:, obstacle_mocap_ids].set(nominal_obstacle_pos)
+        nominal_mocap_quat = data.mocap_quat.at[:, gate_mocap_ids].set(gate_quat)
+        data = leaf_replace(data, mask, mocap_pos=nominal_mocap_pos, mocap_quat=nominal_mocap_quat)
+        
         keys = jax.random.split(key, len(randomization_fns))
         for key, randomize_fn in zip(keys, randomization_fns, strict=True):
             data = randomize_fn(data, mask, key)

--- a/tests/integration/test_envs.py
+++ b/tests/integration/test_envs.py
@@ -2,10 +2,12 @@ from pathlib import Path
 
 import gymnasium
 import jax
+import jax.numpy as jp
 import pytest
 from drone_models import available_models
 
 import lsy_drone_racing  # noqa: F401, environment registrations
+from lsy_drone_racing.envs.drone_race import DroneRaceEnv
 from lsy_drone_racing.utils import load_config
 
 CONFIG_FILES = {
@@ -113,4 +115,104 @@ def test_multi_drone_envs(config_file: str, physics: str, device: str):
     for _ in range(2):
         obs, _, _, _, _ = env.step(env.action_space.sample())
     assert obs["pos"].device == device, f"Expected device {device}, but got {obs['pos'].device}"
+    env.close()
+
+
+@pytest.mark.parametrize("config_file", ["level2.toml", "level3.toml"])
+def test_vector_envs_randomization(config_file: str):
+    """Test track randomization works correctly with vectorized environments."""
+    config = load_config(Path(__file__).parents[2] / "config" / config_file)
+
+    kwargs = {
+        "num_envs": 2,
+        "control_mode": "attitude",
+        "freq": config.env.freq,
+        "sim_config": config.sim,
+        "sensor_range": config.env.sensor_range,
+        "track": config.env.track,
+        "disturbances": config.env.get("disturbances"),
+        "randomizations": config.env.get("randomizations"),
+        "seed": config.env.seed,
+    }
+
+    env: DroneRaceEnv = gymnasium.make_vec("DroneRacing-v0", **kwargs)
+    env.autoreset = True
+
+    def get_obj_mocap(env: DroneRaceEnv) -> jax.Array:
+        gate_mocap_ids = env.data.gate_mj_ids
+        obstacle_mocap_ids = env.data.obstacle_mj_ids
+        gates_mocap_pos = env.sim.mjx_data.mocap_pos[:, gate_mocap_ids].copy()
+        gates_mocap_quat = env.sim.mjx_data.mocap_quat[:, gate_mocap_ids][..., [1, 2, 3, 0]].copy()
+        obstacles_mocap_pos = env.sim.mjx_data.mocap_pos[:, obstacle_mocap_ids].copy()
+        return gates_mocap_pos, gates_mocap_quat, obstacles_mocap_pos
+
+    # Backup nominal track mocap data
+    nominal_gates_pos, nominal_gates_quat, nominal_obstacles_pos = get_obj_mocap(env)
+
+    env.reset()
+
+    # Check if track is randomized
+    gates_pos, gates_quat, obstacles_pos = get_obj_mocap(env)
+    drone_pos = env.sim.data.states.pos[:, 0, :].copy()
+    nominal_drone_pos = env.sim.default_data.states.pos[:, 0, :].copy()
+    assert not jp.allclose(gates_pos, nominal_gates_pos), (
+        "Track should be randomized, but gates_pos remains default."
+    )
+    assert not jp.allclose(gates_quat, nominal_gates_quat), (
+        "Track should be randomized, but gates_quat remains default."
+    )
+    assert not jp.allclose(obstacles_pos, nominal_obstacles_pos), (
+        "Track should be randomized, but obstacles_pos remains default."
+    )
+    assert not jp.allclose(drone_pos, nominal_drone_pos), (
+        "Drone takeoff pos should be randomized, but it remains default."
+    )
+
+    action = jp.tile(jp.array([0.0, 0.0, 0.0, 0.6]), (2, 1, 1))  # ensure drone doesn't crash
+    env.step(action)
+    gates_pos_1, gates_quat_1, obstacles_pos_1 = get_obj_mocap(env)
+
+    # Force reset 2nd world
+    env.data = env.data.replace(marked_for_reset=jp.array([0, 1]))
+
+    # Step once to trigger autoreset
+    env.step(action)
+    gates_pos_2, gates_quat_2, obstacles_pos_2 = get_obj_mocap(env)
+    drone_pos = env.sim.data.states.pos[:, 0, :].copy()
+    nominal_drone_pos = env.sim.default_data.states.pos[:, 0, :].copy()
+
+    # Check if track is re-randomized for the 2nd world but not for the 1st world
+    assert jp.allclose(gates_pos_2[0], gates_pos_1[0]), (
+        "World 0 should not be reset, but gates_pos is now changed."
+    )
+    assert jp.allclose(gates_quat_2[0], gates_quat_1[0]), (
+        "World 0 should not be reset, but gates_quat is now changed."
+    )
+    assert jp.allclose(obstacles_pos_2[0], obstacles_pos_1[0]), (
+        "World 0 should not be reset, but obstacles_pos is now changed."
+    )
+
+    assert not jp.allclose(gates_pos_2[1], nominal_gates_pos[1]), (
+        "World 1 should be randomized, but gates_pos is now default."
+    )
+    assert not jp.allclose(gates_quat_2[1], nominal_gates_quat[1]), (
+        "World 1 should be randomized, but gates_quat is now default."
+    )
+    assert not jp.allclose(obstacles_pos_2[1], nominal_obstacles_pos[1]), (
+        "World 1 should be randomized, but obstacles_pos is now default."
+    )
+    assert not jp.allclose(drone_pos[1], nominal_drone_pos[1]), (
+        "World 1 drone takeoff pos should be randomized, but it remains default."
+    )
+
+    assert not jp.allclose(gates_pos_2[1], gates_pos_1[1]), (
+        "World 1 should be re-randomized, but gates_pos remain unchanged."
+    )
+    assert not jp.allclose(gates_quat_2[1], gates_quat_1[1]), (
+        "World 1 should be re-randomized, but gates_quat remain unchanged."
+    )
+    assert not jp.allclose(obstacles_pos_2[1], obstacles_pos_1[1]), (
+        "World 1 should be re-randomized, but obstacles_pos remain unchanged."
+    )
+
     env.close()

--- a/tests/integration/test_envs.py
+++ b/tests/integration/test_envs.py
@@ -123,27 +123,22 @@ def test_vector_envs_randomization(config_file: str):
     """Test track randomization works correctly with vectorized environments."""
     config = load_config(Path(__file__).parents[2] / "config" / config_file)
 
-    kwargs = {
-        "num_envs": 2,
-        "control_mode": "attitude",
-        "freq": config.env.freq,
-        "sim_config": config.sim,
-        "sensor_range": config.env.sensor_range,
-        "track": config.env.track,
-        "disturbances": config.env.get("disturbances"),
-        "randomizations": config.env.get("randomizations"),
-        "seed": config.env.seed,
-    }
-
-    env: DroneRaceEnv = gymnasium.make_vec("DroneRacing-v0", **kwargs)
-    env.autoreset = True
+    env: DroneRaceEnv = gymnasium.make_vec(
+        "DroneRacing-v0",
+        num_envs=2,
+        control_mode="attitude",
+        freq=config.env.freq,
+        sim_config=config.sim,
+        track=config.env.track,
+        randomizations=config.env.get("randomizations"),
+    )
 
     def get_obj_mocap(env: DroneRaceEnv) -> jax.Array:
         gate_mocap_ids = env.data.gate_mj_ids
         obstacle_mocap_ids = env.data.obstacle_mj_ids
-        gates_mocap_pos = env.sim.mjx_data.mocap_pos[:, gate_mocap_ids].copy()
-        gates_mocap_quat = env.sim.mjx_data.mocap_quat[:, gate_mocap_ids][..., [1, 2, 3, 0]].copy()
-        obstacles_mocap_pos = env.sim.mjx_data.mocap_pos[:, obstacle_mocap_ids].copy()
+        gates_mocap_pos = env.sim.mjx_data.mocap_pos[:, gate_mocap_ids]
+        gates_mocap_quat = env.sim.mjx_data.mocap_quat[:, gate_mocap_ids][..., [1, 2, 3, 0]]
+        obstacles_mocap_pos = env.sim.mjx_data.mocap_pos[:, obstacle_mocap_ids]
         return gates_mocap_pos, gates_mocap_quat, obstacles_mocap_pos
 
     # Backup nominal track mocap data
@@ -153,66 +148,42 @@ def test_vector_envs_randomization(config_file: str):
 
     # Check if track is randomized
     gates_pos, gates_quat, obstacles_pos = get_obj_mocap(env)
-    drone_pos = env.sim.data.states.pos[:, 0, :].copy()
-    nominal_drone_pos = env.sim.default_data.states.pos[:, 0, :].copy()
-    assert not jp.allclose(gates_pos, nominal_gates_pos), (
-        "Track should be randomized, but gates_pos remains default."
-    )
-    assert not jp.allclose(gates_quat, nominal_gates_quat), (
-        "Track should be randomized, but gates_quat remains default."
-    )
-    assert not jp.allclose(obstacles_pos, nominal_obstacles_pos), (
-        "Track should be randomized, but obstacles_pos remains default."
-    )
-    assert not jp.allclose(drone_pos, nominal_drone_pos), (
-        "Drone takeoff pos should be randomized, but it remains default."
-    )
+    drone_pos = env.sim.data.states.pos[:, 0, :]
+    nominal_drone_pos = env.sim.default_data.states.pos[:, 0, :]
+    assert not jp.allclose(gates_pos, nominal_gates_pos), "gates_pos not randomized"
+    assert not jp.allclose(gates_quat, nominal_gates_quat), "gates_quat not randomized"
+    assert not jp.allclose(obstacles_pos, nominal_obstacles_pos), "obstacles_pos not randomized"
+    assert not jp.allclose(drone_pos, nominal_drone_pos), "drone_pos not randomized"
 
     action = jp.tile(jp.array([0.0, 0.0, 0.0, 0.6]), (2, 1, 1))  # ensure drone doesn't crash
     env.step(action)
     gates_pos_1, gates_quat_1, obstacles_pos_1 = get_obj_mocap(env)
 
     # Force reset 2nd world
-    env.data = env.data.replace(marked_for_reset=jp.array([0, 1]))
+    env.data = env.data.replace(marked_for_reset=env.data.marked_for_reset.at[1].set(True))
 
     # Step once to trigger autoreset
     env.step(action)
     gates_pos_2, gates_quat_2, obstacles_pos_2 = get_obj_mocap(env)
-    drone_pos = env.sim.data.states.pos[:, 0, :].copy()
-    nominal_drone_pos = env.sim.default_data.states.pos[:, 0, :].copy()
+    drone_pos = env.sim.data.states.pos[:, 0, :]
+    nominal_drone_pos = env.sim.default_data.states.pos[:, 0, :]
 
     # Check if track is re-randomized for the 2nd world but not for the 1st world
-    assert jp.allclose(gates_pos_2[0], gates_pos_1[0]), (
-        "World 0 should not be reset, but gates_pos is now changed."
-    )
-    assert jp.allclose(gates_quat_2[0], gates_quat_1[0]), (
-        "World 0 should not be reset, but gates_quat is now changed."
-    )
-    assert jp.allclose(obstacles_pos_2[0], obstacles_pos_1[0]), (
-        "World 0 should not be reset, but obstacles_pos is now changed."
-    )
+    assert jp.allclose(gates_pos_2[0], gates_pos_1[0]), "unexpected gates_pos[0] change"
+    assert jp.allclose(gates_quat_2[0], gates_quat_1[0]), "unexpected gates_quat[0] change"
+    assert jp.allclose(obstacles_pos_2[0], obstacles_pos_1[0]), "unexpected obstacles_pos[0] change"
 
-    assert not jp.allclose(gates_pos_2[1], nominal_gates_pos[1]), (
-        "World 1 should be randomized, but gates_pos is now default."
-    )
-    assert not jp.allclose(gates_quat_2[1], nominal_gates_quat[1]), (
-        "World 1 should be randomized, but gates_quat is now default."
-    )
+    assert not jp.allclose(gates_pos_2[1], nominal_gates_pos[1]), "gates_pos[1] not randomized"
+    assert not jp.allclose(gates_quat_2[1], nominal_gates_quat[1]), "gates_quat[1] not randomized"
     assert not jp.allclose(obstacles_pos_2[1], nominal_obstacles_pos[1]), (
-        "World 1 should be randomized, but obstacles_pos is now default."
+        "obstacles_pos[1] not randomized"
     )
-    assert not jp.allclose(drone_pos[1], nominal_drone_pos[1]), (
-        "World 1 drone takeoff pos should be randomized, but it remains default."
-    )
+    assert not jp.allclose(drone_pos[1], nominal_drone_pos[1]), "drone_pos[1] not randomized"
 
-    assert not jp.allclose(gates_pos_2[1], gates_pos_1[1]), (
-        "World 1 should be re-randomized, but gates_pos remain unchanged."
-    )
-    assert not jp.allclose(gates_quat_2[1], gates_quat_1[1]), (
-        "World 1 should be re-randomized, but gates_quat remain unchanged."
-    )
+    assert not jp.allclose(gates_pos_2[1], gates_pos_1[1]), "gates_pos[1] not re-randomized"
+    assert not jp.allclose(gates_quat_2[1], gates_quat_1[1]), "gates_quat[1] not re-randomized"
     assert not jp.allclose(obstacles_pos_2[1], obstacles_pos_1[1]), (
-        "World 1 should be re-randomized, but obstacles_pos remain unchanged."
+        "obstacles_pos[1] not re-randomized"
     )
 
     env.close()


### PR DESCRIPTION
1. In update_sim_data, write new takeoff pos to default_data, instead of directly override data.state.pos

2. call sim.reset() after update_sim_data(), to add additional domain randomization. 
- Since randomization on drone pos is by default built in sim.reset_pipeline, I think it's better to keep this structure: randomize drone pos by calling sim.reset()
- Neither the complete randomization nor the small perturbation are based on reset SimData, so it's fine to reset SimData afterwards.
- Also compatible with level 2, where the default position stays the same, then the domain randomization will also take effect.
- At last, we update EnvData, where we need the current drone pos to update target gate and so on.

3. Explicitly write mask as an argument in update_sim_data(), although it's closure captured, put it in args for better readability.

4. Apply mask when overriding data.state.pos. Otherwise, when any world is marked for reset, all worlds will be reset to the newly generated takeoff pos! 
(Should not have this problem if we only write to default data, but still doesn't make sense to update default data when some worlds are not yet done.)