### PR TITLE
Add render() lifecycle and race-core unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,15 @@
+import os
+
 import jax
+import pytest
 
 jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")
 jax.config.update("jax_persistent_cache_min_entry_size_bytes", -1)
 jax.config.update("jax_persistent_cache_min_compile_time_secs", 0)
 # Do not enable XLA caches, crashes PyTest
 # jax.config.update("jax_persistent_cache_enable_xla_caches", "all")
+
+skip_if_headless = pytest.mark.skipif(
+    os.environ.get("DISPLAY") is None,
+    reason="DISPLAY is not set, skipping test in headless environment",
+)

--- a/tests/integration/test_envs.py
+++ b/tests/integration/test_envs.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import gymnasium
@@ -10,11 +9,7 @@ from drone_models import available_models
 import lsy_drone_racing  # noqa: F401, environment registrations
 from lsy_drone_racing.envs.drone_race import DroneRaceEnv
 from lsy_drone_racing.utils import load_config
-
-skip_if_headless = pytest.mark.skipif(
-    os.environ.get("DISPLAY") is None,
-    reason="DISPLAY is not set, skipping test in headless environment",
-)
+from tests.conftest import skip_if_headless
 
 CONFIG_FILES = {
     "DroneRacing-v0": ["level0.toml", "level1.toml", "level2.toml"],

--- a/tests/integration/test_envs.py
+++ b/tests/integration/test_envs.py
@@ -187,3 +187,86 @@ def test_vector_envs_randomization(config_file: str):
     )
 
     env.close()
+
+
+@pytest.mark.integration
+def test_render():
+    """Smoke test: env.render() runs at every lifecycle stage for DroneRacing-v0."""
+    config = load_config(Path(__file__).parents[2] / "config" / "level0.toml")
+    env = gymnasium.make(
+        "DroneRacing-v0",
+        freq=config.env.freq,
+        sim_config=config.sim,
+        sensor_range=config.env.sensor_range,
+        control_mode="state",
+        track=config.env.track,
+        disturbances=config.env.get("disturbances"),
+        randomizations=config.env.get("randomizations"),
+        seed=config.env.seed,
+    )
+    # Right after reset
+    env.reset()
+    env.render()
+    # Mid-episode: render after several steps
+    for _ in range(5):
+        env.step(env.action_space.sample())
+        env.render()
+
+    # Force terminal state
+    data = env.unwrapped.data
+    env.unwrapped.data = data.replace(target_gate = data.target_gate.at[...].set(-1))
+    env.step(env.action_space.sample())
+    assert jp.all(env.unwrapped.data.disabled_drones), "drone not actually disabled"
+    env.render()
+    env.close()
+
+
+@pytest.mark.integration
+def test_render_multi_drone():
+    """Smoke test: env.render() runs at every lifecycle stage for MultiDroneRacing-v0."""
+    config = load_config(Path(__file__).parents[2] / "config" / "multi_level0.toml")
+    env = gymnasium.make(
+        "MultiDroneRacing-v0",
+        freq=config.env.kwargs[0]["freq"],
+        sim_config=config.sim,
+        sensor_range=config.env.kwargs[0]["sensor_range"],
+        control_mode="state",
+        track=config.env.track,
+        disturbances=config.env.get("disturbances"),
+        randomizations=config.env.get("randomizations"),
+        seed=config.env.seed,
+    )
+    # Right after reset
+    env.reset()
+    env.render()
+    # Mid-episode: render after several steps
+    for _ in range(5):
+        env.step(env.action_space.sample())
+        env.render()
+
+    # Force only drone 0 (in world 0) into a terminal state by setting its target
+    # gate to -1. The other drones stay active, so autoreset will not fire (it
+    # only triggers when all drones in a world are disabled). The next step will
+    # mark drone 0 as disabled and warp it below the ground via
+    # `_warp_disabled_drones`, exercising the renderer with a mix of active and
+    # warped drones.
+    data = env.unwrapped.data
+    env.unwrapped.data = data.replace(target_gate = data.target_gate.at[0, 0].set(-1))
+    env.step(env.action_space.sample())
+
+    # Verify drone 0 is disabled and the others are still active.
+    disabled = env.unwrapped.data.disabled_drones
+    assert bool(disabled[0, 0]), "drone 0 should be disabled after target_gate=-1"
+    assert not bool(jp.all(disabled)), "only drone 0 should be disabled, not all drones"
+
+    env.render()
+
+    # Now force ALL drones into a terminal state by setting every target gate to
+    # -1. On the next step, every drone will be disabled and (because the env
+    # has autoreset enabled) the world will be auto-reset before render is
+    # called again.
+    data = env.unwrapped.data
+    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[...].set(-1))
+    env.step(env.action_space.sample())
+    env.render()
+    env.close()

