### PR TITLE
Remove duplicate CI tests

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,8 @@
 name: Ruff
-on: [ push, pull_request ]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   ruff-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,9 @@
 name: Testing  # Skips RL tests because stable-baselines3 comes with a lot of heavy-weight dependencies
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Same fix as for crazyflow to prevent testing PRs from our branches twice.