### PR TITLE
Add gate order field

### DIFF
--- a/config/level0.toml
+++ b/config/level0.toml
@@ -52,6 +52,10 @@ control_mode = "state"  # Control mode of the environment. Can be either "state"
 # Note: The order and therefore also height is not randomized!
 randomize = false
 
+# Order in which the gates have to be passed. Entries are signed gate numbers, not gate IDs:
+# `1` means gate ID 0 in forward direction, `-1` means the same gate in reverse direction.
+gate_order = [1, 2, 3, 4]
+
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
 # Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]

--- a/config/level1.toml
+++ b/config/level1.toml
@@ -53,6 +53,10 @@ control_mode = "state"  # Control mode of the environment. Can be either "state"
 # Note: The order and therefore also height is not randomized!
 randomize = false
 
+# Order in which the gates have to be passed. Entries are signed gate numbers, not gate IDs:
+# `1` means gate ID 0 in forward direction, `-1` means the same gate in reverse direction.
+gate_order = [1, 2, 3, 4]
+
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
 # Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]

--- a/config/level2.toml
+++ b/config/level2.toml
@@ -53,6 +53,10 @@ control_mode = "state"  # Control mode of the environment. Can be either "state"
 # Note: The order and therefore also height is not randomized!
 randomize = false
 
+# Order in which the gates have to be passed. Entries are signed gate numbers, not gate IDs:
+# `1` means gate ID 0 in forward direction, `-1` means the same gate in reverse direction.
+gate_order = [1, 2, 3, 4]
+
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
 # Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]

--- a/config/level3.toml
+++ b/config/level3.toml
@@ -53,6 +53,10 @@ control_mode = "state"  # Control mode of the environment. Can be either "state"
 # Note: The order and therefore also height is not randomized!
 randomize = true
 
+# Order in which the gates have to be passed. Entries are signed gate numbers, not gate IDs:
+# `1` means gate ID 0 in forward direction, `-1` means the same gate in reverse direction.
+gate_order = [1, 2, 3, 4]
+
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
 # Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]

--- a/config/multi_level0.toml
+++ b/config/multi_level0.toml
@@ -65,6 +65,10 @@ control_mode = "attitude"
 # Note: The order and therefore also height is not randomized!
 randomize = false
 
+# Order in which the gates have to be passed. Entries are signed gate numbers, not gate IDs:
+# `1` means gate ID 0 in forward direction, `-1` means the same gate in reverse direction.
+gate_order = [1, 2, 3, 4]
+
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
 # Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]

--- a/config/multi_level2.toml
+++ b/config/multi_level2.toml
@@ -65,6 +65,10 @@ control_mode = "attitude"
 # Note: The order and therefore also height is not randomized!
 randomize = false
 
+# Order in which the gates have to be passed. Entries are signed gate numbers, not gate IDs:
+# `1` means gate ID 0 in forward direction, `-1` means the same gate in reverse direction.
+gate_order = [1, 2, 3, 4]
+
 # Tall gates: 1.195m height. Short gates: 0.695m height. Height is measured from the ground to the center of the gate.
 # Gates are square. Gates are 0.72m wide (outer dimensions of the frame) with a 0.4m wide opening.
 [[env.track.gates]]

--- a/docs/challenge/overview.md
+++ b/docs/challenge/overview.md
@@ -6,7 +6,7 @@ We use the Crazyflie nano quadcopter for our challenge. It is a small, low-cost 
 
 ## The Track
 
-Contrary to other drone racing challenges, this setup not only includes gates in the track but also obstacles that must be avoided by the drones. The current iteration consists of four gates and four obstacles. Gates must be traversed in the correct order and in the correct direction, as passing a gate in the opposite direction will not count as a successful pass. Once a gate has been successfully passed, traversing it again in reverse will not undo the completion; from that point on, the gate simply acts as another obstacle within the track.
+Contrary to other drone racing challenges, this setup not only includes gates in the track but also obstacles that must be avoided by the drones. The current iteration consists of four gates and four obstacles. Gates must be traversed in the configured order and in the configured direction, as passing a gate in the opposite direction will not count as a successful pass. Once a gate has been successfully passed, traversing it again in reverse will not undo the completion. However, the gate-order list may revisit the same physical gate multiple times, including in reverse, so only the current target entry in the order counts toward progress. 
 
 All details about the track elements are provided in the level files explained below. The track features two types of gates: tall gates and short gates. The tall gates have a height of 1.195 meters, while the short gates measure 0.695 meters. In both cases, the height is measured from the ground to the center of the gate. Each gate is square in shape, with an outer frame width of 0.72 meters and an inner opening width of 0.4 meters.
 

--- a/docs/challenge/overview.md
+++ b/docs/challenge/overview.md
@@ -16,8 +16,6 @@ The obstacles are designed as slender cylindrical poles with 0.03 meters in diam
 
 The goal of the project is to develop a controller that can navigate the drone through the track with the least possible time on a real Crazyflie drone. As previously mentioned, controllers have to be compatible with the predefined interface. Once you have designed a controller and verified its performance and safety in simulation, you can deploy it on the real hardware.
 
-For racing-specific observability, the environment observation exposes `n_gates_passed` as the number of configured gate-order entries already completed, `gate_sequence` as the full configured gate order in 0-based gate IDs, `gate_sequence_direction` as the signed pass direction for each entry (`1` for the positive passing direction, `-1` for the reverse direction), `target_gate` as the next physical gate ID, and `target_gate_reverse` as the signed pass direction for that next gate.
-
 !!! warning
     While the interfaces are the same and we take great care to ensure that the simulation faithfully reproduces the real-world behavior of the drones, running a controller on the real drone is significantly different from running it in simulation. Be aware that unexpected behavior might occur, depending on the actual drone and the used controller, and further extensive tuning and testing may be necessary.
 

--- a/docs/challenge/overview.md
+++ b/docs/challenge/overview.md
@@ -16,6 +16,8 @@ The obstacles are designed as slender cylindrical poles with 0.03 meters in diam
 
 The goal of the project is to develop a controller that can navigate the drone through the track with the least possible time on a real Crazyflie drone. As previously mentioned, controllers have to be compatible with the predefined interface. Once you have designed a controller and verified its performance and safety in simulation, you can deploy it on the real hardware.
 
+For racing-specific observability, the environment observation exposes `n_gates_passed` as the number of configured gate-order entries already completed, `gate_sequence` as the full configured gate order in 0-based gate IDs, `gate_sequence_direction` as the signed pass direction for each entry (`1` for the positive passing direction, `-1` for the reverse direction), `target_gate` as the next physical gate ID, and `target_gate_reverse` as the signed pass direction for that next gate.
+
 !!! warning
     While the interfaces are the same and we take great care to ensure that the simulation faithfully reproduces the real-world behavior of the drones, running a controller on the real drone is significantly different from running it in simulation. Be aware that unexpected behavior might occur, depending on the actual drone and the used controller, and further extensive tuning and testing may be necessary.
 

--- a/lsy_drone_racing/envs/drone_race.py
+++ b/lsy_drone_racing/envs/drone_race.py
@@ -68,7 +68,7 @@ class DroneRaceEnv(RaceCoreEnv, Env):
         self.action_space = build_action_space(control_mode, sim_config.drone_model)
         n_gates, n_obstacles = len(track.gates), len(track.obstacles)
         self.observation_space = build_observation_space(
-            n_gates, n_obstacles, self.data.gate_order_ids.shape[0]
+            n_gates, n_obstacles, self.data.gate_sequence.shape[0]
         )
         self.settings = self.settings.replace(autoreset=False)
         self._step = self.build_step_fn()  # Apply new settings to capture autoreset effect
@@ -157,7 +157,7 @@ class VecDroneRaceEnv(RaceCoreEnv, VectorEnv):
         self.action_space = batch_space(self.single_action_space, num_envs)
         n_gates, n_obstacles = len(track.gates), len(track.obstacles)
         self.single_observation_space = build_observation_space(
-            n_gates, n_obstacles, self.data.gate_order_ids.shape[0]
+            n_gates, n_obstacles, self.data.gate_sequence.shape[0]
         )
         self.observation_space = batch_space(self.single_observation_space, num_envs)
 

--- a/lsy_drone_racing/envs/drone_race.py
+++ b/lsy_drone_racing/envs/drone_race.py
@@ -67,7 +67,9 @@ class DroneRaceEnv(RaceCoreEnv, Env):
         )
         self.action_space = build_action_space(control_mode, sim_config.drone_model)
         n_gates, n_obstacles = len(track.gates), len(track.obstacles)
-        self.observation_space = build_observation_space(n_gates, n_obstacles)
+        self.observation_space = build_observation_space(
+            n_gates, n_obstacles, self.data.gate_order_ids.shape[0]
+        )
         self.settings = self.settings.replace(autoreset=False)
         self._step = self.build_step_fn()  # Apply new settings to capture autoreset effect
 
@@ -154,7 +156,9 @@ class VecDroneRaceEnv(RaceCoreEnv, VectorEnv):
         self.single_action_space = build_action_space(control_mode, sim_config.drone_model)
         self.action_space = batch_space(self.single_action_space, num_envs)
         n_gates, n_obstacles = len(track.gates), len(track.obstacles)
-        self.single_observation_space = build_observation_space(n_gates, n_obstacles)
+        self.single_observation_space = build_observation_space(
+            n_gates, n_obstacles, self.data.gate_order_ids.shape[0]
+        )
         self.observation_space = batch_space(self.single_observation_space, num_envs)
 
     def reset(self, seed: int | None = None, options: dict | None = None) -> tuple[dict, dict]:

--- a/lsy_drone_racing/envs/multi_drone_race.py
+++ b/lsy_drone_racing/envs/multi_drone_race.py
@@ -74,7 +74,8 @@ class MultiDroneRaceEnv(RaceCoreEnv, Env):
             build_action_space(control_mode, sim_config.drone_model), n_drones
         )
         self.observation_space = batch_space(
-            build_observation_space(n_gates, n_obstacles), n_drones
+            build_observation_space(n_gates, n_obstacles, self.data.gate_order_ids.shape[0]),
+            n_drones,
         )
         self.settings = self.settings.replace(autoreset=False)
         self._step = self.build_step_fn()  # Apply new settings to capture autoreset effect
@@ -170,7 +171,8 @@ class VecMultiDroneRaceEnv(RaceCoreEnv, VectorEnv):
         )
         self.action_space = batch_space(batch_space(self.single_action_space), num_envs)
         self.single_observation_space = batch_space(
-            build_observation_space(n_gates, n_obstacles), n_drones
+            build_observation_space(n_gates, n_obstacles, self.data.gate_order_ids.shape[0]),
+            n_drones,
         )
         self.observation_space = batch_space(self.single_observation_space, num_envs)
 

--- a/lsy_drone_racing/envs/multi_drone_race.py
+++ b/lsy_drone_racing/envs/multi_drone_race.py
@@ -74,7 +74,7 @@ class MultiDroneRaceEnv(RaceCoreEnv, Env):
             build_action_space(control_mode, sim_config.drone_model), n_drones
         )
         self.observation_space = batch_space(
-            build_observation_space(n_gates, n_obstacles, self.data.gate_order_ids.shape[0]),
+            build_observation_space(n_gates, n_obstacles, self.data.gate_sequence.shape[0]),
             n_drones,
         )
         self.settings = self.settings.replace(autoreset=False)
@@ -171,7 +171,7 @@ class VecMultiDroneRaceEnv(RaceCoreEnv, VectorEnv):
         )
         self.action_space = batch_space(batch_space(self.single_action_space), num_envs)
         self.single_observation_space = batch_space(
-            build_observation_space(n_gates, n_obstacles, self.data.gate_order_ids.shape[0]),
+            build_observation_space(n_gates, n_obstacles, self.data.gate_sequence.shape[0]),
             n_drones,
         )
         self.observation_space = batch_space(self.single_observation_space, num_envs)

--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -74,7 +74,8 @@ class EnvData:
     episode.
 
     Attributes:
-        race_progress: Current target waypoint index for each drone in each environment
+        n_gates_passed: Number of configured gate-order entries already passed by each drone in
+            each environment
         gates_visited: Boolean flags indicating which gates have been visited by each drone
         obstacles_visited: Boolean flags indicating which obstacles have been detected
         last_drone_pos: Previous positions of drones, used for gate passing detection
@@ -87,12 +88,13 @@ class EnvData:
         obstacle_mj_ids: MuJoCo IDs for the obstacles
         max_episode_steps: Maximum number of steps per episode
         sensor_range: Range at which drones can detect gates and obstacles
-        gate_order_ids: 0-based gate IDs describing the configured gate order
-        gate_order_reverse: Flags indicating whether each gate-order entry is reversed
+        gate_sequence: 0-based gate IDs describing the configured gate order
+        gate_sequence_direction: Signed passing directions for each gate-order entry. ``1``
+            indicates the positive passing direction, ``-1`` the reverse direction.
     """
 
     # Dynamic variables
-    race_progress: Array
+    n_gates_passed: Array
     gates_visited: Array
     obstacles_visited: Array
     last_drone_pos: Array
@@ -109,8 +111,8 @@ class EnvData:
     nominal_gates_pos: Array
     nominal_gates_quat: Array
     nominal_obstacles_pos: Array
-    gate_order_ids: Array
-    gate_order_reverse: Array
+    gate_sequence: Array
+    gate_sequence_direction: Array
     # sim_data is stored in the env data to allow passing a single tree on which we can operate
     sim_data: SimData
     # Static variables
@@ -132,8 +134,8 @@ class EnvData:
         nominal_gates_pos: Array,
         nominal_gates_quat: Array,
         nominal_obstacles_pos: Array,
-        gate_order_ids: Array,
-        gate_order_reverse: Array,
+        gate_sequence: Array,
+        gate_sequence_direction: Array,
         sim_data: SimData,
         device: Device,
     ) -> EnvData:
@@ -150,7 +152,7 @@ class EnvData:
             jp.tile(nominal_obstacles_pos[None, ...], (n_envs, 1, 1)), device
         )
         return EnvData(
-            race_progress=jp.zeros((n_envs, n_drones), dtype=int, device=device),
+            n_gates_passed=jp.zeros((n_envs, n_drones), dtype=int, device=device),
             gates_visited=jp.zeros((n_envs, n_drones, n_gates), dtype=bool, device=device),
             obstacles_visited=jp.zeros((n_envs, n_drones, n_obstacles), dtype=bool, device=device),
             last_drone_pos=jp.zeros((n_envs, n_drones, 3), dtype=np.float32, device=device),
@@ -168,8 +170,8 @@ class EnvData:
             nominal_gates_pos=tiled_gates_pos,
             nominal_gates_quat=tiled_gates_quat,
             nominal_obstacles_pos=tiled_obstacles_pos,
-            gate_order_ids=jp.array(gate_order_ids, dtype=int, device=device),
-            gate_order_reverse=jp.array(gate_order_reverse, dtype=bool, device=device),
+            gate_sequence=jp.array(gate_sequence, dtype=int, device=device),
+            gate_sequence_direction=jp.array(gate_sequence_direction, dtype=int, device=device),
             sim_data=sim_data,
             sensor_range=jp.array([sensor_range], dtype=jp.float32, device=device),
         )
@@ -257,9 +259,11 @@ def build_observation_space(n_gates: int, n_obstacles: int, n_gate_passes: int) 
         "quat": spaces.Box(low=-1, high=1, shape=(4,)),
         "vel": spaces.Box(low=-np.inf, high=np.inf, shape=(3,)),
         "ang_vel": spaces.Box(low=-np.inf, high=np.inf, shape=(3,)),
-        "race_progress": spaces.Discrete(n_gate_passes + 1, start=-1),
-        "target_gate": spaces.Discrete(n_gates + 1, start=-1),
-        "target_gate_reverse": spaces.Box(low=0, high=1, shape=(), dtype=bool),
+        "n_gates_passed": spaces.Discrete(n_gate_passes + 1, start=0),
+        "gate_sequence": spaces.MultiDiscrete(np.full(n_gate_passes, n_gates, dtype=np.int64)),
+        "gate_sequence_direction": spaces.Box(
+            low=-1, high=1, shape=(n_gate_passes,), dtype=np.int32
+        ),
         "gates_pos": spaces.Box(low=-np.inf, high=np.inf, shape=(n_gates, 3)),
         "gates_quat": spaces.Box(low=-1, high=1, shape=(n_gates, 4)),
         "gates_visited": spaces.Box(low=0, high=1, shape=(n_gates,), dtype=bool),
@@ -297,8 +301,11 @@ class RaceCoreEnv:
     * quat: Drone orientation as a quaternion (x, y, z, w)
     * vel: Drone linear velocity
     * ang_vel: Drone angular velocity
-    * race_progress: The current index in the configured gate order, or -1 if the track is
-      completed
+    * n_gates_passed: The number of entries in the configured gate order that have already been
+      passed
+    * gate_sequence: The configured gate order expressed as 0-based gate IDs
+    * gate_sequence_direction: Signed passing direction for each gate-sequence entry. `1`
+      indicates the positive passing direction, `-1` the reverse direction
     * gates_pos: Positions of the gates
     * gates_quat: Orientations of the gates
     * gates_visited: Flags indicating if the drone already was/ is in the sensor range of the
@@ -306,9 +313,6 @@ class RaceCoreEnv:
     * obstacles_pos: Positions of the obstacles
     * obstacles_visited: Flags indicating if the drone already was/ is in the sensor range of the
       obstacles and the true position is known
-    * target_gate: The 0-based gate ID of the next gate in the configured gate order, or -1 if
-      the track is completed
-    * target_gate_reverse: Whether the next gate must be passed in reverse direction
 
     The action space consists of a desired full-state command
     [x, y, z, vx, vy, vz, ax, ay, az, yaw, rrate, prate, yrate] that is tracked by the drone's
@@ -387,7 +391,7 @@ class RaceCoreEnv:
         self.track = track
         gates, obstacles, drones = load_track(track)
         n_gates, n_obstacles = len(track.gates), len(track.obstacles)
-        gate_order_ids, gate_order_reverse = load_gate_order(track, n_gates)
+        gate_sequence, gate_sequence_direction = load_gate_order(track, n_gates)
         contact_masks = _load_contact_masks(self.sim)
         specs = {} if disturbances is None else disturbances
         disturbances = {mode: rng_spec2fn(spec) for mode, spec in specs.items()}
@@ -416,8 +420,8 @@ class RaceCoreEnv:
             nominal_gates_pos=gates.nominal_pos,
             nominal_gates_quat=gates.nominal_quat,
             nominal_obstacles_pos=obstacles.nominal_pos,
-            gate_order_ids=gate_order_ids,
-            gate_order_reverse=gate_order_reverse,
+            gate_sequence=gate_sequence,
+            gate_sequence_direction=gate_sequence_direction,
             sim_data=self.sim.data,
             device=self.settings.device,
         )
@@ -694,10 +698,6 @@ class RaceCoreEnv:
 
 def obs(data: EnvData) -> dict[str, Array]:
     """Return the observation of the environment."""
-    target_gate = data.gate_order_ids[data.race_progress]
-    target_gate = jp.where(data.race_progress < 0, -1, target_gate)
-    target_gate_reverse = data.gate_order_reverse[data.race_progress]
-    target_gate_reverse = jp.where(data.race_progress < 0, False, target_gate_reverse)
     mask = data.gates_visited[..., None]
     sensor_gates_pos = jp.where(mask, data.gates_pos[:, None], data.nominal_gates_pos[:, None])
     sensor_gates_quat = jp.where(mask, data.gates_quat[:, None], data.nominal_gates_quat[:, None])
@@ -710,9 +710,9 @@ def obs(data: EnvData) -> dict[str, Array]:
         "quat": data.sim_data.states.quat,
         "vel": data.sim_data.states.vel,
         "ang_vel": data.sim_data.states.ang_vel,
-        "race_progress": data.race_progress,
-        "target_gate": target_gate,
-        "target_gate_reverse": target_gate_reverse,
+        "n_gates_passed": data.n_gates_passed,
+        "gate_sequence": data.gate_sequence,
+        "gate_sequence_direction": data.gate_sequence_direction,
         "gates_pos": sensor_gates_pos,
         "gates_quat": sensor_gates_quat,
         "gates_visited": data.gates_visited,
@@ -732,7 +732,7 @@ def reward(data: EnvData) -> Array:
     Returns:
         Reward for the current state.
     """