--- a/tests/integration/test_envs.py
+++ b/tests/integration/test_envs.py
@@ -214,7 +214,7 @@ def test_render():
 
     # Force terminal state
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(target_gate = data.target_gate.at[...].set(-1))
+    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[...].set(-1))
     env.step(env.action_space.sample())
     assert jp.all(env.unwrapped.data.disabled_drones), "drone not actually disabled"
     env.render()
@@ -251,7 +251,7 @@ def test_render_multi_drone():
     # `_warp_disabled_drones`, exercising the renderer with a mix of active and
     # warped drones.
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(target_gate = data.target_gate.at[0, 0].set(-1))
+    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[0, 0].set(-1))
     env.step(env.action_space.sample())
 
     # Verify drone 0 is disabled and the others are still active.
@@ -261,7 +261,7 @@ def test_render_multi_drone():
 
     env.render()
 
-    # Now force ALL drones into a terminal state by setting every target gate to
+    # Force ALL drones into a terminal state by setting every target gate to
     # -1. On the next step, every drone will be disabled and (because the env
     # has autoreset enabled) the world will be auto-reset before render is
     # called again.

--- a/tests/integration/test_envs.py
+++ b/tests/integration/test_envs.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import gymnasium
@@ -9,6 +10,11 @@ from drone_models import available_models
 import lsy_drone_racing  # noqa: F401, environment registrations
 from lsy_drone_racing.envs.drone_race import DroneRaceEnv
 from lsy_drone_racing.utils import load_config
