### PR TITLE
Fix deploy runtime errors

### DIFF
--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -180,7 +180,7 @@ class RealRaceCoreEnv:
             passed = gate_passed(
                 drone_pos, self.data.last_drone_pos, gate_pos, gate_quat, gate_reverse, (0.45, 0.45)
             )
-        self.data.n_gates_passed = self.data.n_gates_passed + passed
+        self.data.n_gates_passed = self.data.n_gates_passed + np.asarray(passed)
         self.data.last_drone_pos[...] = drone_pos
         self.data.taken_off |= drone_pos[self.rank, 2] > 0.1
         return self.obs(), self.reward(), self.terminated(), self.truncated(), self.info()

--- a/lsy_drone_racing/utils/crazyflie.py
+++ b/lsy_drone_racing/utils/crazyflie.py
@@ -386,9 +386,7 @@ class Crazyflie:
         body_rates: NDArray[np.floating],
     ) -> None:
         await self._change_commander_level("low")
-        await self.cf.commander().send_setpoint_full_state(
-            pos, vel, acc, quat, body_rates[0], body_rates[1], body_rates[2]
-        )
+        await self.cf.commander().send_setpoint_full_state(pos, vel, acc, quat, body_rates)
 
     async def _stop_setpoint(self) -> None:
         await self.cf.commander().send_stop_setpoint()


### PR DESCRIPTION
Two runtime-only regressions that crash real deployments on current main:
Fix 1:
- #120 switched the pin to the official cflib2, whose `send_setpoint_full_state` takes `ang_vel` as a single `[ωx, ωy, ωz]` argument instead of three scalars (see `_rust.pyi`); the wrapper still used the old fork's 7-argument call, raising `TypeError` on every state-mode setpoint.

previous signature(https://github.com/ratheron/crazyflie-lib-python-v2/blob/bccd34092c22392b941bbef9bc5a3718b9d27da0/rust/src/subsystems/commander.rs#L81): 
```
async def send_setpoint_full_state(
    self,
    pos: Sequence[float],
    vel: Sequence[float],
    acc: Sequence[float],
    orientation: Sequence[float],
    rollrate: float,   
    pitchrate: float,
    yawrate: float,
) -> None:
    """
    * `rollrate`  - Target roll rate in radians/second
    * `pitchrate` - Target pitch rate in radians/second
    * `yawrate`   - Target yaw rate in radians/second
    """
```
current signature: 
```
async def send_setpoint_full_state(
    self,
    pos: typing.Sequence[builtins.float],
    vel: typing.Sequence[builtins.float],
    acc: typing.Sequence[builtins.float],
    orientation: typing.Sequence[builtins.float],
    ang_vel: typing.Sequence[builtins.float],
) -> None:
    r"""
    Sends a full-state setpoint in world coordinates.

    # Arguments
    * `pos` - Target position [x, y, z] (meters, world frame)
    * `vel` - Target velocity [vx, vy, vz] (meters/second, world frame)
    * `acc` - Target acceleration [ax, ay, az] (meters/second^2, world frame)
    * `orientation` - Target orientation quaternion [qx, qy, qz, qw] (unitless, world frame)
    * `ang_vel` - Target angular velocity [ωx, ωy, ωz] (radians/second, body frame)
    """
```
Fix 2:

- #121 dropped the `np.asarray` conversion of the jit-compiled `gate_passed` result, so `n_gates_passed` silently became a jax array and `terminated()` crashed on in-place assignment at the first step.

Both verified in real.