-    return -1.0 * (data.race_progress == -1)  # Implicit float conversion
+    return -1.0 * (data.n_gates_passed >= data.gate_sequence.shape[0])  # Implicit float conversion
 
 
 def terminated(data: EnvData) -> Array:
@@ -751,7 +751,7 @@ def _reset_env_data(data: EnvData, mask: Array | None = None) -> EnvData:
     """Reset auxiliary variables of the environment data."""
     drone_pos = data.sim_data.states.pos
     mask = jp.ones(data.steps.shape, dtype=bool) if mask is None else mask
-    race_progress = jp.where(mask[..., None], 0, data.race_progress)
+    n_gates_passed = jp.where(mask[..., None], 0, data.n_gates_passed)
     last_drone_pos = jp.where(mask[..., None, None], drone_pos, data.last_drone_pos)
     disabled_drones = jp.where(mask[..., None], False, data.disabled_drones)
     steps = jp.where(mask, 0, data.steps)
@@ -765,7 +765,7 @@ def _reset_env_data(data: EnvData, mask: Array | None = None) -> EnvData:
     obstacles_visited = jp.linalg.norm(dpos, axis=-1) < data.sensor_range
     obstacles_visited = jp.where(mask[..., None, None], obstacles_visited, data.obstacles_visited)
     return data.replace(
-        race_progress=race_progress,
+        n_gates_passed=n_gates_passed,
         last_drone_pos=last_drone_pos,
         disabled_drones=disabled_drones,
         gates_visited=gates_visited,
@@ -793,18 +793,19 @@ def _update_visited_objects(data: EnvData) -> EnvData:
 
 def _update_target_gates(data: EnvData) -> EnvData:
     """Update the waypoint progress based on the current gate-order entry."""
-    n_gate_passes = data.gate_order_ids.shape[0]
+    n_gate_passes = data.gate_sequence.shape[0]
     gates_pos, gates_quat = data.gates_pos, data.gates_quat
     drone_pos = data.sim_data.states.pos
-    gate_ids = data.gate_order_ids[data.race_progress]
-    reverse = data.gate_order_reverse[data.race_progress]
+    progress = jp.clip(data.n_gates_passed, 0, n_gate_passes - 1)
+    gate_ids = data.gate_sequence[progress]
+    reverse = data.gate_sequence_direction[progress] < 0
     gate_pos = gates_pos[jp.arange(gates_pos.shape[0])[:, None], gate_ids]
     gate_quat = gates_quat[jp.arange(gates_quat.shape[0])[:, None], gate_ids]
     passed = gate_passed(drone_pos, data.last_drone_pos, gate_pos, gate_quat, reverse, (0.45, 0.45))
     # Advance the gate-order progress by one if drones have passed the current waypoint.
-    race_progress = data.race_progress + passed * ~data.disabled_drones
-    race_progress = jp.where(race_progress >= n_gate_passes, -1, race_progress)
-    return data.replace(race_progress=race_progress, last_drone_pos=data.sim_data.states.pos)
+    increment = (passed & ~data.disabled_drones).astype(data.n_gates_passed.dtype)
+    n_gates_passed = jp.minimum(data.n_gates_passed + increment, n_gate_passes)
+    return data.replace(n_gates_passed=n_gates_passed, last_drone_pos=data.sim_data.states.pos)
 
 
 def _mark_drones_for_reset(data: EnvData) -> EnvData:
@@ -853,7 +854,7 @@ def _disabled_drones(pos: Array, contacts: Array, data: EnvData) -> Array:
     not_in_platform |= jp.any(pos[..., :2] > data.takeoff_pos[..., :2] + 0.02, axis=-1)
     disabled = disabled | jp.any(pos < data.pos_limit_low, axis=-1) & not_in_platform
     disabled = disabled | jp.any(pos > data.pos_limit_high, axis=-1)
-    disabled = disabled | (data.race_progress == -1)
+    disabled = disabled | (data.n_gates_passed >= data.gate_sequence.shape[0])
     contacts = jp.any(contacts[:, :, None] & data.contact_masks, axis=-1)
     disabled = disabled | contacts
     return disabled

--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -49,7 +49,7 @@ from lsy_drone_racing.envs.randomize import (
     randomize_gate_rpy_fn,
     randomize_obstacle_pos_fn,
 )
-from lsy_drone_racing.envs.utils import gate_passed, load_track
+from lsy_drone_racing.envs.utils import gate_passed, load_gate_order, load_track
 
 if TYPE_CHECKING:
     from crazyflow.sim.data import SimData
@@ -74,7 +74,7 @@ class EnvData:
     episode.
 
     Attributes:
-        target_gate: Current target gate index for each drone in each environment
+        gate_progress: Current target waypoint index for each drone in each environment
         gates_visited: Boolean flags indicating which gates have been visited by each drone
         obstacles_visited: Boolean flags indicating which obstacles have been detected
         last_drone_pos: Previous positions of drones, used for gate passing detection
@@ -87,10 +87,12 @@ class EnvData:
         obstacle_mj_ids: MuJoCo IDs for the obstacles
         max_episode_steps: Maximum number of steps per episode
         sensor_range: Range at which drones can detect gates and obstacles
+        gate_order_ids: 0-based gate IDs describing the configured gate order
+        gate_order_reverse: Flags indicating whether each gate-order entry is reversed
     """
 
     # Dynamic variables
-    target_gate: Array
+    gate_progress: Array
     gates_visited: Array
     obstacles_visited: Array
     last_drone_pos: Array
@@ -107,6 +109,8 @@ class EnvData:
     nominal_gates_pos: Array
     nominal_gates_quat: Array
     nominal_obstacles_pos: Array
+    gate_order_ids: Array
+    gate_order_reverse: Array
     # sim_data is stored in the env data to allow passing a single tree on which we can operate
     sim_data: SimData
     # Static variables
@@ -128,6 +132,8 @@ class EnvData:
         nominal_gates_pos: Array,
         nominal_gates_quat: Array,
         nominal_obstacles_pos: Array,
+        gate_order_ids: Array,
+        gate_order_reverse: Array,
         sim_data: SimData,
         device: Device,
     ) -> EnvData:
@@ -144,7 +150,7 @@ class EnvData:
             jp.tile(nominal_obstacles_pos[None, ...], (n_envs, 1, 1)), device
         )
         return EnvData(
-            target_gate=jp.zeros((n_envs, n_drones), dtype=int, device=device),
+            gate_progress=jp.zeros((n_envs, n_drones), dtype=int, device=device),
             gates_visited=jp.zeros((n_envs, n_drones, n_gates), dtype=bool, device=device),
             obstacles_visited=jp.zeros((n_envs, n_drones, n_obstacles), dtype=bool, device=device),
             last_drone_pos=jp.zeros((n_envs, n_drones, 3), dtype=np.float32, device=device),
@@ -162,6 +168,8 @@ class EnvData:
             nominal_gates_pos=tiled_gates_pos,
             nominal_gates_quat=tiled_gates_quat,
             nominal_obstacles_pos=tiled_obstacles_pos,
+            gate_order_ids=jp.array(gate_order_ids, dtype=int, device=device),
+            gate_order_reverse=jp.array(gate_order_reverse, dtype=bool, device=device),
             sim_data=sim_data,
             sensor_range=jp.array([sensor_range], dtype=jp.float32, device=device),
         )
@@ -248,7 +256,8 @@ def build_observation_space(n_gates: int, n_obstacles: int) -> spaces.Dict:
         "quat": spaces.Box(low=-1, high=1, shape=(4,)),
         "vel": spaces.Box(low=-np.inf, high=np.inf, shape=(3,)),
         "ang_vel": spaces.Box(low=-np.inf, high=np.inf, shape=(3,)),
-        "target_gate": spaces.Discrete(n_gates, start=-1),
+        "target_gate": spaces.Discrete(n_gates + 1, start=-1),
+        "target_gate_reverse": spaces.Box(low=0, high=1, shape=(), dtype=bool),
         "gates_pos": spaces.Box(low=-np.inf, high=np.inf, shape=(n_gates, 3)),
         "gates_quat": spaces.Box(low=-1, high=1, shape=(n_gates, 4)),
         "gates_visited": spaces.Box(low=0, high=1, shape=(n_gates,), dtype=bool),
@@ -293,7 +302,9 @@ class RaceCoreEnv:
     * obstacles_pos: Positions of the obstacles
     * obstacles_visited: Flags indicating if the drone already was/ is in the sensor range of the
       obstacles and the true position is known
-    * target_gate: The current target gate index
+    * target_gate: The 0-based gate ID of the next gate in the configured gate order, or -1 if
+      the track is completed
+    * target_gate_reverse: Whether the next gate must be passed in reverse direction
 
     The action space consists of a desired full-state command
     [x, y, z, vx, vy, vz, ax, ay, az, yaw, rrate, prate, yrate] that is tracked by the drone's
@@ -372,6 +383,7 @@ class RaceCoreEnv:
         self.track = track
         gates, obstacles, drones = load_track(track)
         n_gates, n_obstacles = len(track.gates), len(track.obstacles)
+        gate_order_ids, gate_order_reverse = load_gate_order(track, n_gates)
         contact_masks = _load_contact_masks(self.sim)
         specs = {} if disturbances is None else disturbances
         disturbances = {mode: rng_spec2fn(spec) for mode, spec in specs.items()}
@@ -400,6 +412,8 @@ class RaceCoreEnv:
             nominal_gates_pos=gates.nominal_pos,
             nominal_gates_quat=gates.nominal_quat,
             nominal_obstacles_pos=obstacles.nominal_pos,
+            gate_order_ids=gate_order_ids,
+            gate_order_reverse=gate_order_reverse,
             sim_data=self.sim.data,
             device=self.settings.device,
         )
@@ -676,6 +690,7 @@ class RaceCoreEnv:
 
 def obs(data: EnvData) -> dict[str, Array]:
     """Return the observation of the environment."""
+    target_gate, target_gate_reverse = _target_gate_obs(data)
     mask = data.gates_visited[..., None]
     sensor_gates_pos = jp.where(mask, data.gates_pos[:, None], data.nominal_gates_pos[:, None])
     sensor_gates_quat = jp.where(mask, data.gates_quat[:, None], data.nominal_gates_quat[:, None])
@@ -688,7 +703,8 @@ def obs(data: EnvData) -> dict[str, Array]:
         "quat": data.sim_data.states.quat,
         "vel": data.sim_data.states.vel,
         "ang_vel": data.sim_data.states.ang_vel,
-        "target_gate": data.target_gate,
+        "target_gate": target_gate,
+        "target_gate_reverse": target_gate_reverse,
         "gates_pos": sensor_gates_pos,
         "gates_quat": sensor_gates_quat,
         "gates_visited": data.gates_visited,
@@ -708,7 +724,7 @@ def reward(data: EnvData) -> Array:
     Returns:
         Reward for the current state.
     """
-    return -1.0 * (data.target_gate == -1)  # Implicit float conversion
+    return -1.0 * (data.gate_progress == -1)  # Implicit float conversion
 
 
 def terminated(data: EnvData) -> Array:
@@ -727,7 +743,7 @@ def _reset_env_data(data: EnvData, mask: Array | None = None) -> EnvData:
     """Reset auxiliary variables of the environment data."""
     drone_pos = data.sim_data.states.pos
     mask = jp.ones(data.steps.shape, dtype=bool) if mask is None else mask
-    target_gate = jp.where(mask[..., None], 0, data.target_gate)
+    gate_progress = jp.where(mask[..., None], 0, data.gate_progress)
     last_drone_pos = jp.where(mask[..., None, None], drone_pos, data.last_drone_pos)
     disabled_drones = jp.where(mask[..., None], False, data.disabled_drones)
     steps = jp.where(mask, 0, data.steps)
@@ -741,7 +757,7 @@ def _reset_env_data(data: EnvData, mask: Array | None = None) -> EnvData:
     obstacles_visited = jp.linalg.norm(dpos, axis=-1) < data.sensor_range
     obstacles_visited = jp.where(mask[..., None, None], obstacles_visited, data.obstacles_visited)
     return data.replace(
-        target_gate=target_gate,
+        gate_progress=gate_progress,
         last_drone_pos=last_drone_pos,
         disabled_drones=disabled_drones,
         gates_visited=gates_visited,
@@ -768,17 +784,30 @@ def _update_visited_objects(data: EnvData) -> EnvData:
 
 
 def _update_target_gates(data: EnvData) -> EnvData:
-    """Update the target gate index based on the current target gate and the number of gates."""
-    n_gates = data.gates_pos.shape[1]
+    """Update the waypoint progress based on the current gate-order entry."""
+    n_gate_passes = data.gate_order_ids.shape[0]
     gates_pos, gates_quat = data.gates_pos, data.gates_quat
     drone_pos = data.sim_data.states.pos
-    gate_pos = gates_pos[jp.arange(gates_pos.shape[0])[:, None], data.target_gate % n_gates]
-    gate_quat = gates_quat[jp.arange(gates_quat.shape[0])[:, None], data.target_gate % n_gates]
-    passed = gate_passed(drone_pos, data.last_drone_pos, gate_pos, gate_quat, (0.45, 0.45))
-    # Update the target gate index. Increment by one if drones have passed a gate
-    target_gate = data.target_gate + passed * ~data.disabled_drones
-    target_gate = jp.where(target_gate >= n_gates, -1, target_gate)
-    return data.replace(target_gate=target_gate, last_drone_pos=data.sim_data.states.pos)
+    progress = jp.where(data.gate_progress < 0, 0, data.gate_progress)
+    gate_ids = data.gate_order_ids[progress]
+    reverse = data.gate_order_reverse[progress]
+    gate_pos = gates_pos[jp.arange(gates_pos.shape[0])[:, None], gate_ids]
+    gate_quat = gates_quat[jp.arange(gates_quat.shape[0])[:, None], gate_ids]
+    passed = gate_passed(drone_pos, data.last_drone_pos, gate_pos, gate_quat, reverse, (0.45, 0.45))
+    # Advance the gate-order progress by one if drones have passed the current waypoint.
+    gate_progress = data.gate_progress + passed * ~data.disabled_drones
+    gate_progress = jp.where(gate_progress >= n_gate_passes, -1, gate_progress)
+    return data.replace(gate_progress=gate_progress, last_drone_pos=data.sim_data.states.pos)
+
+
+def _target_gate_obs(data: EnvData) -> tuple[Array, Array]:
+    """Map internal waypoint progress to public observation fields."""
+    progress = jp.where(data.gate_progress < 0, 0, data.gate_progress)
+    gate_ids = data.gate_order_ids[progress]
+    reverse = data.gate_order_reverse[progress]
+    target_gate = jp.where(data.gate_progress < 0, -1, gate_ids)
+    target_gate_reverse = jp.where(data.gate_progress < 0, False, reverse)
+    return target_gate, target_gate_reverse
 
 
 def _mark_drones_for_reset(data: EnvData) -> EnvData:
@@ -827,7 +856,7 @@ def _disabled_drones(pos: Array, contacts: Array, data: EnvData) -> Array:
     not_in_platform |= jp.any(pos[..., :2] > data.takeoff_pos[..., :2] + 0.02, axis=-1)
     disabled = disabled | jp.any(pos < data.pos_limit_low, axis=-1) & not_in_platform
     disabled = disabled | jp.any(pos > data.pos_limit_high, axis=-1)
-    disabled = disabled | (data.target_gate == -1)
+    disabled = disabled | (data.gate_progress == -1)
     contacts = jp.any(contacts[:, :, None] & data.contact_masks, axis=-1)
     disabled = disabled | contacts
     return disabled

--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -74,7 +74,7 @@ class EnvData:
     episode.
 
     Attributes:
-        gate_progress: Current target waypoint index for each drone in each environment
+        race_progress: Current target waypoint index for each drone in each environment
         gates_visited: Boolean flags indicating which gates have been visited by each drone
         obstacles_visited: Boolean flags indicating which obstacles have been detected
         last_drone_pos: Previous positions of drones, used for gate passing detection
@@ -92,7 +92,7 @@ class EnvData:
     """
 
     # Dynamic variables
-    gate_progress: Array
+    race_progress: Array
     gates_visited: Array
     obstacles_visited: Array
     last_drone_pos: Array
@@ -150,7 +150,7 @@ class EnvData:
             jp.tile(nominal_obstacles_pos[None, ...], (n_envs, 1, 1)), device
         )
         return EnvData(
-            gate_progress=jp.zeros((n_envs, n_drones), dtype=int, device=device),
+            race_progress=jp.zeros((n_envs, n_drones), dtype=int, device=device),
             gates_visited=jp.zeros((n_envs, n_drones, n_gates), dtype=bool, device=device),
             obstacles_visited=jp.zeros((n_envs, n_drones, n_obstacles), dtype=bool, device=device),
             last_drone_pos=jp.zeros((n_envs, n_drones, 3), dtype=np.float32, device=device),
@@ -241,7 +241,7 @@ def build_action_space(control_mode: Literal["state", "attitude"], drone_model: 
     raise ValueError(f"Invalid control mode: {control_mode}")
 
 
-def build_observation_space(n_gates: int, n_obstacles: int) -> spaces.Dict:
+def build_observation_space(n_gates: int, n_obstacles: int, n_gate_passes: int) -> spaces.Dict:
     """Create the observation space for the environment.
 
     The observation space is a dictionary containing the drone state, gate information,
@@ -250,12 +250,14 @@ def build_observation_space(n_gates: int, n_obstacles: int) -> spaces.Dict:
     Args:
         n_gates: Number of gates in the environment.
         n_obstacles: Number of obstacles in the environment.
+        n_gate_passes: Number of entries in the configured gate order.
     """
     obs_spec = {
         "pos": spaces.Box(low=-np.inf, high=np.inf, shape=(3,)),
         "quat": spaces.Box(low=-1, high=1, shape=(4,)),
         "vel": spaces.Box(low=-np.inf, high=np.inf, shape=(3,)),
         "ang_vel": spaces.Box(low=-np.inf, high=np.inf, shape=(3,)),
+        "race_progress": spaces.Discrete(n_gate_passes + 1, start=-1),
         "target_gate": spaces.Discrete(n_gates + 1, start=-1),
         "target_gate_reverse": spaces.Box(low=0, high=1, shape=(), dtype=bool),
         "gates_pos": spaces.Box(low=-np.inf, high=np.inf, shape=(n_gates, 3)),
@@ -295,6 +297,8 @@ class RaceCoreEnv:
     * quat: Drone orientation as a quaternion (x, y, z, w)
     * vel: Drone linear velocity
     * ang_vel: Drone angular velocity
+    * race_progress: The current index in the configured gate order, or -1 if the track is
+      completed
     * gates_pos: Positions of the gates
     * gates_quat: Orientations of the gates
     * gates_visited: Flags indicating if the drone already was/ is in the sensor range of the
@@ -690,10 +694,10 @@ class RaceCoreEnv:
 
 def obs(data: EnvData) -> dict[str, Array]:
     """Return the observation of the environment."""
-    target_gate = data.gate_order_ids[data.gate_progress]
-    target_gate = jp.where(data.gate_progress < 0, -1, target_gate)
-    target_gate_reverse = data.gate_order_reverse[data.gate_progress]
-    target_gate_reverse = jp.where(data.gate_progress < 0, False, target_gate_reverse)
+    target_gate = data.gate_order_ids[data.race_progress]
+    target_gate = jp.where(data.race_progress < 0, -1, target_gate)
+    target_gate_reverse = data.gate_order_reverse[data.race_progress]
+    target_gate_reverse = jp.where(data.race_progress < 0, False, target_gate_reverse)
     mask = data.gates_visited[..., None]
     sensor_gates_pos = jp.where(mask, data.gates_pos[:, None], data.nominal_gates_pos[:, None])
     sensor_gates_quat = jp.where(mask, data.gates_quat[:, None], data.nominal_gates_quat[:, None])
@@ -706,6 +710,7 @@ def obs(data: EnvData) -> dict[str, Array]:
         "quat": data.sim_data.states.quat,
         "vel": data.sim_data.states.vel,
         "ang_vel": data.sim_data.states.ang_vel,
+        "race_progress": data.race_progress,
         "target_gate": target_gate,
         "target_gate_reverse": target_gate_reverse,
         "gates_pos": sensor_gates_pos,
@@ -727,7 +732,7 @@ def reward(data: EnvData) -> Array:
     Returns:
         Reward for the current state.
     """
-    return -1.0 * (data.gate_progress == -1)  # Implicit float conversion
+    return -1.0 * (data.race_progress == -1)  # Implicit float conversion
 
 
 def terminated(data: EnvData) -> Array:
@@ -746,7 +751,7 @@ def _reset_env_data(data: EnvData, mask: Array | None = None) -> EnvData:
     """Reset auxiliary variables of the environment data."""
     drone_pos = data.sim_data.states.pos
     mask = jp.ones(data.steps.shape, dtype=bool) if mask is None else mask
-    gate_progress = jp.where(mask[..., None], 0, data.gate_progress)
+    race_progress = jp.where(mask[..., None], 0, data.race_progress)
     last_drone_pos = jp.where(mask[..., None, None], drone_pos, data.last_drone_pos)
     disabled_drones = jp.where(mask[..., None], False, data.disabled_drones)
     steps = jp.where(mask, 0, data.steps)
@@ -760,7 +765,7 @@ def _reset_env_data(data: EnvData, mask: Array | None = None) -> EnvData:
     obstacles_visited = jp.linalg.norm(dpos, axis=-1) < data.sensor_range
     obstacles_visited = jp.where(mask[..., None, None], obstacles_visited, data.obstacles_visited)
     return data.replace(
-        gate_progress=gate_progress,
+        race_progress=race_progress,
         last_drone_pos=last_drone_pos,
         disabled_drones=disabled_drones,
         gates_visited=gates_visited,
@@ -791,15 +796,15 @@ def _update_target_gates(data: EnvData) -> EnvData:
     n_gate_passes = data.gate_order_ids.shape[0]
     gates_pos, gates_quat = data.gates_pos, data.gates_quat
     drone_pos = data.sim_data.states.pos
-    gate_ids = data.gate_order_ids[data.gate_progress]
-    reverse = data.gate_order_reverse[data.gate_progress]
+    gate_ids = data.gate_order_ids[data.race_progress]
+    reverse = data.gate_order_reverse[data.race_progress]
     gate_pos = gates_pos[jp.arange(gates_pos.shape[0])[:, None], gate_ids]
     gate_quat = gates_quat[jp.arange(gates_quat.shape[0])[:, None], gate_ids]
     passed = gate_passed(drone_pos, data.last_drone_pos, gate_pos, gate_quat, reverse, (0.45, 0.45))
     # Advance the gate-order progress by one if drones have passed the current waypoint.
-    gate_progress = data.gate_progress + passed * ~data.disabled_drones
-    gate_progress = jp.where(gate_progress >= n_gate_passes, -1, gate_progress)
-    return data.replace(gate_progress=gate_progress, last_drone_pos=data.sim_data.states.pos)
+    race_progress = data.race_progress + passed * ~data.disabled_drones
+    race_progress = jp.where(race_progress >= n_gate_passes, -1, race_progress)
+    return data.replace(race_progress=race_progress, last_drone_pos=data.sim_data.states.pos)
 
 
 def _mark_drones_for_reset(data: EnvData) -> EnvData:
@@ -848,7 +853,7 @@ def _disabled_drones(pos: Array, contacts: Array, data: EnvData) -> Array:
     not_in_platform |= jp.any(pos[..., :2] > data.takeoff_pos[..., :2] + 0.02, axis=-1)
     disabled = disabled | jp.any(pos < data.pos_limit_low, axis=-1) & not_in_platform
     disabled = disabled | jp.any(pos > data.pos_limit_high, axis=-1)
-    disabled = disabled | (data.gate_progress == -1)
+    disabled = disabled | (data.race_progress == -1)
     contacts = jp.any(contacts[:, :, None] & data.contact_masks, axis=-1)
     disabled = disabled | contacts
     return disabled

--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -795,19 +795,16 @@ def _update_visited_objects(data: EnvData) -> EnvData:
 
 
 def _update_target_gates(data: EnvData) -> EnvData:
-    """Update the waypoint progress based on the current gate-order entry."""
-    n_gate_passes = data.gate_sequence.shape[0]
+    """Update the number of passed gates based on the current target gate and the gate sequence."""
     gates_pos, gates_quat = data.gates_pos, data.gates_quat
     drone_pos = data.sim_data.states.pos
-    progress = jp.clip(data.n_gates_passed, 0, n_gate_passes - 1)
-    gate_ids = data.gate_sequence[progress]
-    reverse = data.gate_sequence_direction[progress] < 0
+    gate_ids = data.gate_sequence[data.n_gates_passed]
+    reverse = data.gate_sequence_direction[data.n_gates_passed] < 0
     gate_pos = gates_pos[jp.arange(gates_pos.shape[0])[:, None], gate_ids]
     gate_quat = gates_quat[jp.arange(gates_quat.shape[0])[:, None], gate_ids]
     passed = gate_passed(drone_pos, data.last_drone_pos, gate_pos, gate_quat, reverse, (0.45, 0.45))
     # Advance the gate-order progress by one if drones have passed the current waypoint.
-    increment = (passed & ~data.disabled_drones).astype(data.n_gates_passed.dtype)
-    n_gates_passed = jp.minimum(data.n_gates_passed + increment, n_gate_passes)
+    n_gates_passed = data.n_gates_passed + (passed & ~data.disabled_drones)
     return data.replace(n_gates_passed=n_gates_passed, last_drone_pos=data.sim_data.states.pos)
 
 

--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -698,6 +698,9 @@ class RaceCoreEnv:
 
 def obs(data: EnvData) -> dict[str, Array]:
     """Return the observation of the environment."""
+    gate_sequence_shape = (*data.n_gates_passed.shape, data.gate_sequence.shape[0])
+    gate_sequence = jp.broadcast_to(data.gate_sequence, gate_sequence_shape)
+    gate_sequence_direction = jp.broadcast_to(data.gate_sequence_direction, gate_sequence_shape)
     mask = data.gates_visited[..., None]
     sensor_gates_pos = jp.where(mask, data.gates_pos[:, None], data.nominal_gates_pos[:, None])
     sensor_gates_quat = jp.where(mask, data.gates_quat[:, None], data.nominal_gates_quat[:, None])
@@ -711,8 +714,8 @@ def obs(data: EnvData) -> dict[str, Array]:
         "vel": data.sim_data.states.vel,
         "ang_vel": data.sim_data.states.ang_vel,
         "n_gates_passed": data.n_gates_passed,
-        "gate_sequence": data.gate_sequence,
-        "gate_sequence_direction": data.gate_sequence_direction,
+        "gate_sequence": gate_sequence,
+        "gate_sequence_direction": gate_sequence_direction,
         "gates_pos": sensor_gates_pos,
         "gates_quat": sensor_gates_quat,
         "gates_visited": data.gates_visited,

--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -690,7 +690,10 @@ class RaceCoreEnv:
 
 def obs(data: EnvData) -> dict[str, Array]:
     """Return the observation of the environment."""
-    target_gate, target_gate_reverse = _target_gate_obs(data)
+    target_gate = data.gate_order_ids[data.gate_progress]
+    target_gate = jp.where(data.gate_progress < 0, -1, target_gate)
+    target_gate_reverse = data.gate_order_reverse[data.gate_progress]
+    target_gate_reverse = jp.where(data.gate_progress < 0, False, target_gate_reverse)
     mask = data.gates_visited[..., None]
     sensor_gates_pos = jp.where(mask, data.gates_pos[:, None], data.nominal_gates_pos[:, None])
     sensor_gates_quat = jp.where(mask, data.gates_quat[:, None], data.nominal_gates_quat[:, None])
@@ -788,9 +791,8 @@ def _update_target_gates(data: EnvData) -> EnvData:
     n_gate_passes = data.gate_order_ids.shape[0]
     gates_pos, gates_quat = data.gates_pos, data.gates_quat
     drone_pos = data.sim_data.states.pos
-    progress = jp.where(data.gate_progress < 0, 0, data.gate_progress)
-    gate_ids = data.gate_order_ids[progress]
-    reverse = data.gate_order_reverse[progress]
+    gate_ids = data.gate_order_ids[data.gate_progress]
+    reverse = data.gate_order_reverse[data.gate_progress]
     gate_pos = gates_pos[jp.arange(gates_pos.shape[0])[:, None], gate_ids]
     gate_quat = gates_quat[jp.arange(gates_quat.shape[0])[:, None], gate_ids]
     passed = gate_passed(drone_pos, data.last_drone_pos, gate_pos, gate_quat, reverse, (0.45, 0.45))
@@ -798,16 +800,6 @@ def _update_target_gates(data: EnvData) -> EnvData:
     gate_progress = data.gate_progress + passed * ~data.disabled_drones
     gate_progress = jp.where(gate_progress >= n_gate_passes, -1, gate_progress)
     return data.replace(gate_progress=gate_progress, last_drone_pos=data.sim_data.states.pos)
-
-
-def _target_gate_obs(data: EnvData) -> tuple[Array, Array]:
-    """Map internal waypoint progress to public observation fields."""
-    progress = jp.where(data.gate_progress < 0, 0, data.gate_progress)
-    gate_ids = data.gate_order_ids[progress]
-    reverse = data.gate_order_reverse[progress]
-    target_gate = jp.where(data.gate_progress < 0, -1, gate_ids)
-    target_gate_reverse = jp.where(data.gate_progress < 0, False, reverse)
-    return target_gate, target_gate_reverse
 
 
 def _mark_drones_for_reset(data: EnvData) -> EnvData:

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -213,14 +213,17 @@ class RealRaceCoreEnv:
         drone_quat = np.stack([self._ros_connector.quat[drone] for drone in self.drone_names])
         drone_vel = np.stack([self._ros_connector.vel[drone] for drone in self.drone_names])
         drone_ang_vel = np.stack([self._ros_connector.ang_vel[drone] for drone in self.drone_names])
+        gate_sequence_shape = (self.n_drones, self.gate_sequence.shape[0])
+        gate_sequence = np.broadcast_to(self.gate_sequence, gate_sequence_shape)
+        gate_sequence_direction = np.broadcast_to(self.gate_sequence_direction, gate_sequence_shape)
         obs = {
             "pos": drone_pos,
             "quat": drone_quat,
             "vel": drone_vel,
             "ang_vel": drone_ang_vel,
             "n_gates_passed": self.data.n_gates_passed,
-            "gate_sequence": self.gate_sequence,
-            "gate_sequence_direction": self.gate_sequence_direction,
+            "gate_sequence": gate_sequence,
+            "gate_sequence_direction": gate_sequence_direction,
             "gates_pos": gates_pos,
             "gates_quat": gates_quat,
             "gates_visited": self.data.gates_visited,

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -175,10 +175,8 @@ class RealRaceCoreEnv:
         dpos = drone_pos[:, None, :2] - self.obstacles.pos[None, :, :2]
         self.data.obstacles_visited |= np.linalg.norm(dpos, axis=-1) < self.sensor_range
 
-        n_gate_passes = self.gate_sequence.shape[0]
-        progress = np.clip(self.data.n_gates_passed, 0, n_gate_passes - 1)
-        gate_ids = self.gate_sequence[progress]
-        gate_reverse = self.gate_sequence_direction[progress] < 0
+        gate_ids = self.gate_sequence[self.data.n_gates_passed]
+        gate_reverse = self.gate_sequence_direction[self.data.n_gates_passed] < 0
         gate_pos = self.gates.pos[gate_ids]
         gate_quat = self.gates.quat[gate_ids]
 
@@ -186,8 +184,7 @@ class RealRaceCoreEnv:
             passed = gate_passed(
                 drone_pos, self.data.last_drone_pos, gate_pos, gate_quat, gate_reverse, (0.45, 0.45)
             )
-        increment = np.asarray(passed, dtype=self.data.n_gates_passed.dtype)
-        self.data.n_gates_passed = np.minimum(self.data.n_gates_passed + increment, n_gate_passes)
+        self.data.n_gates_passed = self.data.n_gates_passed + passed
         self.data.last_drone_pos[...] = drone_pos
         self.data.taken_off |= drone_pos[self.rank, 2] > 0.1
         # Send vicon position updates to the drone at a fixed frequency irrespective of the env freq

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -213,7 +213,10 @@ class RealRaceCoreEnv:
         drone_quat = np.stack([self._ros_connector.quat[drone] for drone in self.drone_names])
         drone_vel = np.stack([self._ros_connector.vel[drone] for drone in self.drone_names])
         drone_ang_vel = np.stack([self._ros_connector.ang_vel[drone] for drone in self.drone_names])
-        target_gate, target_gate_reverse = self._target_gate_obs()
+        target_gate = self.gate_order_ids[self.data.race_progress]
+        target_gate = np.where(self.data.race_progress < 0, -1, target_gate)
+        target_gate_reverse = self.gate_order_reverse[self.data.race_progress]
+        target_gate_reverse = np.where(self.data.race_progress < 0, False, target_gate_reverse)
         obs = {
             "pos": drone_pos,
             "quat": drone_quat,
@@ -261,15 +264,6 @@ class RealRaceCoreEnv:
     def info(self) -> dict:
         """Return an info dictionary containing additional information about the environment."""
         return {}
-
-    def _target_gate_obs(self) -> tuple[NDArray, NDArray]:
-        """Map internal waypoint progress to public observation fields."""
-        progress = np.where(self.data.race_progress < 0, 0, self.data.race_progress)
-        target_gate = self.gate_order_ids[progress]
-        target_gate = np.where(self.data.race_progress < 0, -1, target_gate)
-        target_gate_reverse = self.gate_order_reverse[progress]
-        target_gate_reverse = np.where(self.data.race_progress < 0, False, target_gate_reverse)
-        return target_gate, target_gate_reverse
 
     def _update_track_poses(self):
         """Update the track poses from the motion capture system."""

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -19,7 +19,7 @@ from drone_estimators.ros_nodes.ros2_connector import ROSConnector
 from drone_models.core import load_params
 from gymnasium import Env
 
-from lsy_drone_racing.envs.utils import gate_passed, load_track
+from lsy_drone_racing.envs.utils import gate_passed, load_gate_order, load_track
 from lsy_drone_racing.utils.checks import check_drone_start_pos, check_race_track
 from lsy_drone_racing.utils.crazyflie import Crazyflie
 
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 class EnvData:
     """Struct holding the data of all auxiliary variables for the environment."""
 
-    target_gate: NDArray
+    gate_progress: NDArray
     gates_visited: NDArray
     obstacles_visited: NDArray
     last_drone_pos: NDArray[np.float32]
@@ -42,7 +42,7 @@ class EnvData:
     def create(cls, n_drones: int, n_gates: int, n_obstacles: int) -> EnvData:
         """Create an instance of the EnvData class."""
         return EnvData(
-            target_gate=np.zeros(n_drones, dtype=int),
+            gate_progress=np.zeros(n_drones, dtype=int),
             gates_visited=np.zeros((n_drones, n_gates), dtype=bool),
             obstacles_visited=np.zeros((n_drones, n_obstacles), dtype=bool),
             last_drone_pos=np.zeros((n_drones, 3), dtype=np.float32),
@@ -50,7 +50,7 @@ class EnvData:
 
     def reset(self, last_drone_pos: NDArray[np.float32]):
         """Reset the environment data."""
-        self.target_gate[...] = 0
+        self.gate_progress[...] = 0
         self.gates_visited[...] = False
         self.obstacles_visited[...] = False
         self.last_drone_pos[...] = last_drone_pos
@@ -94,6 +94,8 @@ class RealRaceCoreEnv:
         self.n_drones = len(drones)
         self.gates, self.obstacles, self.drones = load_track(track)
         self.n_gates = len(self.gates.pos)
+        self.gate_order_ids, self.gate_order_reverse = load_gate_order(track, self.n_gates)
+        self.n_gate_passes = len(self.gate_order_ids)
         self.n_obstacles = len(self.obstacles.pos)
         self.pos_limit_low = np.array(track.safety_limits["pos_limit_low"])
         self.pos_limit_high = np.array(track.safety_limits["pos_limit_high"])
@@ -174,15 +176,26 @@ class RealRaceCoreEnv:
         dpos = drone_pos[:, None, :2] - self.obstacles.pos[None, :, :2]
         self.data.obstacles_visited |= np.linalg.norm(dpos, axis=-1) < self.sensor_range
 
-        gate_pos = self.gates.pos[self.data.target_gate]
-        gate_quat = self.gates.quat[self.data.target_gate]
+        progress = np.where(self.data.gate_progress < 0, 0, self.data.gate_progress)
+        gate_ids = self.gate_order_ids[progress]
+        gate_reverse = self.gate_order_reverse[progress]
+        gate_pos = self.gates.pos[gate_ids]
+        gate_quat = self.gates.quat[gate_ids]
 
         with jax.default_device(self.device):  # Ensure gate_passed runs on the CPU
             passed = gate_passed(
-                drone_pos, self.data.last_drone_pos, gate_pos, gate_quat, (0.45, 0.45)
+                drone_pos,
+                self.data.last_drone_pos,
+                gate_pos,
+                gate_quat,
+                gate_reverse,
+                (0.45, 0.45),
             )
-        self.data.target_gate += np.asarray(passed)
-        self.data.target_gate[self.data.target_gate >= self.n_gates] = -1
+        active = self.data.gate_progress >= 0
+        self.data.gate_progress = np.where(
+            active, self.data.gate_progress + np.asarray(passed), -1
+        )
+        self.data.gate_progress[self.data.gate_progress >= self.n_gate_passes] = -1
         self.data.last_drone_pos[...] = drone_pos
         self.data.taken_off |= drone_pos[self.rank, 2] > 0.1
         # Send vicon position updates to the drone at a fixed frequency irrespective of the env freq
@@ -208,12 +221,14 @@ class RealRaceCoreEnv:
         drone_quat = np.stack([self._ros_connector.quat[drone] for drone in self.drone_names])
         drone_vel = np.stack([self._ros_connector.vel[drone] for drone in self.drone_names])
         drone_ang_vel = np.stack([self._ros_connector.ang_vel[drone] for drone in self.drone_names])
+        target_gate, target_gate_reverse = self._target_gate_obs()
         obs = {
             "pos": drone_pos,
             "quat": drone_quat,
             "vel": drone_vel,
             "ang_vel": drone_ang_vel,
-            "target_gate": self.data.target_gate,
+            "target_gate": target_gate,
+            "target_gate_reverse": target_gate_reverse,
             "gates_pos": gates_pos,
             "gates_quat": gates_quat,
             "gates_visited": self.data.gates_visited,
@@ -233,11 +248,11 @@ class RealRaceCoreEnv:
         Returns:
             Reward for the current state.
         """
-        return -1.0 * (self.data.target_gate == -1)  # Implicit float conversion
+        return -1.0 * (self.data.gate_progress == -1)  # Implicit float conversion
 
     def terminated(self) -> NDArray:
         """Check if the episode is terminated."""
-        terminated = self.data.target_gate == -1
+        terminated = self.data.gate_progress == -1
         terminated[self.rank] |= not self.drone.is_connected
         terminated |= np.any(
             (self.pos_limit_low > self.data.last_drone_pos)
@@ -253,6 +268,15 @@ class RealRaceCoreEnv:
     def info(self) -> dict:
         """Return an info dictionary containing additional information about the environment."""
         return {}
+
+    def _target_gate_obs(self) -> tuple[NDArray, NDArray]:
+        """Map internal waypoint progress to public observation fields."""
+        progress = np.where(self.data.gate_progress < 0, 0, self.data.gate_progress)
+        target_gate = self.gate_order_ids[progress]
+        target_gate = np.where(self.data.gate_progress < 0, -1, target_gate)
+        target_gate_reverse = self.gate_order_reverse[progress]
+        target_gate_reverse = np.where(self.data.gate_progress < 0, False, target_gate_reverse)
+        return target_gate, target_gate_reverse
 
     def _update_track_poses(self):
         """Update the track poses from the motion capture system."""
@@ -286,9 +310,10 @@ class RealRaceCoreEnv:
         drone_pos = np.zeros((self.n_drones, 3), dtype=np.float32)
         gate_pos = np.zeros((self.n_drones, 3), dtype=np.float32)
         gate_quat = np.zeros((self.n_drones, 4), dtype=np.float32)
+        reverse = np.zeros(self.n_drones, dtype=bool)
         with jax.default_device(self.device):
             jax.block_until_ready(
-                gate_passed(drone_pos, drone_pos, gate_pos, gate_quat, (0.45, 0.45))
+                gate_passed(drone_pos, drone_pos, gate_pos, gate_quat, reverse, (0.45, 0.45))
             )
 
     def close(self):
@@ -359,7 +384,9 @@ class RealDroneRaceEnv(RealRaceCoreEnv, Env):
         Observation space:
             The observation space is a dictionary containing the state of all drones in the race.
             It mimics exactly the observation space of
-            [lsy_drone_racing.envs.drone_race.DroneRaceEnv][].
+            [lsy_drone_racing.envs.drone_race.DroneRaceEnv][]. In particular, `target_gate`
+            reports the next gate's 0-based ID and `target_gate_reverse` reports whether that gate
+            must be passed in reverse direction.
 
         Note:
             rclpy must be initialized before creating this environment.
@@ -435,7 +462,9 @@ class RealMultiDroneRaceEnv(RealRaceCoreEnv, Env):
     Observation space:
         The observation space is a dictionary containing the state of all drones in the race.
         It mimics exactly the observation space of
-        [lsy_drone_racing.envs.multi_drone_race.MultiDroneRaceEnv][].
+        [lsy_drone_racing.envs.multi_drone_race.MultiDroneRaceEnv][]. In particular,
+        `target_gate` reports the next gate's 0-based ID and `target_gate_reverse` reports whether
+        that gate must be passed in reverse direction.
 
     Note:
         Each instance of this environment controls only one drone (specified by rank), but provides

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 class EnvData:
     """Struct holding the data of all auxiliary variables for the environment."""
 
-    gate_progress: NDArray
+    race_progress: NDArray
     gates_visited: NDArray
     obstacles_visited: NDArray
     last_drone_pos: NDArray[np.float32]
@@ -42,7 +42,7 @@ class EnvData:
     def create(cls, n_drones: int, n_gates: int, n_obstacles: int) -> EnvData:
         """Create an instance of the EnvData class."""
         return EnvData(
-            gate_progress=np.zeros(n_drones, dtype=int),
+            race_progress=np.zeros(n_drones, dtype=int),
             gates_visited=np.zeros((n_drones, n_gates), dtype=bool),
             obstacles_visited=np.zeros((n_drones, n_obstacles), dtype=bool),
             last_drone_pos=np.zeros((n_drones, 3), dtype=np.float32),
@@ -50,7 +50,7 @@ class EnvData:
 
     def reset(self, last_drone_pos: NDArray[np.float32]):
         """Reset the environment data."""
-        self.gate_progress[...] = 0
+        self.race_progress[...] = 0
         self.gates_visited[...] = False
         self.obstacles_visited[...] = False
         self.last_drone_pos[...] = last_drone_pos
@@ -176,8 +176,8 @@ class RealRaceCoreEnv:
         dpos = drone_pos[:, None, :2] - self.obstacles.pos[None, :, :2]
         self.data.obstacles_visited |= np.linalg.norm(dpos, axis=-1) < self.sensor_range
 
-        gate_ids = self.gate_order_ids[self.data.gate_progress]
-        gate_reverse = self.gate_order_reverse[self.data.gate_progress]
+        gate_ids = self.gate_order_ids[self.data.race_progress]
+        gate_reverse = self.gate_order_reverse[self.data.race_progress]
         gate_pos = self.gates.pos[gate_ids]
         gate_quat = self.gates.quat[gate_ids]
 
@@ -185,9 +185,9 @@ class RealRaceCoreEnv:
             passed = gate_passed(
                 drone_pos, self.data.last_drone_pos, gate_pos, gate_quat, gate_reverse, (0.45, 0.45)
             )
-        active = self.data.gate_progress >= 0
-        self.data.gate_progress = np.where(active, self.data.gate_progress + np.asarray(passed), -1)
-        self.data.gate_progress[self.data.gate_progress >= self.n_gate_passes] = -1
+        active = self.data.race_progress >= 0
+        self.data.race_progress = np.where(active, self.data.race_progress + np.asarray(passed), -1)
+        self.data.race_progress[self.data.race_progress >= self.n_gate_passes] = -1
         self.data.last_drone_pos[...] = drone_pos
         self.data.taken_off |= drone_pos[self.rank, 2] > 0.1
         # Send vicon position updates to the drone at a fixed frequency irrespective of the env freq
@@ -213,15 +213,13 @@ class RealRaceCoreEnv:
         drone_quat = np.stack([self._ros_connector.quat[drone] for drone in self.drone_names])
         drone_vel = np.stack([self._ros_connector.vel[drone] for drone in self.drone_names])
         drone_ang_vel = np.stack([self._ros_connector.ang_vel[drone] for drone in self.drone_names])
-        target_gate = self.gate_order_ids[self.data.gate_progress]
-        target_gate = np.where(self.data.gate_progress < 0, -1, target_gate)
-        target_gate_reverse = self.gate_order_reverse[self.data.gate_progress]
-        target_gate_reverse = np.where(self.data.gate_progress < 0, False, target_gate_reverse)
+        target_gate, target_gate_reverse = self._target_gate_obs()
         obs = {
             "pos": drone_pos,
             "quat": drone_quat,
             "vel": drone_vel,
             "ang_vel": drone_ang_vel,
+            "race_progress": self.data.race_progress,
             "target_gate": target_gate,
             "target_gate_reverse": target_gate_reverse,
             "gates_pos": gates_pos,
@@ -243,11 +241,11 @@ class RealRaceCoreEnv:
         Returns:
             Reward for the current state.
         """
-        return -1.0 * (self.data.gate_progress == -1)  # Implicit float conversion
+        return -1.0 * (self.data.race_progress == -1)  # Implicit float conversion
 
     def terminated(self) -> NDArray:
         """Check if the episode is terminated."""
-        terminated = self.data.gate_progress == -1
+        terminated = self.data.race_progress == -1
         terminated[self.rank] |= not self.drone.is_connected
         terminated |= np.any(
             (self.pos_limit_low > self.data.last_drone_pos)
@@ -266,11 +264,11 @@ class RealRaceCoreEnv:
 
     def _target_gate_obs(self) -> tuple[NDArray, NDArray]:
         """Map internal waypoint progress to public observation fields."""
-        progress = np.where(self.data.gate_progress < 0, 0, self.data.gate_progress)
+        progress = np.where(self.data.race_progress < 0, 0, self.data.race_progress)
         target_gate = self.gate_order_ids[progress]
-        target_gate = np.where(self.data.gate_progress < 0, -1, target_gate)
+        target_gate = np.where(self.data.race_progress < 0, -1, target_gate)
         target_gate_reverse = self.gate_order_reverse[progress]
-        target_gate_reverse = np.where(self.data.gate_progress < 0, False, target_gate_reverse)
+        target_gate_reverse = np.where(self.data.race_progress < 0, False, target_gate_reverse)
         return target_gate, target_gate_reverse
 
     def _update_track_poses(self):

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -379,9 +379,7 @@ class RealDroneRaceEnv(RealRaceCoreEnv, Env):
         Observation space:
             The observation space is a dictionary containing the state of all drones in the race.
             It mimics exactly the observation space of
-            [lsy_drone_racing.envs.drone_race.DroneRaceEnv][]. In particular, `target_gate`
-            reports the next gate's 0-based ID and `target_gate_reverse` reports whether that gate
-            must be passed in reverse direction.
+            [lsy_drone_racing.envs.drone_race.DroneRaceEnv][].
 
         Note:
             rclpy must be initialized before creating this environment.
@@ -457,9 +455,7 @@ class RealMultiDroneRaceEnv(RealRaceCoreEnv, Env):
     Observation space:
         The observation space is a dictionary containing the state of all drones in the race.
         It mimics exactly the observation space of
-        [lsy_drone_racing.envs.multi_drone_race.MultiDroneRaceEnv][]. In particular,
-        `target_gate` reports the next gate's 0-based ID and `target_gate_reverse` reports whether
-        that gate must be passed in reverse direction.
+        [lsy_drone_racing.envs.multi_drone_race.MultiDroneRaceEnv][].
 
     Note:
         Each instance of this environment controls only one drone (specified by rank), but provides

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -176,25 +176,17 @@ class RealRaceCoreEnv:
         dpos = drone_pos[:, None, :2] - self.obstacles.pos[None, :, :2]
         self.data.obstacles_visited |= np.linalg.norm(dpos, axis=-1) < self.sensor_range
 
-        progress = np.where(self.data.gate_progress < 0, 0, self.data.gate_progress)
-        gate_ids = self.gate_order_ids[progress]
-        gate_reverse = self.gate_order_reverse[progress]
+        gate_ids = self.gate_order_ids[self.data.gate_progress]
+        gate_reverse = self.gate_order_reverse[self.data.gate_progress]
         gate_pos = self.gates.pos[gate_ids]
         gate_quat = self.gates.quat[gate_ids]
 
         with jax.default_device(self.device):  # Ensure gate_passed runs on the CPU
             passed = gate_passed(
-                drone_pos,
-                self.data.last_drone_pos,
-                gate_pos,
-                gate_quat,
-                gate_reverse,
-                (0.45, 0.45),
+                drone_pos, self.data.last_drone_pos, gate_pos, gate_quat, gate_reverse, (0.45, 0.45)
             )
         active = self.data.gate_progress >= 0
-        self.data.gate_progress = np.where(
-            active, self.data.gate_progress + np.asarray(passed), -1
-        )
+        self.data.gate_progress = np.where(active, self.data.gate_progress + np.asarray(passed), -1)
         self.data.gate_progress[self.data.gate_progress >= self.n_gate_passes] = -1
         self.data.last_drone_pos[...] = drone_pos
         self.data.taken_off |= drone_pos[self.rank, 2] > 0.1
@@ -221,7 +213,10 @@ class RealRaceCoreEnv:
         drone_quat = np.stack([self._ros_connector.quat[drone] for drone in self.drone_names])
         drone_vel = np.stack([self._ros_connector.vel[drone] for drone in self.drone_names])
         drone_ang_vel = np.stack([self._ros_connector.ang_vel[drone] for drone in self.drone_names])
-        target_gate, target_gate_reverse = self._target_gate_obs()
+        target_gate = self.gate_order_ids[self.data.gate_progress]
+        target_gate = np.where(self.data.gate_progress < 0, -1, target_gate)
+        target_gate_reverse = self.gate_order_reverse[self.data.gate_progress]
+        target_gate_reverse = np.where(self.data.gate_progress < 0, False, target_gate_reverse)
         obs = {
             "pos": drone_pos,
             "quat": drone_quat,

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 class EnvData:
     """Struct holding the data of all auxiliary variables for the environment."""
 
-    race_progress: NDArray
+    n_gates_passed: NDArray
     gates_visited: NDArray
     obstacles_visited: NDArray
     last_drone_pos: NDArray[np.float32]
@@ -42,7 +42,7 @@ class EnvData:
     def create(cls, n_drones: int, n_gates: int, n_obstacles: int) -> EnvData:
         """Create an instance of the EnvData class."""
         return EnvData(
-            race_progress=np.zeros(n_drones, dtype=int),
+            n_gates_passed=np.zeros(n_drones, dtype=int),
             gates_visited=np.zeros((n_drones, n_gates), dtype=bool),
             obstacles_visited=np.zeros((n_drones, n_obstacles), dtype=bool),
             last_drone_pos=np.zeros((n_drones, 3), dtype=np.float32),
@@ -50,7 +50,7 @@ class EnvData:
 
     def reset(self, last_drone_pos: NDArray[np.float32]):
         """Reset the environment data."""
-        self.race_progress[...] = 0
+        self.n_gates_passed[...] = 0
         self.gates_visited[...] = False
         self.obstacles_visited[...] = False
         self.last_drone_pos[...] = last_drone_pos
@@ -94,8 +94,7 @@ class RealRaceCoreEnv:
         self.n_drones = len(drones)
         self.gates, self.obstacles, self.drones = load_track(track)
         self.n_gates = len(self.gates.pos)
-        self.gate_order_ids, self.gate_order_reverse = load_gate_order(track, self.n_gates)
-        self.n_gate_passes = len(self.gate_order_ids)
+        self.gate_sequence, self.gate_sequence_direction = load_gate_order(track, self.n_gates)
         self.n_obstacles = len(self.obstacles.pos)
         self.pos_limit_low = np.array(track.safety_limits["pos_limit_low"])
         self.pos_limit_high = np.array(track.safety_limits["pos_limit_high"])
@@ -176,8 +175,10 @@ class RealRaceCoreEnv:
         dpos = drone_pos[:, None, :2] - self.obstacles.pos[None, :, :2]
         self.data.obstacles_visited |= np.linalg.norm(dpos, axis=-1) < self.sensor_range
 
-        gate_ids = self.gate_order_ids[self.data.race_progress]
-        gate_reverse = self.gate_order_reverse[self.data.race_progress]
+        n_gate_passes = self.gate_sequence.shape[0]
+        progress = np.clip(self.data.n_gates_passed, 0, n_gate_passes - 1)
+        gate_ids = self.gate_sequence[progress]
+        gate_reverse = self.gate_sequence_direction[progress] < 0
         gate_pos = self.gates.pos[gate_ids]
         gate_quat = self.gates.quat[gate_ids]
 
@@ -185,9 +186,8 @@ class RealRaceCoreEnv:
             passed = gate_passed(
                 drone_pos, self.data.last_drone_pos, gate_pos, gate_quat, gate_reverse, (0.45, 0.45)
             )
-        active = self.data.race_progress >= 0
-        self.data.race_progress = np.where(active, self.data.race_progress + np.asarray(passed), -1)
-        self.data.race_progress[self.data.race_progress >= self.n_gate_passes] = -1
+        increment = np.asarray(passed, dtype=self.data.n_gates_passed.dtype)
+        self.data.n_gates_passed = np.minimum(self.data.n_gates_passed + increment, n_gate_passes)
         self.data.last_drone_pos[...] = drone_pos
         self.data.taken_off |= drone_pos[self.rank, 2] > 0.1
         # Send vicon position updates to the drone at a fixed frequency irrespective of the env freq
@@ -213,18 +213,14 @@ class RealRaceCoreEnv:
         drone_quat = np.stack([self._ros_connector.quat[drone] for drone in self.drone_names])
         drone_vel = np.stack([self._ros_connector.vel[drone] for drone in self.drone_names])
         drone_ang_vel = np.stack([self._ros_connector.ang_vel[drone] for drone in self.drone_names])
-        target_gate = self.gate_order_ids[self.data.race_progress]
-        target_gate = np.where(self.data.race_progress < 0, -1, target_gate)
-        target_gate_reverse = self.gate_order_reverse[self.data.race_progress]
-        target_gate_reverse = np.where(self.data.race_progress < 0, False, target_gate_reverse)
         obs = {
             "pos": drone_pos,
             "quat": drone_quat,
             "vel": drone_vel,
             "ang_vel": drone_ang_vel,
-            "race_progress": self.data.race_progress,
-            "target_gate": target_gate,
-            "target_gate_reverse": target_gate_reverse,
+            "n_gates_passed": self.data.n_gates_passed,
+            "gate_sequence": self.gate_sequence,
+            "gate_sequence_direction": self.gate_sequence_direction,
             "gates_pos": gates_pos,
             "gates_quat": gates_quat,
             "gates_visited": self.data.gates_visited,
@@ -244,11 +240,11 @@ class RealRaceCoreEnv:
         Returns:
             Reward for the current state.
         """
-        return -1.0 * (self.data.race_progress == -1)  # Implicit float conversion
+        return -1.0 * (self.data.n_gates_passed >= self.gate_sequence.shape[0])
 
     def terminated(self) -> NDArray:
         """Check if the episode is terminated."""
-        terminated = self.data.race_progress == -1
+        terminated = self.data.n_gates_passed >= self.gate_sequence.shape[0]
         terminated[self.rank] |= not self.drone.is_connected
         terminated |= np.any(
             (self.pos_limit_low > self.data.last_drone_pos)

--- a/lsy_drone_racing/envs/utils.py
+++ b/lsy_drone_racing/envs/utils.py
@@ -71,13 +71,12 @@ def load_gate_order(track: ConfigDict, n_gates: int) -> tuple[np.ndarray, np.nda
     gate_order = np.asarray(track["gate_order"], dtype=np.int32)
     assert gate_order.ndim == 1, "track.gate_order must be a 1D list of signed integers."
     assert gate_order.size > 0, "track.gate_order must be a non-empty list."
-    assert not np.any(gate_order == 0), "track.gate_order must not contain 0. "
+    assert not np.any(gate_order == 0), "track.gate_order must not contain 0."
+    assert not np.any(np.abs(gate_order) > n_gates), (
+        "track.gate_order must not contain gate indices greater than the number of gates."
+    )
     gate_sequence = np.abs(gate_order) - 1
-    if np.any(gate_sequence < 0) or np.any(gate_sequence >= n_gates):
-        raise ValueError(
-            f"track.gate_order must reference gate numbers in the interval [1, {n_gates})."
-        )
-    gate_sequence_direction = np.where(gate_order < 0, -1, 1).astype(np.int32)
+    gate_sequence_direction = np.sign(gate_order)
     return gate_sequence, gate_sequence_direction
 
 
@@ -119,11 +118,9 @@ def gate_passed(
     pos_local = gate_rot.apply(drone_pos - gate_pos, inverse=True)
     # Check the plane intersection. If passed, calculate the point of the intersection and check if
     # it is within the gate box.
-    passed_plane = jp.where(
-        reverse,
-        (last_pos_local[0] > 0) & (pos_local[0] < 0),
-        (last_pos_local[0] < 0) & (pos_local[0] > 0),
-    )
+    passed_plane_fwd = (last_pos_local[0] < 0) & (pos_local[0] > 0)
+    passed_plane_rev = (last_pos_local[0] > 0) & (pos_local[0] < 0)
+    passed_plane = jp.where(reverse, passed_plane_rev, passed_plane_fwd)
     alpha = -last_pos_local[0] / (pos_local[0] - last_pos_local[0])
     y_intersect = alpha * (pos_local[1]) + (1 - alpha) * last_pos_local[1]
     z_intersect = alpha * (pos_local[2]) + (1 - alpha) * last_pos_local[2]

--- a/lsy_drone_racing/envs/utils.py
+++ b/lsy_drone_racing/envs/utils.py
@@ -6,6 +6,7 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 import jax
+import jax.numpy as jp
 import numpy as np
 from jax.numpy import vectorize
 from ml_collections import ConfigDict
@@ -51,23 +52,51 @@ def load_track(track: ConfigDict) -> tuple[ConfigDict, ConfigDict, ConfigDict]:
     return ConfigDict(gates), ConfigDict(obstacles), ConfigDict(drones)
 
 
+def load_gate_order(track: ConfigDict, n_gates: int) -> tuple[np.ndarray, np.ndarray]:
+    """Load the gate order from a track config.
+
+    The gate order is a signed, 1-based list. Positive values denote a forward pass through the
+    gate, negative values denote a reverse pass, and duplicate gate entries are allowed.
+
+    Args:
+        track: The track config dict.
+        n_gates: Number of physical gates in the track.
+
+    Returns:
+        A tuple ``(gate_order_ids, gate_order_reverse)`` with 0-based gate IDs and reverse flags.
+    """
+    assert "gate_order" in track, "Track must contain gate_order field."
+    gate_order = np.asarray(track["gate_order"], dtype=np.int32)
+    assert gate_order.ndim == 1, "track.gate_order must be a 1D list of signed integers."
+    assert gate_order.size > 0, "track.gate_order must be a non-empty list."
+    assert not np.any(gate_order == 0), "track.gate_order must not contain 0. "
+    gate_ids = np.abs(gate_order) - 1
+    if np.any(gate_ids < 0) or np.any(gate_ids >= n_gates):
+        raise ValueError(
+            f"track.gate_order must reference gate numbers in the interval [1, {n_gates})."
+        )
+    return gate_ids, gate_order < 0
+
+
 @jax.jit
-@partial(vectorize, signature="(3),(3),(3),(4)->()", excluded=[4])
+@partial(vectorize, signature="(3),(3),(3),(4),()->()", excluded=[5])
 def gate_passed(
     drone_pos: Array,
     last_drone_pos: Array,
     gate_pos: Array,
     gate_quat: Array,
+    reverse: Array | bool,
     gate_size: tuple[float, float],
 ) -> bool:
     """Check if the drone has passed the current gate.
 
-    We transform the position of the drone into the reference frame of the current gate. Gates have
-    to be crossed in the direction of the x-Axis (pointing from -x to +x). Therefore, we check if x
-    has changed from negative to positive. If so, the drone has crossed the plane spanned by the
-    gate frame. We then check if the drone has passed the plane within the gate frame, i.e. the y
-    and z box boundaries. First, we linearly interpolate to get the y and z coordinates of the
-    intersection with the gate plane. Then we check if the intersection is within the gate box.
+    We transform the position of the drone into the reference frame of the current gate. Gates
+    have to be crossed along their x-axis. Forward passes cross from -x to +x, reverse passes from
+    +x to -x. We therefore check if the local x coordinate changes sign in the desired direction.
+    If so, the drone has crossed the plane spanned by the gate frame. We then check if the drone
+    has passed the plane within the gate frame, i.e. the y and z box boundaries. First, we linearly
+    interpolate to get the y and z coordinates of the intersection with the gate plane. Then we
+    check if the intersection is within the gate box.
 
     Note:
         We need to recalculate the last drone position each time as the transform changes if the
@@ -78,6 +107,7 @@ def gate_passed(
         last_drone_pos: The position of the drone in the world frame at the last time step.
         gate_pos: The position of the gate in the world frame.
         gate_quat: The rotation of the gate as an xyzw quaternion.
+        reverse: Whether the gate has to be passed in reverse direction (+x to -x).
         gate_size: The size of the gate box in meters.
     """
     # Transform last and current drone position into current gate frame.
@@ -86,7 +116,11 @@ def gate_passed(
     pos_local = gate_rot.apply(drone_pos - gate_pos, inverse=True)
     # Check the plane intersection. If passed, calculate the point of the intersection and check if
     # it is within the gate box.
-    passed_plane = (last_pos_local[0] < 0) & (pos_local[0] > 0)
+    passed_plane = jp.where(
+        reverse,
+        (last_pos_local[0] > 0) & (pos_local[0] < 0),
+        (last_pos_local[0] < 0) & (pos_local[0] > 0),
+    )
     alpha = -last_pos_local[0] / (pos_local[0] - last_pos_local[0])
     y_intersect = alpha * (pos_local[1]) + (1 - alpha) * last_pos_local[1]
     z_intersect = alpha * (pos_local[2]) + (1 - alpha) * last_pos_local[2]

--- a/lsy_drone_racing/envs/utils.py
+++ b/lsy_drone_racing/envs/utils.py
@@ -63,19 +63,22 @@ def load_gate_order(track: ConfigDict, n_gates: int) -> tuple[np.ndarray, np.nda
         n_gates: Number of physical gates in the track.
 
     Returns:
-        A tuple ``(gate_order_ids, gate_order_reverse)`` with 0-based gate IDs and reverse flags.
+        A tuple ``(gate_sequence, gate_sequence_direction)`` with 0-based gate IDs and signed pass
+        directions. ``1`` indicates the positive gate-frame crossing direction, ``-1`` the reverse
+        direction.
     """
     assert "gate_order" in track, "Track must contain gate_order field."
     gate_order = np.asarray(track["gate_order"], dtype=np.int32)
     assert gate_order.ndim == 1, "track.gate_order must be a 1D list of signed integers."
     assert gate_order.size > 0, "track.gate_order must be a non-empty list."
     assert not np.any(gate_order == 0), "track.gate_order must not contain 0. "
-    gate_ids = np.abs(gate_order) - 1
-    if np.any(gate_ids < 0) or np.any(gate_ids >= n_gates):
+    gate_sequence = np.abs(gate_order) - 1
+    if np.any(gate_sequence < 0) or np.any(gate_sequence >= n_gates):
         raise ValueError(
             f"track.gate_order must reference gate numbers in the interval [1, {n_gates})."
         )
-    return gate_ids, gate_order < 0
+    gate_sequence_direction = np.where(gate_order < 0, -1, 1).astype(np.int32)
+    return gate_sequence, gate_sequence_direction
 
 
 @jax.jit

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -73,7 +73,7 @@ def main(config: str = "level2.toml", controller: str | None = None):
                 exc = dt - 1 / config.env.freq
                 logger.warning(f"Controller execution time exceeded loop frequency by {exc:.3f}s.")
         ep_time = time.perf_counter() - start_time
-        finished_track = next_obs["target_gate"] == -1
+        finished_track = next_obs["n_gates_passed"] == next_obs["gate_sequence"].shape[0]
         logger.info(f"Track time: {ep_time:.3f}s" if finished_track else "Task not completed")
     finally:
         env.close()

--- a/scripts/multi_deploy.py
+++ b/scripts/multi_deploy.py
@@ -86,7 +86,7 @@ def control_loop(rank: int, config: ConfigDict, start_barrier: Barrier):
                     throttle_duration_sec=2,
                 )
         ep_time = time.perf_counter() - start_time
-        finished_track = (next_obs["target_gate"] == -1)[rank]
+        finished_track = (next_obs["n_gates_passed"] == next_obs["gate_sequence"].shape[-1])[rank]
         print(f"Track time: {ep_time:.3f}s" if finished_track else "Task not completed")
     finally:
         node.destroy_node()

--- a/scripts/multi_sim.py
+++ b/scripts/multi_sim.py
@@ -118,9 +118,8 @@ def simulate(
 
             obs, reward, terminated, truncated, info = env.step(actions)
 
-            newly_finished = (obs["n_gates_passed"] == obs["gate_sequence"].shape[-1]) & np.isnan(
-                finish_times
-            )
+            track_len = obs["gate_sequence"].shape[-1]
+            newly_finished = (obs["n_gates_passed"] == track_len) & np.isnan(finish_times)
             finish_times[newly_finished] = curr_time
             # Update the controllers' internal state and models.
             for rank, (ctrl, ctrl_info) in enumerate(zip(controller_instances, ranked_infos)):

--- a/scripts/multi_sim.py
+++ b/scripts/multi_sim.py
@@ -149,19 +149,29 @@ def simulate(
         for ctrl in controller_instances:
             ctrl.episode_callback()  # Update the controller internal state and models.
             ctrl.episode_reset()
-        log_episode_stats(obs, config, finish_times, controller_names)
+        log_episode_stats(
+            obs,
+            config,
+            finish_times,
+            controller_names,
+            np.asarray(env.unwrapped.data.gate_progress[0]),
+        )
 
     # Close the environment
     env.close()
 
 
 def log_episode_stats(
-    obs: dict, config: ConfigDict, finish_times: np.ndarray, controller_names: list[str]
+    obs: dict,
+    config: ConfigDict,
+    finish_times: np.ndarray,
+    controller_names: list[str],
+    race_progress: np.ndarray,
 ):
     """Log the statistics of a single episode."""
-    gates_passed = obs["target_gate"]
-    finished = gates_passed == -1
-    gates_passed = np.where(gates_passed == -1, len(config.env.track.gates), gates_passed)
+    n_gate_passes = len(config.env.track.get("gate_order", config.env.track.gates))
+    finished = race_progress == -1
+    gates_passed = np.where(finished, n_gate_passes, race_progress)
     time_strings = ["N/A" if np.isnan(t) else f"{t:.2f}" for t in finish_times]
     name_width = max(len("controller"), max(len(name) for name in controller_names))
     time_width = max(len("time [s]"), max(len(time_str) for time_str in time_strings))

--- a/scripts/multi_sim.py
+++ b/scripts/multi_sim.py
@@ -22,8 +22,6 @@ from gymnasium.wrappers.jax_to_numpy import JaxToNumpy
 from lsy_drone_racing.utils import load_config, load_controller
 
 if TYPE_CHECKING:
-    from ml_collections import ConfigDict
-
     from lsy_drone_racing.control.controller import Controller
     from lsy_drone_racing.envs.multi_drone_race import MultiDroneRacingEnv
 

--- a/scripts/multi_sim.py
+++ b/scripts/multi_sim.py
@@ -120,7 +120,9 @@ def simulate(
 
             obs, reward, terminated, truncated, info = env.step(actions)
 
-            newly_finished = (obs["race_progress"] == -1) & np.isnan(finish_times)
+            newly_finished = (obs["n_gates_passed"] == obs["gate_sequence"].shape[-1]) & np.isnan(
+                finish_times
+            )
             finish_times[newly_finished] = curr_time
             # Update the controllers' internal state and models.
             for rank, (ctrl, ctrl_info) in enumerate(zip(controller_instances, ranked_infos)):
@@ -149,20 +151,15 @@ def simulate(
         for ctrl in controller_instances:
             ctrl.episode_callback()  # Update the controller internal state and models.
             ctrl.episode_reset()
-        log_episode_stats(obs, config, finish_times, controller_names)
+        log_episode_stats(obs, finish_times, controller_names)
 
     # Close the environment
     env.close()
 
 
-def log_episode_stats(
-    obs: dict, config: ConfigDict, finish_times: np.ndarray, controller_names: list[str]
-):
+def log_episode_stats(obs: dict, finish_times: np.ndarray, controller_names: list[str]):
     """Log the statistics of a single episode."""
-    n_gate_passes = len(config.env.track["gate_order"])
-    gates_passed = n_gate_passes if obs["race_progress"] == -1 else obs["race_progress"]
-    finished = obs["race_progress"] == -1
-    gates_passed = np.where(finished, n_gate_passes, obs["race_progress"])
+    finished = obs["n_gates_passed"] == obs["gate_sequence"].shape[-1]
     time_strings = ["N/A" if np.isnan(t) else f"{t:.2f}" for t in finish_times]
     name_width = max(len("controller"), max(len(name) for name in controller_names))
     time_width = max(len("time [s]"), max(len(time_str) for time_str in time_strings))
@@ -176,7 +173,7 @@ def log_episode_stats(
     for i, controller_name in enumerate(controller_names):
         lines.append(
             f"{controller_name:<{name_width}} | {time_strings[i]:>{time_width}} | "
-            f"{str(finished[i]):>{finished_width}} | {gates_passed[i]:>{gates_width}}"
+            f"{str(finished[i]):>{finished_width}} | {obs['n_gates_passed'][i]:>{gates_width}}"
         )
     table = "\n".join(lines)
     logger.info(f"Episode stats:\n{table}\n")

--- a/scripts/multi_sim.py
+++ b/scripts/multi_sim.py
@@ -120,7 +120,7 @@ def simulate(
 
             obs, reward, terminated, truncated, info = env.step(actions)
 
-            newly_finished = (obs["target_gate"] == -1) & np.isnan(finish_times)
+            newly_finished = (obs["race_progress"] == -1) & np.isnan(finish_times)
             finish_times[newly_finished] = curr_time
             # Update the controllers' internal state and models.
             for rank, (ctrl, ctrl_info) in enumerate(zip(controller_instances, ranked_infos)):
@@ -149,29 +149,20 @@ def simulate(
         for ctrl in controller_instances:
             ctrl.episode_callback()  # Update the controller internal state and models.
             ctrl.episode_reset()
-        log_episode_stats(
-            obs,
-            config,
-            finish_times,
-            controller_names,
-            np.asarray(env.unwrapped.data.gate_progress[0]),
-        )
+        log_episode_stats(obs, config, finish_times, controller_names)
 
     # Close the environment
     env.close()
 
 
 def log_episode_stats(
-    obs: dict,
-    config: ConfigDict,
-    finish_times: np.ndarray,
-    controller_names: list[str],
-    race_progress: np.ndarray,
+    obs: dict, config: ConfigDict, finish_times: np.ndarray, controller_names: list[str]
 ):
     """Log the statistics of a single episode."""
-    n_gate_passes = len(config.env.track.get("gate_order", config.env.track.gates))
-    finished = race_progress == -1
-    gates_passed = np.where(finished, n_gate_passes, race_progress)
+    n_gate_passes = len(config.env.track["gate_order"])
+    gates_passed = n_gate_passes if obs["race_progress"] == -1 else obs["race_progress"]
+    finished = obs["race_progress"] == -1
+    gates_passed = np.where(finished, n_gate_passes, obs["race_progress"])
     time_strings = ["N/A" if np.isnan(t) else f"{t:.2f}" for t in finish_times]
     name_width = max(len("controller"), max(len(name) for name in controller_names))
     time_width = max(len("time [s]"), max(len(time_str) for time_str in time_strings))

--- a/scripts/sim.py
+++ b/scripts/sim.py
@@ -16,14 +16,11 @@ from typing import TYPE_CHECKING
 
 import fire
 import gymnasium
-import numpy as np
 from gymnasium.wrappers.jax_to_numpy import JaxToNumpy
 
 from lsy_drone_racing.utils import load_config, load_controller
 
 if TYPE_CHECKING:
-    from ml_collections import ConfigDict
-
     from lsy_drone_racing.control.controller import Controller
     from lsy_drone_racing.envs.drone_race import DroneRaceEnv
 

--- a/scripts/sim.py
+++ b/scripts/sim.py
@@ -105,22 +105,23 @@ def simulate(
             i += 1
 
         controller.episode_callback()  # Update the controller internal state and models.
-        log_episode_stats(obs, info, config, curr_time)
+        log_episode_stats(obs, curr_time)
         controller.episode_reset()
-        ep_times.append(curr_time if obs["race_progress"] == -1 else None)
+        finished = obs["n_gates_passed"] == obs["gate_sequence"].shape[0]
+        ep_times.append(curr_time if finished else None)
 
     # Close the environment
     env.close()
     return ep_times
 
 
-def log_episode_stats(obs: dict, info: dict, config: ConfigDict, curr_time: float):
+def log_episode_stats(obs: dict, curr_time: float):
     """Log the statistics of a single episode."""
-    n_gate_passes = len(config.env.track["gate_order"])
-    gates_passed = n_gate_passes if obs["race_progress"] == -1 else obs["race_progress"]
-    finished = obs["race_progress"] == -1
+    finished = obs["n_gates_passed"] == obs["gate_sequence"].shape[0]
     logger.info(
-        f"Flight time (s): {curr_time}\nFinished: {finished}\nGates passed: {gates_passed}\n"
+        f"Flight time (s): {curr_time}\n"
+        + f"Finished: {finished}\n"
+        + f"Gates passed: {obs['n_gates_passed']}\n"
     )
 
 

--- a/scripts/sim.py
+++ b/scripts/sim.py
@@ -117,8 +117,8 @@ def log_episode_stats(obs: dict, curr_time: float):
     finished = obs["n_gates_passed"] == obs["gate_sequence"].shape[0]
     logger.info(
         f"Flight time (s): {curr_time}\n"
-        + f"Finished: {finished}\n"
-        + f"Gates passed: {obs['n_gates_passed']}\n"
+        f"Finished: {finished}\n"
+        f"Gates passed: {obs['n_gates_passed']}\n"
     )
 
 

--- a/scripts/sim.py
+++ b/scripts/sim.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 import fire
 import gymnasium
+import numpy as np
 from gymnasium.wrappers.jax_to_numpy import JaxToNumpy
 
 from lsy_drone_racing.utils import load_config, load_controller
@@ -104,22 +105,20 @@ def simulate(
             i += 1
 
         controller.episode_callback()  # Update the controller internal state and models.
-        log_episode_stats(obs, info, config, curr_time, int(env.unwrapped.data.gate_progress[0, 0]))
+        log_episode_stats(obs, info, config, curr_time)
         controller.episode_reset()
-        ep_times.append(curr_time if obs["target_gate"] == -1 else None)
+        ep_times.append(curr_time if int(np.asarray(obs["race_progress"]).item()) == -1 else None)
 
     # Close the environment
     env.close()
     return ep_times
 
 
-def log_episode_stats(
-    obs: dict, info: dict, config: ConfigDict, curr_time: float, race_progress: int
-):
+def log_episode_stats(obs: dict, info: dict, config: ConfigDict, curr_time: float):
     """Log the statistics of a single episode."""
-    n_gate_passes = len(config.env.track.get("gate_order", config.env.track.gates))
-    gates_passed = n_gate_passes if race_progress == -1 else race_progress
-    finished = race_progress == -1
+    n_gate_passes = len(config.env.track["gate_order"])
+    gates_passed = n_gate_passes if obs["race_progress"] == -1 else obs["race_progress"]
+    finished = obs["race_progress"] == -1
     logger.info(
         f"Flight time (s): {curr_time}\nFinished: {finished}\nGates passed: {gates_passed}\n"
     )

--- a/scripts/sim.py
+++ b/scripts/sim.py
@@ -107,7 +107,7 @@ def simulate(
         controller.episode_callback()  # Update the controller internal state and models.
         log_episode_stats(obs, info, config, curr_time)
         controller.episode_reset()
-        ep_times.append(curr_time if int(np.asarray(obs["race_progress"]).item()) == -1 else None)
+        ep_times.append(curr_time if obs["race_progress"] == -1 else None)
 
     # Close the environment
     env.close()

--- a/scripts/sim.py
+++ b/scripts/sim.py
@@ -104,7 +104,7 @@ def simulate(
             i += 1
 
         controller.episode_callback()  # Update the controller internal state and models.
-        log_episode_stats(obs, info, config, curr_time)
+        log_episode_stats(obs, info, config, curr_time, int(env.unwrapped.data.gate_progress[0, 0]))
         controller.episode_reset()
         ep_times.append(curr_time if obs["target_gate"] == -1 else None)
 
@@ -113,12 +113,13 @@ def simulate(
     return ep_times
 
 
-def log_episode_stats(obs: dict, info: dict, config: ConfigDict, curr_time: float):
+def log_episode_stats(
+    obs: dict, info: dict, config: ConfigDict, curr_time: float, race_progress: int
+):
     """Log the statistics of a single episode."""
-    gates_passed = obs["target_gate"]
-    if gates_passed == -1:  # The drone has passed the final gate
-        gates_passed = len(config.env.track.gates)
-    finished = gates_passed == len(config.env.track.gates)
+    n_gate_passes = len(config.env.track.get("gate_order", config.env.track.gates))
+    gates_passed = n_gate_passes if race_progress == -1 else race_progress
+    finished = race_progress == -1
     logger.info(
         f"Flight time (s): {curr_time}\nFinished: {finished}\nGates passed: {gates_passed}\n"
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import os
 
+os.environ["SCIPY_ARRAY_API"] = "1"
+
 import jax
 import pytest
 

--- a/tests/integration/test_controllers.py
+++ b/tests/integration/test_controllers.py
@@ -72,7 +72,9 @@ def test_attitude_controller(physics: str, controller: str):
         if terminated or truncated:
             break
     env.close()
-    assert obs["target_gate"] == -1, "Attitude controller failed to complete the track"
+    assert obs["n_gates_passed"] == obs["gate_sequence"].shape[0], (
+        "Attitude controller failed to complete the track"
+    )
 
 
 @pytest.mark.integration
@@ -113,4 +115,6 @@ def test_trajectory_controller_finish(yaw: float, physics: str):
         ctrl.step_callback(action, obs, reward, terminated, truncated, info)
         if terminated or truncated:
             break
-    assert obs["target_gate"] == -1, "Trajectory controller failed to complete the track"
+    assert obs["n_gates_passed"] == obs["gate_sequence"].shape[0], (
+        "Trajectory controller failed to complete the track"
+    )

--- a/tests/integration/test_envs.py
+++ b/tests/integration/test_envs.py
@@ -211,7 +211,7 @@ def test_render():
 
     # Force terminal state
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[...].set(-1))
+    env.unwrapped.data = data.replace(gate_progress=data.gate_progress.at[...].set(-1))
     env.step(env.action_space.sample())
     assert jp.all(env.unwrapped.data.disabled_drones), "drone not actually disabled"
     env.render()
@@ -249,12 +249,12 @@ def test_render_multi_drone():
     # `_warp_disabled_drones`, exercising the renderer with a mix of active and
     # warped drones.
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[0, 0].set(-1))
+    env.unwrapped.data = data.replace(gate_progress=data.gate_progress.at[0, 0].set(-1))
     env.step(env.action_space.sample())
 
     # Verify drone 0 is disabled and the others are still active.
     disabled = env.unwrapped.data.disabled_drones
-    assert bool(disabled[0, 0]), "drone 0 should be disabled after target_gate=-1"
+    assert bool(disabled[0, 0]), "drone 0 should be disabled after gate_progress=-1"
     assert not bool(jp.all(disabled)), "only drone 0 should be disabled, not all drones"
 
     env.render()
@@ -264,7 +264,7 @@ def test_render_multi_drone():
     # has autoreset enabled) the world will be auto-reset before render is
     # called again.
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[...].set(-1))
+    env.unwrapped.data = data.replace(gate_progress=data.gate_progress.at[...].set(-1))
     env.step(env.action_space.sample())
     env.render()
     env.close()

--- a/tests/integration/test_envs.py
+++ b/tests/integration/test_envs.py
@@ -211,7 +211,9 @@ def test_render():
 
     # Force terminal state
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(race_progress=data.race_progress.at[...].set(-1))
+    env.unwrapped.data = data.replace(
+        n_gates_passed=data.n_gates_passed.at[...].set(data.gate_sequence.shape[0])
+    )
     env.step(env.action_space.sample())
     assert jp.all(env.unwrapped.data.disabled_drones), "drone not actually disabled"
     env.render()
@@ -242,29 +244,33 @@ def test_render_multi_drone():
         env.step(env.action_space.sample())
         env.render()
 
-    # Force only drone 0 (in world 0) into a terminal state by setting its target
-    # gate to -1. The other drones stay active, so autoreset will not fire (it
+    # Force only drone 0 (in world 0) into a terminal state by setting its gate-pass count to the
+    # sequence length. The other drones stay active, so autoreset will not fire (it
     # only triggers when all drones in a world are disabled). The next step will
     # mark drone 0 as disabled and warp it below the ground via
     # `_warp_disabled_drones`, exercising the renderer with a mix of active and
     # warped drones.
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(race_progress=data.race_progress.at[0, 0].set(-1))
+    env.unwrapped.data = data.replace(
+        n_gates_passed=data.n_gates_passed.at[0, 0].set(data.gate_sequence.shape[0])
+    )
     env.step(env.action_space.sample())
 
     # Verify drone 0 is disabled and the others are still active.
     disabled = env.unwrapped.data.disabled_drones
-    assert bool(disabled[0, 0]), "drone 0 should be disabled after race_progress=-1"
+    assert bool(disabled[0, 0]), "drone 0 should be disabled after finishing the gate sequence"
     assert not bool(jp.all(disabled)), "only drone 0 should be disabled, not all drones"
 
     env.render()
 
-    # Force ALL drones into a terminal state by setting every target gate to
-    # -1. On the next step, every drone will be disabled and (because the env
+    # Force ALL drones into a terminal state by setting every gate-pass count to the sequence
+    # length. On the next step, every drone will be disabled and (because the env
     # has autoreset enabled) the world will be auto-reset before render is
     # called again.
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(race_progress=data.race_progress.at[...].set(-1))
+    env.unwrapped.data = data.replace(
+        n_gates_passed=data.n_gates_passed.at[...].set(data.gate_sequence.shape[0])
+    )
     env.step(env.action_space.sample())
     env.render()
     env.close()

--- a/tests/integration/test_envs.py
+++ b/tests/integration/test_envs.py
@@ -211,7 +211,7 @@ def test_render():
 
     # Force terminal state
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(gate_progress=data.gate_progress.at[...].set(-1))
+    env.unwrapped.data = data.replace(race_progress=data.race_progress.at[...].set(-1))
     env.step(env.action_space.sample())
     assert jp.all(env.unwrapped.data.disabled_drones), "drone not actually disabled"
     env.render()
@@ -249,12 +249,12 @@ def test_render_multi_drone():
     # `_warp_disabled_drones`, exercising the renderer with a mix of active and
     # warped drones.
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(gate_progress=data.gate_progress.at[0, 0].set(-1))
+    env.unwrapped.data = data.replace(race_progress=data.race_progress.at[0, 0].set(-1))
     env.step(env.action_space.sample())
 
     # Verify drone 0 is disabled and the others are still active.
     disabled = env.unwrapped.data.disabled_drones
-    assert bool(disabled[0, 0]), "drone 0 should be disabled after gate_progress=-1"
+    assert bool(disabled[0, 0]), "drone 0 should be disabled after race_progress=-1"
     assert not bool(jp.all(disabled)), "only drone 0 should be disabled, not all drones"
 
     env.render()
@@ -264,7 +264,7 @@ def test_render_multi_drone():
     # has autoreset enabled) the world will be auto-reset before render is
     # called again.
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(gate_progress=data.gate_progress.at[...].set(-1))
+    env.unwrapped.data = data.replace(race_progress=data.race_progress.at[...].set(-1))
     env.step(env.action_space.sample())
     env.render()
     env.close()

--- a/tests/unit/envs/test_race_core.py
+++ b/tests/unit/envs/test_race_core.py
@@ -66,7 +66,9 @@ def test_obs_structure_and_initial_values():
         "quat",
         "vel",
         "ang_vel",
-        "race_progress",
+        "n_gates_passed",
+        "gate_sequence",
+        "gate_sequence_direction",
         "target_gate",
         "target_gate_reverse",
         "gates_pos",
@@ -81,9 +83,11 @@ def test_obs_structure_and_initial_values():
     assert np.asarray(obs["pos"]).shape == (3,)
     assert np.asarray(obs["gates_pos"]).ndim == 2
     assert np.asarray(obs["gates_pos"]).shape[1] == 3
-    assert int(np.asarray(obs["race_progress"]).item()) == 0
+    assert int(np.asarray(obs["n_gates_passed"]).item()) == 0
+    np.testing.assert_array_equal(np.asarray(obs["gate_sequence"]), np.array([0, 1, 2, 3]))
+    np.testing.assert_array_equal(np.asarray(obs["gate_sequence_direction"]), np.array([1, 1, 1, 1]))
     assert int(np.asarray(obs["target_gate"]).item()) == 0
-    assert not bool(np.asarray(obs["target_gate_reverse"]).item())
+    assert int(np.asarray(obs["target_gate_reverse"]).item()) == 1
     env.close()
 
 
@@ -163,14 +167,16 @@ def test_terminated_false_after_reset():
 
 
 @pytest.mark.unit
-def test_terminated_true_when_race_progress_negative():
-    """Setting race_progress = -1 marks the drone disabled on the next step."""
+def test_terminated_true_when_n_gates_passed_finished():
+    """Setting n_gates_passed to the sequence length marks the drone disabled on the next step."""
     env = make_env()
     env.reset()
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(race_progress=data.race_progress.at[...].set(-1))
+    env.unwrapped.data = data.replace(
+        n_gates_passed=data.n_gates_passed.at[...].set(data.gate_sequence.shape[0])
+    )
     _, _, terminated, _, _ = env.step(env.action_space.sample())
-    assert terminated, "terminated should be True when race_progress is -1"
+    assert terminated, "terminated should be True when n_gates_passed reaches the sequence length"
     env.close()
 
 
@@ -248,8 +254,8 @@ def test_truncated_on_timeout_does_not_terminate():
 
 
 @pytest.mark.unit
-def test_gate_pass_increments_race_progress():
-    """Crossing the target gate's plane makes ``_update_target_gates`` increment race_progress."""
+def test_gate_pass_increments_n_gates_passed():
+    """Crossing the target gate's plane makes ``_update_target_gates`` increment n_gates_passed."""
     env = make_env()
     env.reset()
     data = env.unwrapped.data
@@ -272,7 +278,7 @@ def test_gate_pass_increments_race_progress():
 
     # Call _update_target_gates directly so physics doesn't overwrite our crafted positions.
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.race_progress[0, 0])) == 1
+    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 1
     env.close()
 
 
@@ -283,22 +289,24 @@ def test_gate_order_initial_obs_mapping():
     config.env.track.gate_order = [-2, 1]
     env = make_env(track=config.env.track)
     env_obs, _ = env.reset()
-    assert int(np.asarray(env_obs["race_progress"]).item()) == 0
+    assert int(np.asarray(env_obs["n_gates_passed"]).item()) == 0
+    np.testing.assert_array_equal(np.asarray(env_obs["gate_sequence"]), np.array([1, 0]))
+    np.testing.assert_array_equal(np.asarray(env_obs["gate_sequence_direction"]), np.array([-1, 1]))
     assert int(np.asarray(env_obs["target_gate"]).item()) == 1
-    assert bool(np.asarray(env_obs["target_gate_reverse"]).item())
+    assert int(np.asarray(env_obs["target_gate_reverse"]).item()) == -1
     env.close()
 
 
 @pytest.mark.unit
 def test_gate_not_passed_without_crossing():
-    """Moving around without crossing the gate plane leaves race_progress unchanged."""
+    """Moving around without crossing the gate plane leaves n_gates_passed unchanged."""
     env = make_env()
     env.reset()
     data = env.unwrapped.data
-    assert int(np.asarray(data.race_progress[0, 0])) == 0
+    assert int(np.asarray(data.n_gates_passed[0, 0])) == 0
     # Nominal step without any crafted crossing: drone still on the takeoff pad.
     new_data = _update_target_gates(data)
-    assert int(np.asarray(new_data.race_progress[0, 0])) == 0
+    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 0
     env.close()
 
 
@@ -325,15 +333,15 @@ def test_repeated_gate_obs_mapping_after_pass():
 
     new_data = _update_target_gates(env.unwrapped.data)
     mapped_obs = obs(new_data)
-    assert int(np.asarray(mapped_obs["race_progress"][0, 0])) == 1
+    assert int(np.asarray(mapped_obs["n_gates_passed"][0, 0])) == 1
     assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == 0
-    assert bool(np.asarray(mapped_obs["target_gate_reverse"][0, 0]))
+    assert int(np.asarray(mapped_obs["target_gate_reverse"][0, 0])) == -1
     env.close()
 
 
 @pytest.mark.unit
 def test_gate_pass_non_target_gate_does_not_increment():
-    """Crossing a gate that is not the current target must not increment race_progress."""
+    """Crossing a gate that is not the current target must not increment n_gates_passed."""
     from scipy.spatial.transform import Rotation as R
 
     env = make_env()
@@ -341,9 +349,9 @@ def test_gate_pass_non_target_gate_does_not_increment():
     data = env.unwrapped.data
     n_gates = data.gates_pos.shape[1]
     assert n_gates >= 2, "need at least 2 gates for this test"
-    assert int(np.asarray(data.race_progress[0, 0])) == 0
+    assert int(np.asarray(data.n_gates_passed[0, 0])) == 0
 
-    # Straddle gate 1 (the *next* gate) while race_progress is still 0.
+    # Straddle gate 1 (the *next* gate) while n_gates_passed is still 0.
     non_target_idx = 1
     gate_pos = np.asarray(data.gates_pos[0, non_target_idx])
     gate_quat_xyzw = np.asarray(data.gates_quat[0, non_target_idx])
@@ -358,7 +366,7 @@ def test_gate_pass_non_target_gate_does_not_increment():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.race_progress[0, 0])) == 0
+    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 0
     env.close()
 
 
@@ -385,7 +393,7 @@ def test_gate_not_passed_in_reverse():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.race_progress[0, 0])) == 0
+    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 0
     env.close()
 
 
@@ -415,28 +423,31 @@ def test_gate_not_passed_when_outside_gate_box():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.race_progress[0, 0])) == 0
+    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 0
     env.close()
 
 
 @pytest.mark.unit
-def test_gate_pass_at_last_gate_clamps_to_negative_one():
-    """Passing the final gate must set race_progress to -1 (course finished sentinel)."""
+def test_gate_pass_at_last_gate_sets_n_gates_passed_to_sequence_length():
+    """Passing the final gate must set n_gates_passed to the full sequence length."""
     from scipy.spatial.transform import Rotation as R
 
     env = make_env()
     env.reset()
     data = env.unwrapped.data
-    n_gates = data.gates_pos.shape[1]
+    n_gate_passes = data.gate_sequence.shape[0]
 
-    # Pre-advance race_progress to the last gate so _update_target_gates will check against it.
-    last_idx = n_gates - 1
-    env.unwrapped.data = data.replace(race_progress=data.race_progress.at[0, 0].set(last_idx))
+    # Pre-advance n_gates_passed to the last sequence entry so _update_target_gates checks it.
+    last_idx = n_gate_passes - 1
+    env.unwrapped.data = data.replace(
+        n_gates_passed=data.n_gates_passed.at[0, 0].set(last_idx)
+    )
     data = env.unwrapped.data
 
     # Craft a forward crossing of the last gate.
-    gate_pos = np.asarray(data.gates_pos[0, last_idx])
-    gate_quat_xyzw = np.asarray(data.gates_quat[0, last_idx])
+    gate_idx = int(np.asarray(data.gate_sequence[last_idx]))
+    gate_pos = np.asarray(data.gates_pos[0, gate_idx])
+    gate_quat_xyzw = np.asarray(data.gates_quat[0, gate_idx])
     forward = R.from_quat(gate_quat_xyzw).apply(np.array([1.0, 0.0, 0.0]))
 
     behind = gate_pos - 0.05 * forward
@@ -448,11 +459,11 @@ def test_gate_pass_at_last_gate_clamps_to_negative_one():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.race_progress[0, 0])) == -1
+    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == n_gate_passes
     mapped_obs = obs(new_data)
-    assert int(np.asarray(mapped_obs["race_progress"][0, 0])) == -1
+    assert int(np.asarray(mapped_obs["n_gates_passed"][0, 0])) == n_gate_passes
     assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == -1
-    assert not bool(np.asarray(mapped_obs["target_gate_reverse"][0, 0]))
+    assert int(np.asarray(mapped_obs["target_gate_reverse"][0, 0])) == 1
     env.close()
 
 
@@ -479,10 +490,10 @@ def test_reverse_only_waypoint_can_finish_track():
 
     new_data = _update_target_gates(env.unwrapped.data)
     mapped_obs = obs(new_data)
-    assert int(np.asarray(new_data.race_progress[0, 0])) == -1
-    assert int(np.asarray(mapped_obs["race_progress"][0, 0])) == -1
+    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 1
+    assert int(np.asarray(mapped_obs["n_gates_passed"][0, 0])) == 1
     assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == -1
-    assert not bool(np.asarray(mapped_obs["target_gate_reverse"][0, 0]))
+    assert int(np.asarray(mapped_obs["target_gate_reverse"][0, 0])) == 1
     env.close()
 
 

--- a/tests/unit/envs/test_race_core.py
+++ b/tests/unit/envs/test_race_core.py
@@ -66,6 +66,7 @@ def test_obs_structure_and_initial_values():
         "quat",
         "vel",
         "ang_vel",
+        "race_progress",
         "target_gate",
         "target_gate_reverse",
         "gates_pos",
@@ -80,6 +81,7 @@ def test_obs_structure_and_initial_values():
     assert np.asarray(obs["pos"]).shape == (3,)
     assert np.asarray(obs["gates_pos"]).ndim == 2
     assert np.asarray(obs["gates_pos"]).shape[1] == 3
+    assert int(np.asarray(obs["race_progress"]).item()) == 0
     assert int(np.asarray(obs["target_gate"]).item()) == 0
     assert not bool(np.asarray(obs["target_gate_reverse"]).item())
     env.close()
@@ -161,14 +163,14 @@ def test_terminated_false_after_reset():
 
 
 @pytest.mark.unit
-def test_terminated_true_when_gate_progress_negative():
-    """Setting gate_progress = -1 marks the drone disabled on the next step."""
+def test_terminated_true_when_race_progress_negative():
+    """Setting race_progress = -1 marks the drone disabled on the next step."""
     env = make_env()
     env.reset()
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(gate_progress=data.gate_progress.at[...].set(-1))
+    env.unwrapped.data = data.replace(race_progress=data.race_progress.at[...].set(-1))
     _, _, terminated, _, _ = env.step(env.action_space.sample())
-    assert terminated, "terminated should be True when gate_progress is -1"
+    assert terminated, "terminated should be True when race_progress is -1"
     env.close()
 
 
@@ -246,8 +248,8 @@ def test_truncated_on_timeout_does_not_terminate():
 
 
 @pytest.mark.unit
-def test_gate_pass_increments_gate_progress():
-    """Crossing the target gate's plane makes ``_update_target_gates`` increment gate_progress."""
+def test_gate_pass_increments_race_progress():
+    """Crossing the target gate's plane makes ``_update_target_gates`` increment race_progress."""
     env = make_env()
     env.reset()
     data = env.unwrapped.data
@@ -270,7 +272,7 @@ def test_gate_pass_increments_gate_progress():
 
     # Call _update_target_gates directly so physics doesn't overwrite our crafted positions.
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.gate_progress[0, 0])) == 1
+    assert int(np.asarray(new_data.race_progress[0, 0])) == 1
     env.close()
 
 
@@ -281,6 +283,7 @@ def test_gate_order_initial_obs_mapping():
     config.env.track.gate_order = [-2, 1]
     env = make_env(track=config.env.track)
     env_obs, _ = env.reset()
+    assert int(np.asarray(env_obs["race_progress"]).item()) == 0
     assert int(np.asarray(env_obs["target_gate"]).item()) == 1
     assert bool(np.asarray(env_obs["target_gate_reverse"]).item())
     env.close()
@@ -288,14 +291,14 @@ def test_gate_order_initial_obs_mapping():
 
 @pytest.mark.unit
 def test_gate_not_passed_without_crossing():
-    """Moving around without crossing the gate plane leaves gate_progress unchanged."""
+    """Moving around without crossing the gate plane leaves race_progress unchanged."""
     env = make_env()
     env.reset()
     data = env.unwrapped.data
-    assert int(np.asarray(data.gate_progress[0, 0])) == 0
+    assert int(np.asarray(data.race_progress[0, 0])) == 0
     # Nominal step without any crafted crossing: drone still on the takeoff pad.
     new_data = _update_target_gates(data)
-    assert int(np.asarray(new_data.gate_progress[0, 0])) == 0
+    assert int(np.asarray(new_data.race_progress[0, 0])) == 0
     env.close()
 
 
@@ -322,6 +325,7 @@ def test_repeated_gate_obs_mapping_after_pass():
 
     new_data = _update_target_gates(env.unwrapped.data)
     mapped_obs = obs(new_data)
+    assert int(np.asarray(mapped_obs["race_progress"][0, 0])) == 1
     assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == 0
     assert bool(np.asarray(mapped_obs["target_gate_reverse"][0, 0]))
     env.close()
@@ -329,7 +333,7 @@ def test_repeated_gate_obs_mapping_after_pass():
 
 @pytest.mark.unit
 def test_gate_pass_non_target_gate_does_not_increment():
-    """Crossing a gate that is not the current target must not increment gate_progress."""
+    """Crossing a gate that is not the current target must not increment race_progress."""
     from scipy.spatial.transform import Rotation as R
 
     env = make_env()
@@ -337,9 +341,9 @@ def test_gate_pass_non_target_gate_does_not_increment():
     data = env.unwrapped.data
     n_gates = data.gates_pos.shape[1]
     assert n_gates >= 2, "need at least 2 gates for this test"
-    assert int(np.asarray(data.gate_progress[0, 0])) == 0
+    assert int(np.asarray(data.race_progress[0, 0])) == 0
 
-    # Straddle gate 1 (the *next* gate) while gate_progress is still 0.
+    # Straddle gate 1 (the *next* gate) while race_progress is still 0.
     non_target_idx = 1
     gate_pos = np.asarray(data.gates_pos[0, non_target_idx])
     gate_quat_xyzw = np.asarray(data.gates_quat[0, non_target_idx])
@@ -354,7 +358,7 @@ def test_gate_pass_non_target_gate_does_not_increment():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.gate_progress[0, 0])) == 0
+    assert int(np.asarray(new_data.race_progress[0, 0])) == 0
     env.close()
 
 
@@ -381,7 +385,7 @@ def test_gate_not_passed_in_reverse():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.gate_progress[0, 0])) == 0
+    assert int(np.asarray(new_data.race_progress[0, 0])) == 0
     env.close()
 
 
@@ -411,13 +415,13 @@ def test_gate_not_passed_when_outside_gate_box():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.gate_progress[0, 0])) == 0
+    assert int(np.asarray(new_data.race_progress[0, 0])) == 0
     env.close()
 
 
 @pytest.mark.unit
 def test_gate_pass_at_last_gate_clamps_to_negative_one():
-    """Passing the final gate must set gate_progress to -1 (course finished sentinel)."""
+    """Passing the final gate must set race_progress to -1 (course finished sentinel)."""
     from scipy.spatial.transform import Rotation as R
 
     env = make_env()
@@ -425,9 +429,9 @@ def test_gate_pass_at_last_gate_clamps_to_negative_one():
     data = env.unwrapped.data
     n_gates = data.gates_pos.shape[1]
 
-    # Pre-advance gate_progress to the last gate so _update_target_gates will check against it.
+    # Pre-advance race_progress to the last gate so _update_target_gates will check against it.
     last_idx = n_gates - 1
-    env.unwrapped.data = data.replace(gate_progress=data.gate_progress.at[0, 0].set(last_idx))
+    env.unwrapped.data = data.replace(race_progress=data.race_progress.at[0, 0].set(last_idx))
     data = env.unwrapped.data
 
     # Craft a forward crossing of the last gate.
@@ -444,8 +448,9 @@ def test_gate_pass_at_last_gate_clamps_to_negative_one():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.gate_progress[0, 0])) == -1
+    assert int(np.asarray(new_data.race_progress[0, 0])) == -1
     mapped_obs = obs(new_data)
+    assert int(np.asarray(mapped_obs["race_progress"][0, 0])) == -1
     assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == -1
     assert not bool(np.asarray(mapped_obs["target_gate_reverse"][0, 0]))
     env.close()
@@ -474,7 +479,8 @@ def test_reverse_only_waypoint_can_finish_track():
 
     new_data = _update_target_gates(env.unwrapped.data)
     mapped_obs = obs(new_data)
-    assert int(np.asarray(new_data.gate_progress[0, 0])) == -1
+    assert int(np.asarray(new_data.race_progress[0, 0])) == -1
+    assert int(np.asarray(mapped_obs["race_progress"][0, 0])) == -1
     assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == -1
     assert not bool(np.asarray(mapped_obs["target_gate_reverse"][0, 0]))
     env.close()

--- a/tests/unit/envs/test_race_core.py
+++ b/tests/unit/envs/test_race_core.py
@@ -69,8 +69,6 @@ def test_obs_structure_and_initial_values():
         "n_gates_passed",
         "gate_sequence",
         "gate_sequence_direction",
-        "target_gate",
-        "target_gate_reverse",
         "gates_pos",
         "gates_quat",
         "gates_visited",
@@ -79,15 +77,13 @@ def test_obs_structure_and_initial_values():
     }
     assert set(obs.keys()) == expected_keys
     # Single-drone make() squeezes leading (world, drone) dims: pos is (3,), gates_pos is