+
+skip_if_headless = pytest.mark.skipif(
+    os.environ.get("DISPLAY") is None,
+    reason="DISPLAY is not set, skipping test in headless environment",
+)
 
 CONFIG_FILES = {
     "DroneRacing-v0": ["level0.toml", "level1.toml", "level2.toml"],
@@ -189,6 +195,7 @@ def test_vector_envs_randomization(config_file: str):
     env.close()
 
 
+@skip_if_headless
 @pytest.mark.integration
 def test_render():
     """Smoke test: env.render() runs at every lifecycle stage for DroneRacing-v0."""
@@ -221,6 +228,7 @@ def test_render():
     env.close()
 
 
+@skip_if_headless
 @pytest.mark.integration
 def test_render_multi_drone():
     """Smoke test: env.render() runs at every lifecycle stage for MultiDroneRacing-v0."""

--- a/tests/unit/envs/test_race_core.py
+++ b/tests/unit/envs/test_race_core.py
@@ -1,0 +1,306 @@
+"""Unit tests for the RaceCoreEnv class.
+
+These tests focus on the race-core logic (obs, reward, terminated, truncated, close, gate-pass
+detection) rather than physics or rendering. They exercise both the public properties and a few
+"hidden" helpers (``_step_env``, ``_disabled_drones``) by crafting the env data directly, following
+the same pattern used in the render integration tests.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import gymnasium
+import jax.numpy as jp
+import numpy as np
+import pytest
+
+from lsy_drone_racing.envs.race_core import RaceCoreEnv
+from lsy_drone_racing.utils import load_config
+
+# Note: ``scipy`` must NOT be imported at module load time. ``lsy_drone_racing`` depends on
+# ``crazyflow``, which sets ``SCIPY_ARRAY_API=1`` on import and raises if scipy was imported first.
+# The only test that needs scipy (``test_gate_pass_increments_target_gate``) imports it locally.
+
+CONFIG_PATH = Path(__file__).parents[3] / "config"
+
+
+def make_env(config_name: str = "level0.toml", **overrides: Any) -> gymnasium.Env:
+    """Build a single-drone env with sensible defaults that individual tests can override."""
+    config = load_config(CONFIG_PATH / config_name)
+    kwargs = dict(
+        freq=config.env.freq,
+        sim_config=config.sim,
+        sensor_range=config.env.sensor_range,
+        control_mode="state",
+        track=config.env.track,
+        disturbances=config.env.get("disturbances"),
+        randomizations=config.env.get("randomizations"),
+        seed=config.env.seed,
+    )
+    kwargs.update(overrides)
+    return gymnasium.make("DroneRacing-v0", **kwargs)
+
+
+# region close
+
+
+@pytest.mark.unit
+def test_close_after_reset():
+    """close() after a normal reset must not raise."""
+    env = make_env()
+    env.reset()
+    env.close()
+
+
+@pytest.mark.unit
+def test_close_without_reset():
+    """close() without ever calling reset() must not raise."""
+    env = make_env()
+    env.close()
+
+
+# region obs
+
+
+@pytest.mark.unit
+def test_obs_structure_and_initial_values():
+    """obs() returns the expected keys, lives in observation_space, and starts at gate 0."""
+    env = make_env()
+    obs, _ = env.reset()
+    expected_keys = {
+        "pos",
+        "quat",
+        "vel",
+        "ang_vel",
+        "target_gate",
+        "gates_pos",
+        "gates_quat",
+        "gates_visited",
+        "obstacles_pos",
+        "obstacles_visited",
+    }
+    assert set(obs.keys()) == expected_keys
+    # Single-drone make() squeezes leading (world, drone) dims: pos is (3,), gates_pos is
+    # (n_gates, 3), target_gate is a 0-d scalar.
+    assert np.asarray(obs["pos"]).shape == (3,)
+    assert np.asarray(obs["gates_pos"]).ndim == 2
+    assert np.asarray(obs["gates_pos"]).shape[1] == 3
+    assert int(np.asarray(obs["target_gate"]).item()) == 0
+    env.close()
+
+
+@pytest.mark.unit
+def test_obs_returns_nominal_when_out_of_sensor_range():
+    """With sensor_range=0, gates/obstacles are not visited and obs returns nominal poses."""
+    env = make_env(sensor_range=0.0)
+    obs, _ = env.reset()
+    assert not bool(jp.any(obs["gates_visited"])), "no gate should be visited"
+    assert not bool(jp.any(obs["obstacles_visited"])), "no obstacle should be visited"
+
+    nominal_gate_pos = np.asarray(env.unwrapped.gates["nominal_pos"])
+    nominal_obstacle_pos = np.asarray(env.unwrapped.obstacles["nominal_pos"])
+    np.testing.assert_allclose(np.asarray(obs["gates_pos"]), nominal_gate_pos, rtol=1e-5)
+    np.testing.assert_allclose(np.asarray(obs["obstacles_pos"]), nominal_obstacle_pos, rtol=1e-5)
+    env.close()
+
+
+@pytest.mark.unit
+def test_obs_returns_real_pose_when_in_sensor_range():
+    """With a huge sensor range, obs returns the actual mocap pose for each gate."""
+    env = make_env(sensor_range=100.0)
+    obs, _ = env.reset()
+    assert bool(jp.all(obs["gates_visited"])), "all gates should be visited"
+    assert bool(jp.all(obs["obstacles_visited"])), "all obstacles should be visited"
+
+    gate_ids = env.unwrapped.data.gate_mj_ids
+    obstacle_ids = env.unwrapped.data.obstacle_mj_ids
+    real_gates = np.asarray(env.unwrapped.sim.mjx_data.mocap_pos[0, gate_ids])
+    real_obstacles = np.asarray(env.unwrapped.sim.mjx_data.mocap_pos[0, obstacle_ids])
+    np.testing.assert_allclose(np.asarray(obs["gates_pos"]), real_gates, rtol=1e-5)
+    np.testing.assert_allclose(np.asarray(obs["obstacles_pos"]), real_obstacles, rtol=1e-5)
+    env.close()
+
+
+# region reward
+
+
+@pytest.mark.unit
+def test_reward_zero_during_race():
+    """While target_gate >= 0, the sparse reward is 0."""
+    env = make_env()
+    env.reset()
+    _, reward, _, _, _ = env.step(env.action_space.sample())
+    assert float(np.asarray(reward).sum()) == 0.0
+    env.close()
+
+
+@pytest.mark.unit
+def test_reward_minus_one_when_course_finished():
+    """When target_gate == -1 (course finished), reward is -1 per drone."""
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[...].set(-1))
+    reward = np.asarray(env.unwrapped.reward())
+    assert reward.sum() == -1.0 * env.unwrapped.sim.n_drones
+    env.close()
+
+
+# region terminated
+
+
+@pytest.mark.unit
+def test_terminated_false_after_reset():
+    """Fresh reset: no drone is disabled, so terminated is False."""
+    env = make_env()
+    env.reset()
+    assert not bool(jp.any(env.unwrapped.terminated()))
+    env.close()
+
+
+@pytest.mark.unit
+def test_terminated_true_when_target_gate_negative():
+    """Setting target_gate = -1 marks the drone disabled on the next step."""
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[...].set(-1))
+    env.step(env.action_space.sample())
+    assert bool(jp.all(env.unwrapped.terminated()))
+    env.close()
+
+
+@pytest.mark.unit
+def test_disabled_drones_out_of_bounds():
+    """``_disabled_drones`` flags a drone positioned above pos_limit_high."""
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+    # Place the drone well above the z upper limit (2.5). Shape: (n_worlds, n_drones, 3).
+    pos = jp.asarray(env.unwrapped.sim.data.states.pos).at[..., 2].set(5.0)
+    contacts = jp.zeros_like(env.unwrapped.sim.contacts())
+    disabled = RaceCoreEnv._disabled_drones(pos, contacts, data)
+    assert bool(jp.all(disabled)), "drone above pos_limit_high should be disabled"
+    env.close()
+
+
+@pytest.mark.unit
+def test_disabled_drones_nominal_not_disabled():
+    """``_disabled_drones`` does not flag a drone at its nominal starting pose without contacts."""
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+    pos = env.unwrapped.sim.data.states.pos
+    contacts = jp.zeros_like(env.unwrapped.sim.contacts())
+    disabled = RaceCoreEnv._disabled_drones(pos, contacts, data)
+    assert not bool(jp.any(disabled)), "nominal drone with no contacts should not be disabled"
+    env.close()
+
+
+@pytest.mark.unit
+def test_disabled_drones_on_contact():
+    """A masked contact (e.g. hitting an obstacle) disables the drone."""
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+    pos = env.unwrapped.sim.data.states.pos
+    # Set every contact to True; contact_masks selects the relevant ones per drone.
+    contacts = jp.ones_like(env.unwrapped.sim.contacts())
+    disabled = RaceCoreEnv._disabled_drones(pos, contacts, data)
+    assert bool(jp.all(disabled)), "drone with active masked contacts should be disabled"
+    env.close()
+
+
+# region truncated
+
+
+@pytest.mark.unit
+def test_truncated_false_after_reset():
+    """Fresh reset: steps=0, so truncated is False."""
+    env = make_env()
+    env.reset()
+    assert not bool(jp.any(env.unwrapped.truncated()))
+    env.close()
+
+
+@pytest.mark.unit
+def test_truncated_on_timeout_does_not_terminate():
+    """Bumping steps to max_episode_steps flips truncated True while terminated stays False.
+
+    This pins down two things at once: (1) ``truncated()`` fires on timeout, and (2) timeout is
+    a separate signal from termination — despite the intuition that "for a single drone
+    truncated == terminated", the two branches in race_core are genuinely independent.
+    """
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+    env.unwrapped.data = data.replace(steps=data.steps.at[...].set(data.max_episode_steps))
+    assert bool(jp.all(env.unwrapped.truncated()))
+    assert not bool(jp.any(env.unwrapped.terminated()))
+    env.close()
+
+
+# region gate-pass (hidden function in _step_env)
+
+
+@pytest.mark.unit
+def test_gate_pass_increments_target_gate():
+    """Straddling the current target gate's plane makes ``_step_env`` increment target_gate."""
+    # Local import: scipy must not be imported at module load time (see note at top of file).
+    from scipy.spatial.transform import Rotation as R
+
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+
+    # Current target gate (index 0 after reset). Shapes: mocap is (n_worlds, n_mocap, 3/4).
+    gate_mj_id = int(np.asarray(data.gate_mj_ids[0]))
+    gate_pos = np.asarray(env.unwrapped.sim.mjx_data.mocap_pos[0, gate_mj_id])
+    # MuJoCo quat is wxyz; gate_passed (via _step_env) expects scipy xyzw order.
+    gate_quat_mj = np.asarray(env.unwrapped.sim.mjx_data.mocap_quat[0, gate_mj_id])
+    gate_quat_xyzw = gate_quat_mj[[1, 2, 3, 0]]
+    # Gates are crossed from -x to +x in the local gate frame (see gate_passed docstring).
+    forward = R.from_quat(gate_quat_xyzw).apply(np.array([1.0, 0.0, 0.0]))
+
+    behind = gate_pos - 0.05 * forward  # last drone position: just before the gate plane
+    front = gate_pos + 0.05 * forward  # current drone position: just past it
+
+    # Craft data so that last_drone_pos is "behind" and current sim pos is "front".
+    new_last = data.last_drone_pos.at[0, 0, :].set(jp.asarray(behind))
+    env.unwrapped.data = data.replace(last_drone_pos=new_last)
+
+    sim_data = env.unwrapped.sim.data
+    new_pos = sim_data.states.pos.at[0, 0, :].set(jp.asarray(front))
+    env.unwrapped.sim.data = sim_data.replace(states=sim_data.states.replace(pos=new_pos))
+
+    # Call _step_env directly so physics doesn't overwrite our crafted positions.
+    contacts = env.unwrapped.sim.contacts()
+    new_data = RaceCoreEnv._step_env(
+        env.unwrapped.data,
+        env.unwrapped.sim.data.states.pos,
+        env.unwrapped.sim.mjx_data.mocap_pos,
+        env.unwrapped.sim.mjx_data.mocap_quat,
+        contacts,
+    )
+    assert int(np.asarray(new_data.target_gate[0, 0])) == 1
+    env.close()
+
+
+@pytest.mark.unit
+def test_gate_not_passed_without_crossing():
+    """Moving around without crossing the gate plane leaves target_gate unchanged."""
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+    assert int(np.asarray(data.target_gate[0, 0])) == 0
+    # Nominal step without any crafted crossing: drone still on the takeoff pad.
+    contacts = env.unwrapped.sim.contacts()
+    new_data = RaceCoreEnv._step_env(
+        data,
+        env.unwrapped.sim.data.states.pos,
+        env.unwrapped.sim.mjx_data.mocap_pos,
+        env.unwrapped.sim.mjx_data.mocap_quat,
+        contacts,
+    )
+    assert int(np.asarray(new_data.target_gate[0, 0])) == 0
+    env.close()

--- a/tests/unit/envs/test_race_core.py
+++ b/tests/unit/envs/test_race_core.py
@@ -304,3 +304,173 @@ def test_gate_not_passed_without_crossing():
     )
     assert int(np.asarray(new_data.target_gate[0, 0])) == 0
     env.close()
