### PR TITLE
Fix nominal gates/obstacles positions in obs for level 3

### DIFF
--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -134,9 +134,13 @@ class EnvData:
         """Create a new environment data struct with default values."""
         n_envs = sim_data.core.n_worlds
         n_drones = sim_data.core.n_drones
-        gates_pos = jax.device_put(jp.tile(nominal_gates_pos[None, ...], (n_envs, 1, 1)), device)
-        gates_quat = jax.device_put(jp.tile(nominal_gates_quat[None, ...], (n_envs, 1, 1)), device)
-        obstacles_pos = jax.device_put(
+        tiled_gates_pos = jax.device_put(
+            jp.tile(nominal_gates_pos[None, ...], (n_envs, 1, 1)), device
+        )
+        tiled_gates_quat = jax.device_put(
+            jp.tile(nominal_gates_quat[None, ...], (n_envs, 1, 1)), device
+        )
+        tiled_obstacles_pos = jax.device_put(
             jp.tile(nominal_obstacles_pos[None, ...], (n_envs, 1, 1)), device
         )
         return EnvData(
@@ -152,12 +156,12 @@ class EnvData:
             pos_limit_low=jp.array(pos_limit_low, dtype=np.float32, device=device),
             pos_limit_high=jp.array(pos_limit_high, dtype=np.float32, device=device),
             max_episode_steps=jp.array([max_episode_steps], dtype=int, device=device),
-            gates_pos=gates_pos,
-            gates_quat=gates_quat,
-            obstacles_pos=obstacles_pos,
-            nominal_gates_pos=jp.array(nominal_gates_pos, dtype=np.float32, device=device),
-            nominal_gates_quat=jp.array(nominal_gates_quat, dtype=np.float32, device=device),
-            nominal_obstacles_pos=jp.array(nominal_obstacles_pos, dtype=np.float32, device=device),
+            gates_pos=tiled_gates_pos,
+            gates_quat=tiled_gates_quat,
+            obstacles_pos=tiled_obstacles_pos,
+            nominal_gates_pos=tiled_gates_pos,
+            nominal_gates_quat=tiled_gates_quat,
+            nominal_obstacles_pos=tiled_obstacles_pos,
             sim_data=sim_data,
             sensor_range=jp.array([sensor_range], dtype=jp.float32, device=device),
         )
@@ -673,13 +677,11 @@ class RaceCoreEnv:
 def obs(data: EnvData) -> dict[str, Array]:
     """Return the observation of the environment."""
     mask = data.gates_visited[..., None]
-    sensor_gates_pos = jp.where(mask, data.gates_pos[:, None], data.nominal_gates_pos[None, None])
-    sensor_gates_quat = jp.where(
-        mask, data.gates_quat[:, None], data.nominal_gates_quat[None, None]
-    )
+    sensor_gates_pos = jp.where(mask, data.gates_pos[:, None], data.nominal_gates_pos[:, None])
+    sensor_gates_quat = jp.where(mask, data.gates_quat[:, None], data.nominal_gates_quat[:, None])
     mask = data.obstacles_visited[..., None]
     sensor_obstacles_pos = jp.where(
-        mask, data.obstacles_pos[:, None], data.nominal_obstacles_pos[None, None]
+        mask, data.obstacles_pos[:, None], data.nominal_obstacles_pos[:, None]
     )
     return {
         "pos": data.sim_data.states.pos,

--- a/lsy_drone_racing/envs/randomize.py
+++ b/lsy_drone_racing/envs/randomize.py
@@ -312,7 +312,14 @@ def build_full_track_randomization_fn(
         keys = jax.random.split(key, n_envs)
         gates_pos, gates_quat, obstacles_pos = batched_generate(keys)
         return leaf_replace(
-            data, mask, gates_pos=gates_pos, gates_quat=gates_quat, obstacles_pos=obstacles_pos
+            data,
+            mask,
+            gates_pos=gates_pos,
+            gates_quat=gates_quat,
+            obstacles_pos=obstacles_pos,
+            nominal_gates_pos=gates_pos,
+            nominal_gates_quat=gates_quat,
+            nominal_obstacles_pos=obstacles_pos,
         )
 
     return randomize_track

--- a/tests/unit/envs/test_race_core.py
+++ b/tests/unit/envs/test_race_core.py
@@ -91,8 +91,8 @@ def test_obs_returns_nominal_when_out_of_sensor_range():
     assert not bool(jp.any(obs["gates_visited"])), "no gate should be visited"
     assert not bool(jp.any(obs["obstacles_visited"])), "no obstacle should be visited"
 
-    nominal_gate_pos = env.unwrapped.data.nominal_gates_pos
-    nominal_obstacle_pos = np.asarray(env.unwrapped.data.nominal_obstacles_pos)
+    nominal_gate_pos = np.asarray(env.unwrapped.data.nominal_gates_pos[0])
+    nominal_obstacle_pos = np.asarray(env.unwrapped.data.nominal_obstacles_pos[0])
     np.testing.assert_allclose(np.asarray(obs["gates_pos"]), nominal_gate_pos, rtol=1e-5)
     np.testing.assert_allclose(np.asarray(obs["obstacles_pos"]), nominal_obstacle_pos, rtol=1e-5)
     env.close()
@@ -110,6 +110,41 @@ def test_obs_returns_real_pose_when_in_sensor_range():
     real_obstacles_pos = env.unwrapped.data.obstacles_pos[0]
     np.testing.assert_allclose(np.asarray(obs["gates_pos"]), real_gates_pos, rtol=1e-5)
     np.testing.assert_allclose(np.asarray(obs["obstacles_pos"]), real_obstacles_pos, rtol=1e-5)
+    env.close()
+
+
+@pytest.mark.unit
+def test_level3_nominal_positions_set_after_randomization():
+    """Full track randomization must populate nominal positions, not leave them zeroed from TOML.
+
+    In level 3 the gate/obstacle x,y coords in the TOML are all 0.0. After reset the nominal
+    positions must reflect the randomly generated layout, not those zeros.
+    """
+    env = make_env("level3.toml", sensor_range=0.0)
+    env.reset()
+    nominal_gates_pos = np.asarray(env.unwrapped.data.nominal_gates_pos)
+    nominal_obstacles_pos = np.asarray(env.unwrapped.data.nominal_obstacles_pos)
+    # After full-track randomization every gate/obstacle should have been moved
+    assert not np.all(nominal_gates_pos[..., :2] == 0.0), "nominal gate pos not updated"
+    assert not np.all(nominal_obstacles_pos[..., :2] == 0.0), "nominal obstacle pos not updated"
+    env.close()
+
+
+@pytest.mark.unit
+def test_level3_initial_obs_differs_from_real_positions():
+    """Level 3 initial obs must report nominal positions, which differ from actual (perturbed) ones.
+
+    With sensor_range=0 every gate is out of range, so obs reports nominal positions. Level 3 also
+    applies per-gate perturbation randomization on top of the full-track layout, so the real gate
+    positions differ from the nominal ones.
+    """
+    env = make_env("level3.toml", sensor_range=0.0)
+    env.reset()
+    obs, _ = env.reset()
+    assert not bool(np.any(obs["gates_visited"])), "no gate should be visited with sensor_range=0"
+    obs_gates_pos = np.asarray(obs["gates_pos"])
+    real_gates_pos = np.asarray(env.unwrapped.data.gates_pos[0])
+    assert not np.allclose(obs_gates_pos, real_gates_pos, atol=1e-6), "obs pos is using real pos"
     env.close()
 
 


### PR DESCRIPTION
We were not overwriting the default positions from the randomization. Track position modifications are happening after this step, so there still is a deviation between nominal and real (as intended). Side-effect from this change: All nominal positions must be n_worlds x n_objects x 3 now, because level 3 has different nominal positions per world. Should not affect memory consumption for the 1 world case.