-    # (n_gates, 3), target_gate is a 0-d scalar.
+    # (n_gates, 3).
     assert np.asarray(obs["pos"]).shape == (3,)
     assert np.asarray(obs["gates_pos"]).ndim == 2
     assert np.asarray(obs["gates_pos"]).shape[1] == 3
     assert int(np.asarray(obs["n_gates_passed"]).item()) == 0
     np.testing.assert_array_equal(np.asarray(obs["gate_sequence"]), np.array([0, 1, 2, 3]))
-    np.testing.assert_array_equal(np.asarray(obs["gate_sequence_direction"]), np.array([1, 1, 1, 1]))
-    assert int(np.asarray(obs["target_gate"]).item()) == 0
-    assert int(np.asarray(obs["target_gate_reverse"]).item()) == 1
+    np.testing.assert_array_equal(np.asarray(obs["gate_sequence_direction"]), np.ones(4))
     env.close()
 
 
@@ -284,7 +280,7 @@ def test_gate_pass_increments_n_gates_passed():
 
 @pytest.mark.unit
 def test_gate_order_initial_obs_mapping():
-    """Initial observations must expose the configured next gate ID and direction."""
+    """Initial observations must expose the configured gate sequence and directions."""
     config = load_config(CONFIG_PATH / "level0.toml")
     config.env.track.gate_order = [-2, 1]
     env = make_env(track=config.env.track)
