### PR TITLE
Fix close cleanup in real race env

### DIFF
--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -449,11 +449,9 @@ class RealRaceCoreEnv:
         Irrespective of succeeding or not, the drone will be stopped immediately afterwards or in
         case of errors, and close the connections to the ROSConnector.
         """
-        if not self.data.drone_connected or not self.data.taken_off:
-            self._ros_connector.close()
-            return
         try:
-            self._return_to_start()
+            if self.data.taken_off:
+                self._return_to_start()
         finally:
             try:
                 # Kill the drone


### PR DESCRIPTION
## Changes

- Remove early-return guard in [`close()`](lsy_drone_racing/envs/real_race_env.py#L445)
- Guard `_return_to_start()` with `if self.data.taken_off`
- Emergency stop, `close_link()`, and ROS connector close now always run via the `try/finally` chain