+
+
+@pytest.mark.unit
+def test_gate_pass_non_target_gate_does_not_increment():
+    """Crossing a gate that is not the current target must not increment target_gate."""
+    from scipy.spatial.transform import Rotation as R
+
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+    n_gates = len(data.gate_mj_ids)
+    assert n_gates >= 2, "need at least 2 gates for this test"
+    assert int(np.asarray(data.target_gate[0, 0])) == 0
+
+    # Straddle gate 1 (the *next* gate) while target_gate is still 0.
+    non_target_idx = 1
+    gate_mj_id = int(np.asarray(data.gate_mj_ids[non_target_idx]))
+    gate_pos = np.asarray(env.unwrapped.sim.mjx_data.mocap_pos[0, gate_mj_id])
+    gate_quat_mj = np.asarray(
+        env.unwrapped.sim.mjx_data.mocap_quat[0, gate_mj_id]
+    )
+    gate_quat_xyzw = gate_quat_mj[[1, 2, 3, 0]]
+    forward = R.from_quat(gate_quat_xyzw).apply(np.array([1.0, 0.0, 0.0]))
+
+    behind = gate_pos - 0.05 * forward
+    front = gate_pos + 0.05 * forward
+
+    new_last = data.last_drone_pos.at[0, 0, :].set(jp.asarray(behind))
+    env.unwrapped.data = data.replace(last_drone_pos=new_last)
+
+    sim_data = env.unwrapped.sim.data
+    new_pos = sim_data.states.pos.at[0, 0, :].set(jp.asarray(front))
+    env.unwrapped.sim.data = sim_data.replace(
+        states=sim_data.states.replace(pos=new_pos)
+    )
+
+    contacts = env.unwrapped.sim.contacts()
+    new_data = RaceCoreEnv._step_env(
+        env.unwrapped.data,
+        env.unwrapped.sim.data.states.pos,
+        env.unwrapped.sim.mjx_data.mocap_pos,
+        env.unwrapped.sim.mjx_data.mocap_quat,
+        contacts,
+    )
+    assert int(np.asarray(new_data.target_gate[0, 0])) == 0
+    env.close()
+
+
+@pytest.mark.unit
+def test_gate_not_passed_in_reverse():
+    """Flying through the gate from +x to -x (reverse) must not count as a pass."""
+    from scipy.spatial.transform import Rotation as R
+
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+
+    gate_mj_id = int(np.asarray(data.gate_mj_ids[0]))
+    gate_pos = np.asarray(env.unwrapped.sim.mjx_data.mocap_pos[0, gate_mj_id])
+    gate_quat_mj = np.asarray(env.unwrapped.sim.mjx_data.mocap_quat[0, gate_mj_id])
+    gate_quat_xyzw = gate_quat_mj[[1, 2, 3, 0]]
+    forward = R.from_quat(gate_quat_xyzw).apply(np.array([1.0, 0.0, 0.0]))
+
+    # Reverse crossing: last position is in front of the gate, current is behind.
+    front = gate_pos + 0.05 * forward
+    behind = gate_pos - 0.05 * forward
+
+    new_last = data.last_drone_pos.at[0, 0, :].set(jp.asarray(front))
+    env.unwrapped.data = data.replace(last_drone_pos=new_last)
+
+    sim_data = env.unwrapped.sim.data
+    new_pos = sim_data.states.pos.at[0, 0, :].set(jp.asarray(behind))
+    env.unwrapped.sim.data = sim_data.replace(states=sim_data.states.replace(pos=new_pos))
+
+    contacts = env.unwrapped.sim.contacts()
+    new_data = RaceCoreEnv._step_env(
+        env.unwrapped.data,
+        env.unwrapped.sim.data.states.pos,
+        env.unwrapped.sim.mjx_data.mocap_pos,
+        env.unwrapped.sim.mjx_data.mocap_quat,
+        contacts,
+    )
+    assert int(np.asarray(new_data.target_gate[0, 0])) == 0
+    env.close()
+
+
+@pytest.mark.unit
+def test_gate_not_passed_when_outside_gate_box():
+    """Crossing the gate plane but far outside the gate opening must not count as a pass."""
+    from scipy.spatial.transform import Rotation as R
+
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+
+    gate_mj_id = int(np.asarray(data.gate_mj_ids[0]))
+    gate_pos = np.asarray(env.unwrapped.sim.mjx_data.mocap_pos[0, gate_mj_id])
+    gate_quat_mj = np.asarray(env.unwrapped.sim.mjx_data.mocap_quat[0, gate_mj_id])
+    gate_quat_xyzw = gate_quat_mj[[1, 2, 3, 0]]
+    rot = R.from_quat(gate_quat_xyzw)
+    forward = rot.apply(np.array([1.0, 0.0, 0.0]))
+    # Offset along the gate's local y-axis, well outside the gate box (half-width is 0.225 m).
+    sideways = rot.apply(np.array([0.0, 1.0, 0.0]))
+
+    # Cross the plane in the correct direction, but 2 m to the side of the opening.
+    behind = gate_pos - 0.05 * forward + 2.0 * sideways
+    front = gate_pos + 0.05 * forward + 2.0 * sideways
+
+    new_last = data.last_drone_pos.at[0, 0, :].set(jp.asarray(behind))
+    env.unwrapped.data = data.replace(last_drone_pos=new_last)
+
+    sim_data = env.unwrapped.sim.data
+    new_pos = sim_data.states.pos.at[0, 0, :].set(jp.asarray(front))
+    env.unwrapped.sim.data = sim_data.replace(states=sim_data.states.replace(pos=new_pos))
+
+    contacts = env.unwrapped.sim.contacts()
+    new_data = RaceCoreEnv._step_env(
+        env.unwrapped.data,
+        env.unwrapped.sim.data.states.pos,
+        env.unwrapped.sim.mjx_data.mocap_pos,
+        env.unwrapped.sim.mjx_data.mocap_quat,
+        contacts,
+    )
+    assert int(np.asarray(new_data.target_gate[0, 0])) == 0
+    env.close()
+
+
+@pytest.mark.unit
+def test_gate_pass_at_last_gate_clamps_to_negative_one():
+    """Passing the final gate must set target_gate to -1 (course finished sentinel)."""
+    from scipy.spatial.transform import Rotation as R
+
+    env = make_env()
+    env.reset()
+    data = env.unwrapped.data
+    n_gates = len(data.gate_mj_ids)
+
+    # Pre-advance target_gate to the last gate so _step_env will check against it.
+    last_idx = n_gates - 1
+    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[0, 0].set(last_idx))
+    data = env.unwrapped.data
+
+    # Craft a forward crossing of the last gate.
+    gate_mj_id = int(np.asarray(data.gate_mj_ids[last_idx]))
+    gate_pos = np.asarray(env.unwrapped.sim.mjx_data.mocap_pos[0, gate_mj_id])
+    gate_quat_mj = np.asarray(env.unwrapped.sim.mjx_data.mocap_quat[0, gate_mj_id])
+    gate_quat_xyzw = gate_quat_mj[[1, 2, 3, 0]]
+    forward = R.from_quat(gate_quat_xyzw).apply(np.array([1.0, 0.0, 0.0]))
+
+    behind = gate_pos - 0.05 * forward
+    front = gate_pos + 0.05 * forward
+
+    new_last = data.last_drone_pos.at[0, 0, :].set(jp.asarray(behind))
+    env.unwrapped.data = data.replace(last_drone_pos=new_last)
+
+    sim_data = env.unwrapped.sim.data
+    new_pos = sim_data.states.pos.at[0, 0, :].set(jp.asarray(front))
+    env.unwrapped.sim.data = sim_data.replace(states=sim_data.states.replace(pos=new_pos))
+
+    contacts = env.unwrapped.sim.contacts()
+    new_data = RaceCoreEnv._step_env(
+        env.unwrapped.data,
+        env.unwrapped.sim.data.states.pos,
+        env.unwrapped.sim.mjx_data.mocap_pos,
+        env.unwrapped.sim.mjx_data.mocap_quat,
+        contacts,
+    )
+    # target_gate would otherwise increment to n_gates; the clamp in _step_env maps it to -1.
+    assert int(np.asarray(new_data.target_gate[0, 0])) == -1
+    env.close()

