### PR TITLE
Fix leaking `nounset` in deploy activation scripts

### DIFF
--- a/tools/setup_acados.sh
+++ b/tools/setup_acados.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 
 # Check if environment variable is already set
 if [ -z "$PIXI_PROJECT_ROOT" ]; then


### PR DESCRIPTION
This PR fixes` pixi shell -e deploy` activation by removing nounset from `tools/setup_acados.sh`. The root cause was that Pixi sources activation hooks into a shared shell, so `set -u `leaked from `setup_acados.sh` into later hooks; when `tools/setup_mocap.sh` then sourced ROS/colcon’s generated `ros_ws/install/setup.sh`, it failed with `COLCON_CURRENT_PREFIX: unbound variable` because that script expects the variable to be allowed to be unset. This change keeps the activation behavior compatible with downstream ROS setup while preserving the intended setup flow.

Fixes #113