@@ -292,8 +288,6 @@ def test_gate_order_initial_obs_mapping():
     assert int(np.asarray(env_obs["n_gates_passed"]).item()) == 0
     np.testing.assert_array_equal(np.asarray(env_obs["gate_sequence"]), np.array([1, 0]))
     np.testing.assert_array_equal(np.asarray(env_obs["gate_sequence_direction"]), np.array([-1, 1]))
-    assert int(np.asarray(env_obs["target_gate"]).item()) == 1
-    assert int(np.asarray(env_obs["target_gate_reverse"]).item()) == -1
     env.close()
 
 
@@ -312,7 +306,7 @@ def test_gate_not_passed_without_crossing():
 
 @pytest.mark.unit
 def test_repeated_gate_obs_mapping_after_pass():
-    """After passing a repeated gate, obs must still point to that gate with the next direction."""
+    """After passing a repeated gate, obs must keep the configured repeated sequence entry."""
     config = load_config(CONFIG_PATH / "level0.toml")
     config.env.track.gate_order = [1, -1]
     env = make_env(track=config.env.track)
@@ -334,8 +328,8 @@ def test_repeated_gate_obs_mapping_after_pass():
     new_data = _update_target_gates(env.unwrapped.data)
     mapped_obs = obs(new_data)
     assert int(np.asarray(mapped_obs["n_gates_passed"][0, 0])) == 1
