### PR TITLE
Add pixi tasks for mocap and estimator in deploy env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,12 @@ ros2-distro-mutex = "0.12.*"  # Pinned for motion_capture_tracking
 scripts = ["tools/setup_mocap.sh"]
 
 ## feature [deploy]
+[tool.pixi.feature.deploy.tasks]
+mocap = { cmd = "ros2 launch motion_capture_tracking launch.py", description = "Launch the motion capture tracking node" }
+estimator = { cmd = "python -m drone_estimators.ros_nodes.ros2_node --drone_name {{ drone_name }}", args = [
+  { arg = "drone_name" },
+], description = "Start the drone state estimator" }
+
 [tool.pixi.feature.deploy.dependencies]
 packaging = ">=24,<26"  # Necessary for cflib2
 maturin = ">=1.13.3,<2"


### PR DESCRIPTION
A task on Todo list, add the pixi task to the pyproject to launch mocap and estimator, tested in real --- a drone successfully took off.