### PR TITLE
Decouple onboard estimator updates onto a background thread

### DIFF
--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -8,7 +8,6 @@ to the real drones.
 
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -64,8 +63,6 @@ class RealRaceCoreEnv:
     This class acts as a generic core implementation of the environment logic that can be reused for
     both single-agent and multi-agent deployments.
     """
-
-    POS_UPDATE_FREQ = 30  # Frequency of position updates to the drone estimator in Hz
 
     def __init__(
         self,
@@ -149,7 +146,6 @@ class RealRaceCoreEnv:
 
         self.drone.connect(timeout=10.0)
         self.drone.reset(arm=True)
-        self._last_drone_pos_update = 0  # Last time a position was sent to the drone estimator
 
         return self.obs(), self.info()
 
@@ -185,11 +181,8 @@ class RealRaceCoreEnv:
         self.data.target_gate[self.data.target_gate >= self.n_gates] = -1
         self.data.last_drone_pos[...] = drone_pos
         self.data.taken_off |= drone_pos[self.rank, 2] > 0.1
-        # Send vicon position updates to the drone at a fixed frequency irrespective of the env freq
-        # Sending too many updates may deteriorate the performance of the drone, hence the limiter
-        if (t := time.perf_counter()) - self._last_drone_pos_update > 1 / self.POS_UPDATE_FREQ:
-            self.drone.send_external_pose()
-            self._last_drone_pos_update = t
+        # Vicon position updates are streamed to the drone estimator on a background thread by the
+        # Crazyflie wrapper at a fixed frequency, decoupled from this control loop.
         return self.obs(), self.reward(), self.terminated(), self.truncated(), self.info()
 
     def obs(self) -> dict[str, NDArray]:

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -181,8 +181,6 @@ class RealRaceCoreEnv:
         self.data.target_gate[self.data.target_gate >= self.n_gates] = -1
         self.data.last_drone_pos[...] = drone_pos
         self.data.taken_off |= drone_pos[self.rank, 2] > 0.1
-        # Vicon position updates are streamed to the drone estimator on a background thread by the
-        # Crazyflie wrapper at a fixed frequency, decoupled from this control loop.
         return self.obs(), self.reward(), self.terminated(), self.truncated(), self.info()
 
     def obs(self) -> dict[str, NDArray]:

--- a/lsy_drone_racing/utils/crazyflie.py
+++ b/lsy_drone_racing/utils/crazyflie.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import multiprocessing as mp
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -18,6 +20,8 @@ from scipy.spatial.transform import Rotation as R
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
+    from concurrent.futures import Future
+    from multiprocessing.synchronize import Event
 
     from numpy.typing import NDArray
 
@@ -41,6 +45,7 @@ class Crazyflie:
         drone_name: str,
         cache_dir: str | Path | None = None,
         power_cycle_on_connect: bool = True,
+        update_freq: float = 30,
     ):
         """Create a Crazyflie wrapper.
 
@@ -49,10 +54,13 @@ class Crazyflie:
             drone_name: Name of the drone in ROS, e.g. cf10.
             cache_dir: Directory used for cflib2 TOC caching.
             power_cycle_on_connect: Whether to power-cycle the STM32 domain before connecting.