-    assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == 0
-    assert int(np.asarray(mapped_obs["target_gate_reverse"][0, 0])) == -1
+    assert int(np.asarray(mapped_obs["gate_sequence"][0, 0, 1])) == 0
+    assert int(np.asarray(mapped_obs["gate_sequence_direction"][0, 0, 1])) == -1
     env.close()
 
 
@@ -439,9 +433,7 @@ def test_gate_pass_at_last_gate_sets_n_gates_passed_to_sequence_length():
 
     # Pre-advance n_gates_passed to the last sequence entry so _update_target_gates checks it.
     last_idx = n_gate_passes - 1
-    env.unwrapped.data = data.replace(
-        n_gates_passed=data.n_gates_passed.at[0, 0].set(last_idx)
-    )
+    env.unwrapped.data = data.replace(n_gates_passed=data.n_gates_passed.at[0, 0].set(last_idx))
     data = env.unwrapped.data
 
     # Craft a forward crossing of the last gate.
@@ -462,8 +454,6 @@ def test_gate_pass_at_last_gate_sets_n_gates_passed_to_sequence_length():
     assert int(np.asarray(new_data.n_gates_passed[0, 0])) == n_gate_passes
     mapped_obs = obs(new_data)
     assert int(np.asarray(mapped_obs["n_gates_passed"][0, 0])) == n_gate_passes