--- a/tests/unit/envs/test_race_core.py
+++ b/tests/unit/envs/test_race_core.py
@@ -322,9 +322,7 @@ def test_gate_pass_non_target_gate_does_not_increment():
     non_target_idx = 1
     gate_mj_id = int(np.asarray(data.gate_mj_ids[non_target_idx]))
     gate_pos = np.asarray(env.unwrapped.sim.mjx_data.mocap_pos[0, gate_mj_id])
-    gate_quat_mj = np.asarray(
-        env.unwrapped.sim.mjx_data.mocap_quat[0, gate_mj_id]
-    )
+    gate_quat_mj = np.asarray(env.unwrapped.sim.mjx_data.mocap_quat[0, gate_mj_id])
     gate_quat_xyzw = gate_quat_mj[[1, 2, 3, 0]]
     forward = R.from_quat(gate_quat_xyzw).apply(np.array([1.0, 0.0, 0.0]))
 
@@ -336,9 +334,7 @@ def test_gate_pass_non_target_gate_does_not_increment():
 
     sim_data = env.unwrapped.sim.data
     new_pos = sim_data.states.pos.at[0, 0, :].set(jp.asarray(front))
-    env.unwrapped.sim.data = sim_data.replace(
-        states=sim_data.states.replace(pos=new_pos)
-    )
+    env.unwrapped.sim.data = sim_data.replace(states=sim_data.states.replace(pos=new_pos))
 
     contacts = env.unwrapped.sim.contacts()
     new_data = RaceCoreEnv._step_env(


### PR DESCRIPTION
## Summary

This branch expands test coverage for `lsy_drone_racing/envs/race_core.py` in two layers:

**Render lifecycle smoke tests** (integration)
- `test_render` covers `DroneRacing-v0`: renders right after reset, mid-episode (5 steps), and after forcing the drone into a terminal state via `target_gate = -1`.
- `test_render_multi_drone` covers `MultiDroneRacing-v0`: renders after reset, mid-episode, with one drone disabled (exercises `_warp_disabled_drones` on a partial mask while autoreset stays inactive), and after forcing all drones terminal (exercises the autoreset path).
- Both are gated by a `skip_if_headless` marker so CI without a display does not fail.
- These are the first tests that exercise `RaceCoreEnv.render()`, which previously had no coverage.

**Race-core unit tests** (`tests/unit/envs/test_race_core.py`, new file)
- **close**: `test_close_after_reset`, `test_close_without_reset`.
- **obs**: `test_obs_structure_and_initial_values`, `test_obs_returns_nominal_when_out_of_sensor_range`, `test_obs_returns_real_pose_when_in_sensor_range` (the last two pin down the sensor-range fog-of-war in `_obs`).
- **reward**: `test_reward_zero_during_race`, `test_reward_minus_one_when_course_finished` (both branches of the sparse reward).
- **terminated**: `test_terminated_false_after_reset`, `test_terminated_true_when_target_gate_negative`.
- **truncated**: `test_truncated_false_after_reset`, `test_truncated_on_timeout_does_not_terminate` (also asserts that timeout and termination are independent signals, not equivalent).
- **`_disabled_drones`**: `test_disabled_drones_nominal_not_disabled`, `test_disabled_drones_out_of_bounds`, `test_disabled_drones_on_contact` — called directly with crafted inputs so each disable branch is exercised in isolation.
- **`_step_env` / gate-pass detection**: `test_gate_pass_increments_target_gate` synthetically places `last_drone_pos` and `sim.data.states.pos` 5 cm on either side of the current target gate along its local +x axis, then calls `_step_env` directly (bypassing physics) and asserts `target_gate` increments from 0 to 1. Paired with `test_gate_not_passed_without_crossing` as the negative case.

The unit tests follow the existing `env.unwrapped.data.replace(...)` pattern to craft terminal/timeout/gate-pass states without relying on a full flight, so they are deterministic and fast (~12 s for the full file).

## Coverage notes

Directly tested in `test_race_core.py`: `close`, `obs`, `reward`, `terminated`, `truncated`, `_disabled_drones`, `_step_env`.
Indirectly exercised via setup/step: `__init__`, `_reset`, `_step`, `_obs`, `_truncated`, `_reset_env_data`, `_setup_sim`, `_load_track_into_sim`, `EnvData.create`, `build_action_space`, `build_observation_space`.
Still untested by this PR: `apply_action` / `_sanitize_action` (action clipping & control-mode dispatch), `info`, `drone_mass`, `rng_spec2fn`, `build_dynamics_disturbance_fn`. These are candidates for a follow-up.

## Test plan

- [x] `pytest tests/integration/test_envs.py::test_render -v`
- [x] `pytest tests/integration/test_envs.py::test_render_multi_drone -v`
- [x] `pytest tests/unit/envs/test_race_core.py -v` (16 passed)
- [x] `ruff check tests/unit/envs/test_race_core.py` (clean)
- [x] CI green on headless runner (verify `skip_if_headless` still skips render tests)