+            update_freq: Frequency (Hz) of external mocap pose updates sent to the drone estimator
+                by the background updater thread. Defaults to 30.
         """
         self.uri = uri
         self.drone_name = drone_name
         self.power_cycle_on_connect = power_cycle_on_connect
+        self.update_freq = update_freq
         self.context = LinkContext()
         cache_dir = Path(__file__).parent / ".cache" if cache_dir is None else Path(cache_dir)
         self.toc_cache = FileTocCache(str(cache_dir))
@@ -64,6 +72,9 @@ class Crazyflie:
         self._commander_level: Literal["low", "high"] | None = None
         self._state_setpoint_fallback_warned = False
         self._loop = asyncio.new_event_loop()
+        self._loop_thread: threading.Thread | None = None
+        self._estimator_stop_event: Event | None = None
+        self._estimator_future: Future[None] | None = None
 
     @classmethod
     def from_radio(
@@ -74,6 +85,7 @@ class Crazyflie:
         drone_name: str | None = None,
         cache_dir: str | Path | None = None,
         power_cycle_on_connect: bool = True,
+        update_freq: float = 30,
     ) -> Crazyflie:
         """Create a Crazyflie wrapper from deployment radio settings."""
         return cls(
@@ -81,6 +93,7 @@ class Crazyflie:
             f"cf{drone_id}" if drone_name is None else drone_name,
             cache_dir=cache_dir,
             power_cycle_on_connect=power_cycle_on_connect,
+            update_freq=update_freq,
         )
 
     @property
@@ -98,12 +111,18 @@ class Crazyflie:
         self._run(self._connect, timeout)
 
     def reset(self, arm: bool = False) -> None:
-        """Apply race settings, reset the estimator, and optionally arm the drone."""
+        """Apply race settings, reset the estimator, and optionally arm the drone.
+
+        After the settings, estimator reset, and arming have been applied synchronously, the
+        background estimator updater is started so mocap poses are streamed to the drone at a
+        fixed frequency, decoupled from the main control loop.
+        """
         self._run(self._apply_settings)
         self._run(self._reset_estimator)
         if arm:
             self._run(self._arm)
             self._run(self._unlock_thrust)
+        self._start_estimator_updater()
 
     def send_external_pose(self) -> None:
         """Send an external mocap pose to the Crazyflie estimator."""
@@ -160,13 +179,14 @@ class Crazyflie:
         self._run(self._prepare_high_level)
 
         def wait_for_action(duration: float) -> None:
+            # The background estimator updater keeps streaming mocap poses during the return, so no
+            # manual send_external_pose() is needed here.
             end_time = self._loop.time() + duration
             while self._loop.time() < end_time:
                 if check_ok is not None and not check_ok():
                     raise RuntimeError("Return-to-start was interrupted")
                 if not self.is_connected:
                     raise RuntimeError("Drone connection lost")
-                self.send_external_pose()
                 self._run(asyncio.sleep, 0.05)
 
         vel_norm = np.linalg.norm(initial_obs["vel"])
@@ -201,10 +221,18 @@ class Crazyflie:
         self._run(self._emergency_stop)
 
     def close(self, emergency_stop: bool = True) -> None:
-        """Emergency-stop, disconnect, and close the cflib2 event loop."""
+        """Stop the estimator updater, emergency-stop, disconnect, and close the event loop."""
         if self._loop.is_closed():
             return
         try:
+            if self._estimator_stop_event is not None:
+                self._estimator_stop_event.set()
+            if self._estimator_future is not None:
+                try:
+                    self._estimator_future.result(timeout=max(1.0, 2 / self.update_freq))
+                except Exception as exc:
+                    logger.warning(f"Stopping estimator updater failed: {exc}")
+
             if emergency_stop and self.is_connected:
                 self._run(self._emergency_stop)
                 self._run(asyncio.sleep, 0.1)
@@ -212,16 +240,49 @@ class Crazyflie:
             if self._cf is not None:
                 self._run(self._disconnect)
         finally:
+            self._estimator_future = None
+            self._estimator_stop_event = None
+            self._stop_loop_thread()
             try:
                 self._ros_connector.close()
             finally:
                 self._loop.close()
 
     def _run(self, operation: Callable[..., Awaitable[Any]], *args: Any, **kwargs: Any) -> Any:
-        """Run an asynchronous operation on this drone's event loop."""
+        """Run an asynchronous operation on this drone's event loop.
+
+        Before the estimator updater thread is started, the loop is driven synchronously via
+        ``run_until_complete``. Once the updater is running the loop is owned by the background
+        thread, so operations are submitted to it with ``run_coroutine_threadsafe`` instead.
+        """
         if self._loop.is_closed():
             raise RuntimeError("Crazyflie wrapper is already closed.")
+        if self._loop_thread is not None:
+            return asyncio.run_coroutine_threadsafe(operation(*args, **kwargs), self._loop).result()
         return self._loop.run_until_complete(operation(*args, **kwargs))
+
+    def _start_estimator_updater(self) -> None:
+        """Start continuous mocap updates after the radio link is connected."""
+        if self._loop_thread is not None:
+            return
+        ctx = mp.get_context("spawn")
+        self._estimator_stop_event = ctx.Event()
+        self._loop_thread = threading.Thread(
+            target=self._loop.run_forever, name=f"{self.drone_name}-event-loop", daemon=True
+        )
+        self._loop_thread.start()
+        self._estimator_future = asyncio.run_coroutine_threadsafe(
+            self._update_estimators(self._estimator_stop_event), self._loop
+        )
+
+    def _stop_loop_thread(self) -> None:
+        """Stop the persistent event loop used by the estimator updater."""
+        if self._loop_thread is None:
+            return
+
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._loop_thread.join()
+        self._loop_thread = None
 
     async def _connect(self, timeout: float) -> None:
         if self.is_connected:
@@ -303,6 +364,21 @@ class Crazyflie:
         pos = self._ros_connector.pos[self.drone_name]
         quat = self._ros_connector.quat[self.drone_name]
         await self.cf.localization().external_pose().send_external_pose(pos=pos, quat=quat)
+
+    async def _update_estimators(self, stop_event: Event) -> None:
+        """Continuously send the mocap pose to the Crazyflie estimator until stopped."""
+        period = 1 / self.update_freq
+        next_tick = asyncio.get_running_loop().time()
+        while not stop_event.is_set():
+            # A single transient send failure must not kill the updater task; log and keep going.
+            # This mirrors the per-drone error handling that DroneSwarm gets from _parallel_by_uri,
+            # which swallows every exception (including disconnects) rather than stopping the loop.
+            try:
+                await self._send_external_pose()
+            except Exception as exc:
+                logger.error(f"Updating estimator of {self.uri} failed: {exc}")
+            next_tick += period
+            await asyncio.sleep(max(0.0, next_tick - asyncio.get_running_loop().time()))
 
     async def _send_attitude_setpoint(
         self, roll: float, pitch: float, yaw_rate: float, thrust: int

--- a/lsy_drone_racing/utils/crazyflie.py
+++ b/lsy_drone_racing/utils/crazyflie.py
@@ -107,22 +107,17 @@ class Crazyflie:
         return self._cf is not None
 
     def connect(self, timeout: float = 10.0) -> None:
-        """Connect to the Crazyflie."""
+        """Connect to the Crazyflie and start streaming mocap poses to its estimator."""
         self._run(self._connect, timeout)
+        self._start_estimator_updater()
 
     def reset(self, arm: bool = False) -> None:
-        """Apply race settings, reset the estimator, and optionally arm the drone.
-
-        After the settings, estimator reset, and arming have been applied synchronously, the
-        background estimator updater is started so mocap poses are streamed to the drone at a
-        fixed frequency, decoupled from the main control loop.
-        """
+        """Apply race settings, reset the estimator, and optionally arm the drone."""
         self._run(self._apply_settings)
         self._run(self._reset_estimator)
         if arm:
             self._run(self._arm)
             self._run(self._unlock_thrust)
-        self._start_estimator_updater()
 
     def send_external_pose(self) -> None:
         """Send an external mocap pose to the Crazyflie estimator."""
@@ -179,8 +174,6 @@ class Crazyflie:
         self._run(self._prepare_high_level)
 
         def wait_for_action(duration: float) -> None:
-            # The background estimator updater keeps streaming mocap poses during the return, so no
-            # manual send_external_pose() is needed here.
             end_time = self._loop.time() + duration
             while self._loop.time() < end_time:
                 if check_ok is not None and not check_ok():
@@ -221,10 +214,13 @@ class Crazyflie:
         self._run(self._emergency_stop)
 
     def close(self, emergency_stop: bool = True) -> None:
-        """Stop the estimator updater, emergency-stop, disconnect, and close the event loop."""
+        """Emergency-stop, stop the estimator updater, disconnect, and close the event loop."""
         if self._loop.is_closed():
             return
         try:
+            if emergency_stop and self.is_connected:
+                self._run(self._emergency_stop)
+                self._run(asyncio.sleep, 0.1)
             if self._estimator_stop_event is not None:
                 self._estimator_stop_event.set()
             if self._estimator_future is not None:
@@ -232,11 +228,6 @@ class Crazyflie:
                     self._estimator_future.result(timeout=max(1.0, 2 / self.update_freq))
                 except Exception as exc:
                     logger.warning(f"Stopping estimator updater failed: {exc}")
-
-            if emergency_stop and self.is_connected:
-                self._run(self._emergency_stop)
-                self._run(asyncio.sleep, 0.1)
-
             if self._cf is not None:
                 self._run(self._disconnect)
         finally:


### PR DESCRIPTION
## Summary

Decouple the onboard estimator (external mocap pose) updates from the control loop by
streaming them from a dedicated background thread at a fixed frequency (default 30 Hz).

Previously the external pose was sent inside the environment `step()` and rate-limited there
(`POS_UPDATE_FREQ`). Because the send was coupled to the control loop, any stall or jitter in
the loop (heavy `compute_control`, GC pause, blocking I/O) directly delayed the estimator
refresh. When the loop stalled, the onboard Kalman filter stopped receiving fresh poses and had
to dead-reckon on IMU alone, causing drift and a visible correction once poses resumed.

## What changed

- `Crazyflie` now owns a persistent event loop running on a background thread and an
  `_update_estimators` task that sends the external pose every `1 / update_freq` seconds,
  independent of the control loop.
- `connect()` starts the updater at the end of the connection sequence, so the estimator
  already receives poses before `reset()` runs and the drone is armed. `close()` sends an
  emergency stop first, then signals the updater to stop and joins the thread cleanly (with a
  bounded timeout).
- Once the updater thread is running, `_run` submits operations with
  `run_coroutine_threadsafe` instead of `run_until_complete`, so control commands and pose
  updates share the same loop safely.
- Removed the now-redundant manual `send_external_pose()` calls in `RealRaceCoreEnv.step()`
  and in `return_to_start()`; the background thread keeps streaming poses in both cases.
- A transient send failure is logged and swallowed so a single hiccup does not kill the updater.
- `update_freq` is exposed as a constructor / `from_radio` argument (default 30 Hz).

## How it was verified

The payoff of decoupling only shows up when the control loop stalls — under a healthy loop both
the old and new code send at a steady 30 Hz. To make the difference measurable, the send
interval was logged on every external-pose send and an artificial stall was injected into the
controller:

```python
# temporary stall injected into compute_control
if random.random() < 0.1:
    time.sleep(0.3)
```

```python
# temporary instrumentation added to _send_external_pose
t = self._loop.time()
last = getattr(self, "_last_pose_send_t", None)
gap = 0.0 if last is None else t - last
logger.warning(f"{self.drone_name} external-pose GAP: {gap * 1000:.0f} ms")
self._last_pose_send_t = t
```

Both the injected stall and the logging are **debug-only and are not part of this PR**.

## Results

Real deployment on `cf52`, same injected stall (controller repeatedly exceeds the loop period
by ~0.28 s):

| Condition | External-pose gap during a control-loop stall |
|---|---|
| **Before** (coupled to `step()`) | spikes to **322–341 ms** — estimator starves for the full stall |
| **After** (background thread) | stays **33–43 ms** — steady ~30 Hz, unaffected by the stall |

Sample logs (after, decoupled — note the gap stays ~33 ms *despite* the loop overrun):

```
WARNING __main__:Controller execution time exceeded loop frequency by 0.281s.
WARNING crazyflie:cf52 external-pose GAP: 34 ms
WARNING crazyflie:cf52 external-pose GAP: 33 ms
```

Sample logs (before, coupled — the gap tracks the stall):

```
WARNING __main__:Controller execution time exceeded loop frequency by 0.284s.
WARNING crazyflie:cf52 external-pose GAP: 322 ms
WARNING __main__:Controller execution time exceeded loop frequency by 0.282s.
WARNING crazyflie:cf52 external-pose GAP: 341 ms
```

### Re-verification after moving the updater start to the end of `connect()`

The first version started the updater in `reset(arm=True)`. After moving the start to the end
of `connect()` and reordering `close()` to emergency-stop first, the full deployment was
re-run on `cf52` with the same injected stall and instrumentation:

- External-pose gaps stay **32–34 ms** while the control loop overruns by ~0.28 s — the
  decoupling is unaffected by the new start location.
- Poses already stream at ~30 Hz right after `connect()` returns, i.e. before `reset()` and
  arming.
- The background stream keeps running through `return_to_start()` and the shutdown sequence;
  `close()` emergency-stops first and then joins the updater cleanly (no send or shutdown
  errors logged, including on Ctrl-C).

```
WARNING:__main__:Controller execution time exceeded loop frequency by 0.282s.
WARNING:lsy_drone_racing.utils.crazyflie:cf52 external-pose GAP: 34 ms
WARNING:lsy_drone_racing.utils.crazyflie:cf52 external-pose GAP: 34 ms
WARNING:lsy_drone_racing.utils.crazyflie:cf52 external-pose GAP: 32 ms
WARNING:lsy_drone_racing.utils.crazyflie:cf52 external-pose GAP: 33 ms
...
WARNING:__main__:Controller execution time exceeded loop frequency by 0.281s.
WARNING:lsy_drone_racing.utils.crazyflie:cf52 external-pose GAP: 34 ms
WARNING:lsy_drone_racing.utils.crazyflie:cf52 external-pose GAP: 32 ms
```

## Testing

- `ruff check .` — passed
- `ruff format --check --diff .` — passed
- `pixi run -e tests tests -v` — 83 passed, 20 skipped (GPU-only)
- Bench + real-flight deployment on `cf52` as above, re-verified after moving the updater
  start to the end of `connect()`