-    assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == -1
-    assert int(np.asarray(mapped_obs["target_gate_reverse"][0, 0])) == 1
     env.close()
 
 
@@ -492,8 +482,6 @@ def test_reverse_only_waypoint_can_finish_track():
     mapped_obs = obs(new_data)
     assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 1
     assert int(np.asarray(mapped_obs["n_gates_passed"][0, 0])) == 1
-    assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == -1
-    assert int(np.asarray(mapped_obs["target_gate_reverse"][0, 0])) == 1
     env.close()
 
 

--- a/tests/unit/envs/test_race_core.py
+++ b/tests/unit/envs/test_race_core.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 from scipy.spatial.transform import Rotation as R
 
-from lsy_drone_racing.envs.race_core import _update_disabled_drones, _update_target_gates
+from lsy_drone_racing.envs.race_core import _update_disabled_drones, _update_target_gates, obs
 from lsy_drone_racing.utils import load_config
 
 CONFIG_PATH = Path(__file__).parents[3] / "config"
@@ -67,6 +67,7 @@ def test_obs_structure_and_initial_values():
         "vel",
         "ang_vel",
         "target_gate",
+        "target_gate_reverse",
         "gates_pos",
         "gates_quat",
         "gates_visited",
@@ -80,6 +81,7 @@ def test_obs_structure_and_initial_values():
     assert np.asarray(obs["gates_pos"]).ndim == 2
     assert np.asarray(obs["gates_pos"]).shape[1] == 3
     assert int(np.asarray(obs["target_gate"]).item()) == 0
