### PR TITLE
Fix close cleanup in real race env

### DIFF
--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -449,11 +449,9 @@ class RealRaceCoreEnv:
         Irrespective of succeeding or not, the drone will be stopped immediately afterwards or in
         case of errors, and close the connections to the ROSConnector.
         """
-        if not self.data.drone_connected or not self.data.taken_off:
-            self._ros_connector.close()
-            return
         try:
-            self._return_to_start()
+            if self.data.taken_off:
+                self._return_to_start()
         finally:
             try:
                 # Kill the drone


### PR DESCRIPTION
`RealRaceCoreEnv.close()` now always emergency-stops the drone and closes the radio link, gating only the return-to-start flight on `taken_off`.

Previously, a connected-but-armed drone that had not taken off (e.g. an abort before takeoff) hit the early return in `close()` and was left armed with the radio link open — no emergency stop was sent, and `scripts/deploy.py` has no other backstop (its teardown is only `env.close()`).

Verified on hardware (Crazyflie, props off) via the firmware `supervisor.info` bitfield: with the fix `is_armed -> 0` right after `close()`; without it the drone stays armed.

Closes #85