### PR TITLE
Fix setup_acados.sh

### DIFF
--- a/tools/setup_acados.sh
+++ b/tools/setup_acados.sh
@@ -62,7 +62,7 @@ fi
 if [ -f ${ACADOS_DIR}/lib/libacados.so ]; then
   export ACADOS_SOURCE_DIR="$ACADOS_DIR"
   export ACADOS_INSTALL_DIR="$ACADOS_DIR"
-  export LD_LIBRARY_PATH="$ACADOS_DIR/lib"
+  export LD_LIBRARY_PATH="$ACADOS_DIR/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
   export PATH="${ACADOS_DIR}/interfaces/acados_template:${PATH}"
 fi
 


### PR DESCRIPTION
The former acados setup script OVERWRITEs the whole environment variable LD_LIBRARY_PATH, making other library paths not visible.