+    assert not bool(np.asarray(obs["target_gate_reverse"]).item())
     env.close()
 
 
@@ -159,14 +161,14 @@ def test_terminated_false_after_reset():
 
 
 @pytest.mark.unit
-def test_terminated_true_when_target_gate_negative():
-    """Setting target_gate = -1 marks the drone disabled on the next step."""
+def test_terminated_true_when_gate_progress_negative():
+    """Setting gate_progress = -1 marks the drone disabled on the next step."""
     env = make_env()
     env.reset()
     data = env.unwrapped.data
-    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[...].set(-1))
+    env.unwrapped.data = data.replace(gate_progress=data.gate_progress.at[...].set(-1))
     _, _, terminated, _, _ = env.step(env.action_space.sample())
-    assert terminated, "terminated should be True when target_gate is -1"
+    assert terminated, "terminated should be True when gate_progress is -1"
     env.close()
 
 
@@ -244,8 +246,8 @@ def test_truncated_on_timeout_does_not_terminate():
 
 
 @pytest.mark.unit
-def test_gate_pass_increments_target_gate():
-    """Crossing the target gate's plane makes ``_update_target_gates`` increment target_gate."""
+def test_gate_pass_increments_gate_progress():
+    """Crossing the target gate's plane makes ``_update_target_gates`` increment gate_progress."""
     env = make_env()
     env.reset()
     data = env.unwrapped.data
@@ -268,26 +270,66 @@ def test_gate_pass_increments_target_gate():
 
     # Call _update_target_gates directly so physics doesn't overwrite our crafted positions.
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.target_gate[0, 0])) == 1
+    assert int(np.asarray(new_data.gate_progress[0, 0])) == 1
+    env.close()
+
+
+@pytest.mark.unit
+def test_gate_order_initial_obs_mapping():
+    """Initial observations must expose the configured next gate ID and direction."""
+    config = load_config(CONFIG_PATH / "level0.toml")
+    config.env.track.gate_order = [-2, 1]
+    env = make_env(track=config.env.track)
+    env_obs, _ = env.reset()
+    assert int(np.asarray(env_obs["target_gate"]).item()) == 1
+    assert bool(np.asarray(env_obs["target_gate_reverse"]).item())
     env.close()
 
 
 @pytest.mark.unit
 def test_gate_not_passed_without_crossing():
-    """Moving around without crossing the gate plane leaves target_gate unchanged."""
+    """Moving around without crossing the gate plane leaves gate_progress unchanged."""
     env = make_env()
     env.reset()
     data = env.unwrapped.data
-    assert int(np.asarray(data.target_gate[0, 0])) == 0
+    assert int(np.asarray(data.gate_progress[0, 0])) == 0
     # Nominal step without any crafted crossing: drone still on the takeoff pad.
     new_data = _update_target_gates(data)
-    assert int(np.asarray(new_data.target_gate[0, 0])) == 0
+    assert int(np.asarray(new_data.gate_progress[0, 0])) == 0
+    env.close()
+
+
+@pytest.mark.unit
+def test_repeated_gate_obs_mapping_after_pass():
+    """After passing a repeated gate, obs must still point to that gate with the next direction."""
+    config = load_config(CONFIG_PATH / "level0.toml")
+    config.env.track.gate_order = [1, -1]
+    env = make_env(track=config.env.track)
+    env.reset()
+    data = env.unwrapped.data
+
+    gate_pos = np.asarray(data.gates_pos[0, 0])
+    gate_quat_xyzw = np.asarray(data.gates_quat[0, 0])
+    forward = R.from_quat(gate_quat_xyzw).apply(np.array([1.0, 0.0, 0.0]))
+
+    behind = gate_pos - 0.05 * forward
+    front = gate_pos + 0.05 * forward
+
+    new_last = data.last_drone_pos.at[0, 0, :].set(jp.asarray(behind))
+    new_pos = data.sim_data.states.pos.at[0, 0, :].set(jp.asarray(front))
+    new_sim_data = data.sim_data.replace(states=data.sim_data.states.replace(pos=new_pos))
+    env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
+
+    new_data = _update_target_gates(env.unwrapped.data)
+    mapped_obs = obs(new_data)
+    assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == 0
+    assert bool(np.asarray(mapped_obs["target_gate_reverse"][0, 0]))
     env.close()
 
 
 @pytest.mark.unit
 def test_gate_pass_non_target_gate_does_not_increment():
-    """Crossing a gate that is not the current target must not increment target_gate."""
+    """Crossing a gate that is not the current target must not increment gate_progress."""
     from scipy.spatial.transform import Rotation as R
 
     env = make_env()
@@ -295,9 +337,9 @@ def test_gate_pass_non_target_gate_does_not_increment():
     data = env.unwrapped.data
     n_gates = data.gates_pos.shape[1]
     assert n_gates >= 2, "need at least 2 gates for this test"
-    assert int(np.asarray(data.target_gate[0, 0])) == 0
+    assert int(np.asarray(data.gate_progress[0, 0])) == 0
 
-    # Straddle gate 1 (the *next* gate) while target_gate is still 0.
+    # Straddle gate 1 (the *next* gate) while gate_progress is still 0.
     non_target_idx = 1
     gate_pos = np.asarray(data.gates_pos[0, non_target_idx])
     gate_quat_xyzw = np.asarray(data.gates_quat[0, non_target_idx])
@@ -312,7 +354,7 @@ def test_gate_pass_non_target_gate_does_not_increment():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.target_gate[0, 0])) == 0
+    assert int(np.asarray(new_data.gate_progress[0, 0])) == 0
     env.close()
 
 
@@ -339,7 +381,7 @@ def test_gate_not_passed_in_reverse():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.target_gate[0, 0])) == 0
+    assert int(np.asarray(new_data.gate_progress[0, 0])) == 0
     env.close()
 
 
@@ -369,13 +411,13 @@ def test_gate_not_passed_when_outside_gate_box():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.target_gate[0, 0])) == 0
+    assert int(np.asarray(new_data.gate_progress[0, 0])) == 0
     env.close()
 
 
 @pytest.mark.unit
 def test_gate_pass_at_last_gate_clamps_to_negative_one():
-    """Passing the final gate must set target_gate to -1 (course finished sentinel)."""
+    """Passing the final gate must set gate_progress to -1 (course finished sentinel)."""
     from scipy.spatial.transform import Rotation as R
 
     env = make_env()
@@ -383,9 +425,9 @@ def test_gate_pass_at_last_gate_clamps_to_negative_one():
     data = env.unwrapped.data
     n_gates = data.gates_pos.shape[1]
 
-    # Pre-advance target_gate to the last gate so _update_target_gates will check against it.
+    # Pre-advance gate_progress to the last gate so _update_target_gates will check against it.
     last_idx = n_gates - 1
-    env.unwrapped.data = data.replace(target_gate=data.target_gate.at[0, 0].set(last_idx))
+    env.unwrapped.data = data.replace(gate_progress=data.gate_progress.at[0, 0].set(last_idx))
     data = env.unwrapped.data
 
     # Craft a forward crossing of the last gate.
@@ -402,7 +444,39 @@ def test_gate_pass_at_last_gate_clamps_to_negative_one():
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
     new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.target_gate[0, 0])) == -1
+    assert int(np.asarray(new_data.gate_progress[0, 0])) == -1
+    mapped_obs = obs(new_data)
+    assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == -1
+    assert not bool(np.asarray(mapped_obs["target_gate_reverse"][0, 0]))
+    env.close()
+
+
+@pytest.mark.unit
+def test_reverse_only_waypoint_can_finish_track():
+    """A reverse-only gate-order entry must be passable and finish the track."""
+    config = load_config(CONFIG_PATH / "level0.toml")
+    config.env.track.gate_order = [-1]
+    env = make_env(track=config.env.track)
+    env.reset()
+    data = env.unwrapped.data
+
+    gate_pos = np.asarray(data.gates_pos[0, 0])
+    gate_quat_xyzw = np.asarray(data.gates_quat[0, 0])
+    forward = R.from_quat(gate_quat_xyzw).apply(np.array([1.0, 0.0, 0.0]))
+
+    front = gate_pos + 0.05 * forward
+    behind = gate_pos - 0.05 * forward
+
+    new_last = data.last_drone_pos.at[0, 0, :].set(jp.asarray(front))
+    new_pos = data.sim_data.states.pos.at[0, 0, :].set(jp.asarray(behind))
+    new_sim_data = data.sim_data.replace(states=data.sim_data.states.replace(pos=new_pos))
+    env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
+
+    new_data = _update_target_gates(env.unwrapped.data)
+    mapped_obs = obs(new_data)
+    assert int(np.asarray(new_data.gate_progress[0, 0])) == -1
+    assert int(np.asarray(mapped_obs["target_gate"][0, 0])) == -1
+    assert not bool(np.asarray(mapped_obs["target_gate_reverse"][0, 0]))
     env.close()
 
 

--- a/tests/unit/envs/test_race_core.py
+++ b/tests/unit/envs/test_race_core.py
@@ -6,11 +6,8 @@ detection) rather than physics or rendering. They exercise both the public prope
 the same pattern used in the render integration tests.
 """
 
-import os
 from pathlib import Path
 from typing import Any
-
-os.environ["SCIPY_ARRAY_API"] = "1"
 
 import gymnasium
 import jax.numpy as jp
@@ -77,13 +74,16 @@ def test_obs_structure_and_initial_values():
     }
     assert set(obs.keys()) == expected_keys
     # Single-drone make() squeezes leading (world, drone) dims: pos is (3,), gates_pos is
-    # (n_gates, 3).
+    # (n_gates, 3), gate_sequence and gate_sequence_direction are (n_gates_to_pass,).
     assert np.asarray(obs["pos"]).shape == (3,)
     assert np.asarray(obs["gates_pos"]).ndim == 2
     assert np.asarray(obs["gates_pos"]).shape[1] == 3
     assert int(np.asarray(obs["n_gates_passed"]).item()) == 0
-    np.testing.assert_array_equal(np.asarray(obs["gate_sequence"]), np.array([0, 1, 2, 3]))
-    np.testing.assert_array_equal(np.asarray(obs["gate_sequence_direction"]), np.ones(4))
+    assert np.asarray(obs["gate_sequence"]).ndim == 1
+    assert np.asarray(obs["gate_sequence_direction"]).ndim == 1
+    assert (
+        np.asarray(obs["gate_sequence"]).shape == np.asarray(obs["gate_sequence_direction"]).shape
+    )
     env.close()
 
 
@@ -286,8 +286,10 @@ def test_gate_order_initial_obs_mapping():
     env = make_env(track=config.env.track)
     env_obs, _ = env.reset()
     assert int(np.asarray(env_obs["n_gates_passed"]).item()) == 0
-    np.testing.assert_array_equal(np.asarray(env_obs["gate_sequence"]), np.array([1, 0]))
-    np.testing.assert_array_equal(np.asarray(env_obs["gate_sequence_direction"]), np.array([-1, 1]))
+    gate_sequence = np.asarray(env_obs["gate_sequence"])
+    assert (gate_sequence == np.array([1, 0])).all()
+    gate_sequence_direction = np.asarray(env_obs["gate_sequence_direction"])
+    assert (gate_sequence_direction == np.array([-1, 1])).all()
     env.close()
 
 
@@ -325,19 +327,17 @@ def test_repeated_gate_obs_mapping_after_pass():
     new_sim_data = data.sim_data.replace(states=data.sim_data.states.replace(pos=new_pos))
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
-    new_data = _update_target_gates(env.unwrapped.data)
-    mapped_obs = obs(new_data)
-    assert int(np.asarray(mapped_obs["n_gates_passed"][0, 0])) == 1
-    assert int(np.asarray(mapped_obs["gate_sequence"][0, 0, 1])) == 0
-    assert int(np.asarray(mapped_obs["gate_sequence_direction"][0, 0, 1])) == -1
+    next_data = _update_target_gates(env.unwrapped.data)
+    next_obs = obs(next_data)
+    assert int(np.asarray(next_obs["n_gates_passed"][0, 0])) == 1
+    assert int(np.asarray(next_obs["gate_sequence"][0, 0, 1])) == 0
+    assert int(np.asarray(next_obs["gate_sequence_direction"][0, 0, 1])) == -1
     env.close()
 
 
 @pytest.mark.unit
 def test_gate_pass_non_target_gate_does_not_increment():
     """Crossing a gate that is not the current target must not increment n_gates_passed."""
-    from scipy.spatial.transform import Rotation as R
-
     env = make_env()
     env.reset()
     data = env.unwrapped.data
@@ -359,16 +359,14 @@ def test_gate_pass_non_target_gate_does_not_increment():
     new_sim_data = data.sim_data.replace(states=data.sim_data.states.replace(pos=new_pos))
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
-    new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 0
+    next_data = _update_target_gates(env.unwrapped.data)
+    assert int(np.asarray(next_data.n_gates_passed[0, 0])) == 0
     env.close()
 
 
 @pytest.mark.unit
 def test_gate_not_passed_in_reverse():
     """Flying through the gate from +x to -x (reverse) must not count as a pass."""
-    from scipy.spatial.transform import Rotation as R
-
     env = make_env()
     env.reset()
     data = env.unwrapped.data
@@ -386,16 +384,14 @@ def test_gate_not_passed_in_reverse():
     new_sim_data = data.sim_data.replace(states=data.sim_data.states.replace(pos=new_pos))
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
-    new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 0
+    next_data = _update_target_gates(env.unwrapped.data)
+    assert int(np.asarray(next_data.n_gates_passed[0, 0])) == 0
     env.close()
 
 
 @pytest.mark.unit
 def test_gate_not_passed_when_outside_gate_box():
     """Crossing the gate plane but far outside the gate opening must not count as a pass."""
-    from scipy.spatial.transform import Rotation as R
-
     env = make_env()
     env.reset()
     data = env.unwrapped.data
@@ -416,16 +412,14 @@ def test_gate_not_passed_when_outside_gate_box():
     new_sim_data = data.sim_data.replace(states=data.sim_data.states.replace(pos=new_pos))
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
-    new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 0
+    next_data = _update_target_gates(env.unwrapped.data)
+    assert int(np.asarray(next_data.n_gates_passed[0, 0])) == 0
     env.close()
 
 
 @pytest.mark.unit
 def test_gate_pass_at_last_gate_sets_n_gates_passed_to_sequence_length():
     """Passing the final gate must set n_gates_passed to the full sequence length."""
-    from scipy.spatial.transform import Rotation as R
-
     env = make_env()
     env.reset()
     data = env.unwrapped.data
@@ -450,10 +444,10 @@ def test_gate_pass_at_last_gate_sets_n_gates_passed_to_sequence_length():
     new_sim_data = data.sim_data.replace(states=data.sim_data.states.replace(pos=new_pos))
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
-    new_data = _update_target_gates(env.unwrapped.data)
-    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == n_gate_passes
-    mapped_obs = obs(new_data)
-    assert int(np.asarray(mapped_obs["n_gates_passed"][0, 0])) == n_gate_passes
+    next_data = _update_target_gates(env.unwrapped.data)
+    assert int(np.asarray(next_data.n_gates_passed[0, 0])) == n_gate_passes
+    next_obs = obs(next_data)
+    assert int(np.asarray(next_obs["n_gates_passed"][0, 0])) == n_gate_passes
     env.close()
 
 
@@ -478,10 +472,10 @@ def test_reverse_only_waypoint_can_finish_track():
     new_sim_data = data.sim_data.replace(states=data.sim_data.states.replace(pos=new_pos))
     env.unwrapped.data = data.replace(last_drone_pos=new_last, sim_data=new_sim_data)
 
-    new_data = _update_target_gates(env.unwrapped.data)
-    mapped_obs = obs(new_data)
-    assert int(np.asarray(new_data.n_gates_passed[0, 0])) == 1
-    assert int(np.asarray(mapped_obs["n_gates_passed"][0, 0])) == 1
+    next_data = _update_target_gates(env.unwrapped.data)
+    next_obs = obs(next_data)
+    assert int(np.asarray(next_data.n_gates_passed[0, 0])) == 1
+    assert int(np.asarray(next_obs["n_gates_passed"][0, 0])) == 1
     env.close()
 
 

--- a/tests/unit/envs/test_randomize.py
+++ b/tests/unit/envs/test_randomize.py
@@ -1,9 +1,5 @@
 """Integration test: level3 produces collision-free tracks through the real reset pipeline."""
 
-import os
-
-os.environ["SCIPY_ARRAY_API"] = "1"
-
 from pathlib import Path
 
 import gymnasium

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -73,6 +73,8 @@ def test_gate_pass():
 def test_load_gate_order():
     config = load_config(Path(__file__).parents[3] / "config/level0.toml")
     config.env.track.gate_order = [1, -2, 2, -1]
-    gate_ids, reverse = load_gate_order(config.env.track, len(config.env.track.gates))
-    np.testing.assert_array_equal(gate_ids, np.array([0, 1, 1, 0]))
-    np.testing.assert_array_equal(reverse, np.array([False, True, False, True]))
+    gate_sequence, gate_sequence_direction = load_gate_order(
+        config.env.track, len(config.env.track.gates)
+    )
+    np.testing.assert_array_equal(gate_sequence, np.array([0, 1, 1, 0]))
+    np.testing.assert_array_equal(gate_sequence_direction, np.array([1, -1, 1, -1]))

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,4 +1,7 @@
+import os
 from pathlib import Path
+
+os.environ["SCIPY_ARRAY_API"] = "1"
 
 import numpy as np
 import pytest
@@ -6,7 +9,7 @@ from ml_collections import ConfigDict
 from scipy.spatial.transform import Rotation as R
 
 from lsy_drone_racing.control.controller import Controller
-from lsy_drone_racing.envs.utils import gate_passed
+from lsy_drone_racing.envs.utils import gate_passed, load_gate_order
 from lsy_drone_racing.utils import load_config, load_controller
 
 
@@ -30,23 +33,46 @@ def test_gate_pass():
     gate_size = np.array([1, 1])
     # Test passing through the gate
     drone_pos, last_drone_pos = np.array([1, 0, 0]), np.array([-1, 0, 0])
-    assert gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, gate_size)
+    assert gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, False, gate_size)
     # Test passing outside the gate boundaries
     drone_pos, last_drone_pos = np.array([-2, 2, 0]), np.array([-1, 2, 0])
-    assert not gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, gate_size)
+    assert not gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, False, gate_size)
     # Test passing close to the gate
     drone_pos, last_drone_pos = np.array([1, 0.51, 0]), np.array([-1, 0.51, 0])
-    assert not gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, gate_size)
+    assert not gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, False, gate_size)
     # Test passing opposite direction
-    assert not gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, gate_size)
+    assert not gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, False, gate_size)
     # Test with rotated gate
     rotated_gate_quat = R.from_euler("xyz", [0, np.pi / 4, 0]).as_quat()
     drone_pos, last_drone_pos = np.array([0.5, 0.5, 0]), np.array([-0.5, -0.5, 0])
-    assert gate_passed(drone_pos, last_drone_pos, gate_pos, rotated_gate_quat, gate_size)
+    assert gate_passed(drone_pos, last_drone_pos, gate_pos, rotated_gate_quat, False, gate_size)
     # Test with moved gate
     moved_gate_pos = np.array([1, 1, 1])
     drone_pos, last_drone_pos = np.array([2, 1, 1]), np.array([0, 1, 1])
-    assert gate_passed(drone_pos, last_drone_pos, moved_gate_pos, gate_quat, gate_size)
+    assert gate_passed(drone_pos, last_drone_pos, moved_gate_pos, gate_quat, False, gate_size)
     # Test not crossing the plane
     drone_pos, last_drone_pos = np.array([-0.5, 0, 0]), np.array([-1, 0, 0])
-    assert not gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, gate_size)
+    assert not gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, False, gate_size)
+
+    # Test reverse passing when requested
+    drone_pos, last_drone_pos = np.array([-1, 0, 0]), np.array([1, 0, 0])
+    assert gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, True, gate_size)
+    assert not gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, False, gate_size)
+
+    # Test vectorized reverse flags
+    drone_pos = np.array([[1, 0, 0], [-1, 0, 0]])
+    last_drone_pos = np.array([[-1, 0, 0], [1, 0, 0]])
+    gate_pos = np.zeros((2, 3))
+    gate_quat = np.tile(R.identity().as_quat(), (2, 1))
+    reverse = np.array([False, True])
+    passed = gate_passed(drone_pos, last_drone_pos, gate_pos, gate_quat, reverse, gate_size)
+    np.testing.assert_array_equal(np.asarray(passed), np.array([True, True]))
+
+
+@pytest.mark.unit
+def test_load_gate_order():
+    config = load_config(Path(__file__).parents[3] / "config/level0.toml")
+    config.env.track.gate_order = [1, -2, 2, -1]
+    gate_ids, reverse = load_gate_order(config.env.track, len(config.env.track.gates))
+    np.testing.assert_array_equal(gate_ids, np.array([0, 1, 1, 0]))
+    np.testing.assert_array_equal(reverse, np.array([False, True, False, True]))

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,7 +1,4 @@
-import os
 from pathlib import Path
-
-os.environ["SCIPY_ARRAY_API"] = "1"
 
 import numpy as np
 import pytest
@@ -78,3 +75,15 @@ def test_load_gate_order():
     )
     np.testing.assert_array_equal(gate_sequence, np.array([0, 1, 1, 0]))
     np.testing.assert_array_equal(gate_sequence_direction, np.array([1, -1, 1, -1]))
+
+
+@pytest.mark.unit
+def test_load_gate_correctness():
+    config = load_config(Path(__file__).parents[3] / "config/level0.toml")
+    config.env.track.gate_order = [0]  # 0 is not allowed, since the sign is ambiguous
+    with pytest.raises(AssertionError):
+        _, _ = load_gate_order(config.env.track, len(config.env.track.gates))
+
+    config.env.track.gate_order = [10]  # 10 is out of bounds
+    with pytest.raises(AssertionError):
+        _, _ = load_gate_order(config.env.track, len(config.env.track.gates))


### PR DESCRIPTION
Added multi lap to ADR.

The gates now have to be passed in `gate_order`, given in the `level.toml`. The sign of the gate number can be negative to indicate reverse direction. Changed the `gate_passed` function and added a `load_gate_order` helper. Adapted the envs (mainly the obs) and docs accordingly.